### PR TITLE
Migrate test changes to grpc/grpc-dotnet

### DIFF
--- a/Grpc.AspNetCore.sln
+++ b/Grpc.AspNetCore.sln
@@ -36,7 +36,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{3E045D
 		examples\Shared\Resources.cs = examples\Shared\Resources.cs
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CECC4AE8-9C4E-4727-939B-517CC2E58D65}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.Server", "src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj", "{89ED416F-92F1-4425-9379-D4E76A285860}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.Server.Tests", "test\Grpc.AspNetCore.Server.Tests\Grpc.AspNetCore.Server.Tests.csproj", "{278B1311-41BF-4345-947E-7B70E277FC3C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.FunctionalTests", "test\FunctionalTests\Grpc.AspNetCore.FunctionalTests.csproj", "{B190F61D-854C-4EE1-9532-B81AB3215F90}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{4163E1B3-4D75-46B4-9107-9A158FD708FC}"
 EndProject
@@ -50,6 +56,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Greeter", "examples\Clients
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "examples\Server\Server.csproj", "{CD6E11AE-34B2-4054-AD14-A27653131762}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testassets", "testassets", "{59C7B1F0-EE4D-4098-8596-0ADDBC305234}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Proto", "Proto", "{BF1393D4-6099-4EF9-85BB-7EE6CBEB920C}"
+	ProjectSection(SolutionItems) = preProject
+		testassets\Proto\chat.proto = testassets\Proto\chat.proto
+		testassets\Proto\count.proto = testassets\Proto\count.proto
+		testassets\Proto\greet.proto = testassets\Proto\greet.proto
+		testassets\Proto\message.proto = testassets\Proto\message.proto
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionalTestsWebsite", "testassets\FunctionalTestsWebsite\FunctionalTestsWebsite.csproj", "{7B95289B-4992-4C0D-B26F-8EC58F81FC96}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +78,14 @@ Global
 		{89ED416F-92F1-4425-9379-D4E76A285860}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{89ED416F-92F1-4425-9379-D4E76A285860}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{89ED416F-92F1-4425-9379-D4E76A285860}.Release|Any CPU.Build.0 = Release|Any CPU
+		{278B1311-41BF-4345-947E-7B70E277FC3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{278B1311-41BF-4345-947E-7B70E277FC3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{278B1311-41BF-4345-947E-7B70E277FC3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{278B1311-41BF-4345-947E-7B70E277FC3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B190F61D-854C-4EE1-9532-B81AB3215F90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B190F61D-854C-4EE1-9532-B81AB3215F90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B190F61D-854C-4EE1-9532-B81AB3215F90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B190F61D-854C-4EE1-9532-B81AB3215F90}.Release|Any CPU.Build.0 = Release|Any CPU
 		{01C2E73D-CE9C-44B5-92D9-4E3B448106F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{01C2E73D-CE9C-44B5-92D9-4E3B448106F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01C2E73D-CE9C-44B5-92D9-4E3B448106F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -80,6 +106,10 @@ Global
 		{CD6E11AE-34B2-4054-AD14-A27653131762}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD6E11AE-34B2-4054-AD14-A27653131762}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CD6E11AE-34B2-4054-AD14-A27653131762}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B95289B-4992-4C0D-B26F-8EC58F81FC96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B95289B-4992-4C0D-B26F-8EC58F81FC96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B95289B-4992-4C0D-B26F-8EC58F81FC96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B95289B-4992-4C0D-B26F-8EC58F81FC96}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -91,11 +121,15 @@ Global
 		{409A27EF-A5E9-45C5-9041-7210C6C8FC17} = {EA330592-E294-4A29-B60E-196AA05831DD}
 		{3E045DF6-62EF-4331-B712-9CF5EC56F04C} = {EA330592-E294-4A29-B60E-196AA05831DD}
 		{89ED416F-92F1-4425-9379-D4E76A285860} = {8C62055F-8CD7-4859-9001-634D544DF2AE}
+		{278B1311-41BF-4345-947E-7B70E277FC3C} = {CECC4AE8-9C4E-4727-939B-517CC2E58D65}
+		{B190F61D-854C-4EE1-9532-B81AB3215F90} = {CECC4AE8-9C4E-4727-939B-517CC2E58D65}
 		{01C2E73D-CE9C-44B5-92D9-4E3B448106F0} = {4163E1B3-4D75-46B4-9107-9A158FD708FC}
 		{1AD4D7AC-9B2E-498B-BB78-BCAF15055B48} = {F6E0F9D7-64E5-4C7B-A9BC-3C2AD687710B}
 		{F65AE56A-E6C8-467D-A097-3766D51720C0} = {F6E0F9D7-64E5-4C7B-A9BC-3C2AD687710B}
 		{265BE0B1-9002-441B-BA96-5C9E01115840} = {F6E0F9D7-64E5-4C7B-A9BC-3C2AD687710B}
 		{CD6E11AE-34B2-4054-AD14-A27653131762} = {A7E09CBD-853F-4C42-B4C4-A1C2CBA10C0B}
+		{BF1393D4-6099-4EF9-85BB-7EE6CBEB920C} = {59C7B1F0-EE4D-4098-8596-0ADDBC305234}
+		{7B95289B-4992-4C0D-B26F-8EC58F81FC96} = {59C7B1F0-EE4D-4098-8596-0ADDBC305234}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD5C2B19-49B4-480A-990C-36D98A719B07}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="nunit" Version="$(NunitPackageVersion)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(Nunit3TestAdapterPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/test/FunctionalTests/ClientStreamingMethodTests.cs
+++ b/test/FunctionalTests/ClientStreamingMethodTests.cs
@@ -1,0 +1,81 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Count;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests
+{
+    [TestFixture]
+    public class ClientStreamingMethodTests : FunctionalTestBase
+    {
+        [Test]
+        public async Task AccumulateCount_MultipleMessagesThenClose_SuccessResponse()
+        {
+            // Arrange
+            var ms = new MemoryStream();
+            await MessageHelpers.WriteMessageAsync(ms, new CounterRequest
+            {
+                Count = 1
+            }).DefaultTimeout();
+
+            var requestStream = new AwaitableMemoryStream();
+
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Count.Counter/AccumulateCount");
+            httpRequest.Content = new StreamContent(requestStream);
+
+            // Act
+            var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
+
+            // Assert
+            Assert.IsFalse(responseTask.IsCompleted, "Server should wait for client to finish streaming");
+
+            Fixture.Signal.Reset();
+            requestStream.SendData(ms.ToArray());
+            await Fixture.Signal.Task.DefaultTimeout();
+
+            Fixture.Signal.Reset();
+            requestStream.SendData(ms.ToArray());
+            await Fixture.Signal.Task.DefaultTimeout();
+
+            Fixture.Signal.Reset();
+            requestStream.SendData(Array.Empty<byte>());
+            await Fixture.Signal.Task.DefaultTimeout();
+
+            var response = await responseTask.DefaultTimeout();
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
+            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+
+            var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
+
+            var replyTask = MessageHelpers.AssertReadMessageAsync<CounterReply>(responseStream);
+            Assert.IsTrue(replyTask.IsCompleted);
+            var reply = await replyTask.DefaultTimeout();
+            Assert.AreEqual(2, reply.Count);
+        }
+    }
+}

--- a/test/FunctionalTests/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/DuplexStreamingMethodTests.cs
@@ -1,0 +1,93 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Chat;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests
+{
+    [TestFixture]
+    public class DuplexStreamingMethodTests : FunctionalTestBase
+    {
+        [Test]
+        public async Task Chat_MultipleMessagesFromOneClient_SuccessResponses()
+        {
+            // Arrange
+            var ms = new MemoryStream();
+            await MessageHelpers.WriteMessageAsync(ms, new ChatMessage
+            {
+                Name = "John",
+                Message = "Hello Jill"
+            }).DefaultTimeout();
+
+            var requestStream = new AwaitableMemoryStream();
+
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Chat.Chatter/Chat");
+            httpRequest.Content = new StreamContent(requestStream);
+
+            // Act
+            var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
+
+            // Assert
+            Assert.IsFalse(responseTask.IsCompleted, "Server should wait for first message from client");
+            requestStream.SendData(ms.ToArray());
+
+            var response = await responseTask.DefaultTimeout();
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
+            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+
+            var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
+
+            var message1Task = MessageHelpers.AssertReadMessageAsync<ChatMessage>(responseStream);
+            Assert.IsTrue(message1Task.IsCompleted);
+            var message1 = await message1Task.DefaultTimeout();
+            Assert.AreEqual("John", message1.Name);
+            Assert.AreEqual("Hello Jill", message1.Message);
+
+            var message2Task = MessageHelpers.AssertReadMessageAsync<ChatMessage>(responseStream);
+            Assert.IsFalse(message2Task.IsCompleted, "Server is waiting for messages from client");
+
+            ms = new MemoryStream();
+            await MessageHelpers.WriteMessageAsync(ms, new ChatMessage
+            {
+                Name = "Jill",
+                Message = "Hello John"
+            }).DefaultTimeout();
+
+            requestStream.SendData(ms.ToArray());
+            var message2 = await message2Task.DefaultTimeout();
+            Assert.AreEqual("Jill", message2.Name);
+            Assert.AreEqual("Hello John", message2.Message);
+
+            var finishedTask = MessageHelpers.AssertReadMessageAsync<ChatMessage>(responseStream);
+            Assert.IsFalse(finishedTask.IsCompleted, "Server is waiting for client to end streaming");
+
+            requestStream.SendData(Array.Empty<byte>());
+            await finishedTask.DefaultTimeout();
+        }
+    }
+}

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -1,0 +1,40 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests
+{
+    public class FunctionalTestBase
+    {
+        protected GrpcTestFixture<FunctionalTestsWebsite.Startup> Fixture { get; private set; }
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            Fixture = new GrpcTestFixture<FunctionalTestsWebsite.Startup>();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            Fixture?.Dispose();
+        }
+    }
+}

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <ProjectReference Include="..\..\testassets\FunctionalTestsWebsite\FunctionalTestsWebsite.csproj" />
+
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/test/FunctionalTests/Infrastructure/AwaitableMemoryStream.cs
+++ b/test/FunctionalTests/Infrastructure/AwaitableMemoryStream.cs
@@ -1,0 +1,110 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class AwaitableMemoryStream : Stream
+    {
+        private TaskCompletionSource<byte[]> _tcs;
+        private byte[] _currentData;
+
+        public AwaitableMemoryStream()
+        {
+            _currentData = Array.Empty<byte>();
+            ResetTcs();
+        }
+
+        private void ResetTcs()
+        {
+            _tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public void SendData(byte[] data)
+        {
+            _tcs.SetResult(data);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // Still have leftover data?
+            if (_currentData.Length > 0)
+            {
+                return ReadInternalBuffer(buffer, offset, count);
+            }
+
+            _currentData = await _tcs.Task;
+            ResetTcs();
+
+            return ReadInternalBuffer(buffer, offset, count);
+        }
+
+        private int ReadInternalBuffer(byte[] buffer, int offset, int count)
+        {
+            var readBytes = Math.Min(count, _currentData.Length);
+            if (readBytes > 0)
+            {
+                Array.Copy(_currentData, 0, buffer, offset, readBytes);
+                _currentData = _currentData.AsSpan(readBytes, _currentData.Length - readBytes).ToArray();
+            }
+
+            return readBytes;
+        }
+
+        #region Stream implementation
+        public override bool CanRead => true;
+
+        public override bool CanSeek => true;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position { get; set; }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return 0;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+    }
+}

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -1,0 +1,63 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Net.Http;
+using FunctionalTestsWebsite.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class GrpcTestFixture<TStartup> : IDisposable where TStartup : class
+    {
+        private readonly TestServer _server;
+
+        public GrpcTestFixture()
+        {
+            Signal = new Signaler();
+
+            Action<IServiceCollection> configureServices = services =>
+            {
+                // Register signaler so server can signal tests
+                services.AddSingleton(Signal);
+            };
+
+            var builder = new WebHostBuilder()
+                .ConfigureServices(configureServices)
+                .UseStartup<TStartup>();
+
+            _server = new TestServer(builder);
+
+            Client = _server.CreateClient();
+            Client.BaseAddress = new Uri("http://localhost");
+        }
+
+        public Signaler Signal { get; }
+
+        public HttpClient Client { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _server.Dispose();
+        }
+    }
+}

--- a/test/FunctionalTests/Infrastructure/MessageHelpers.cs
+++ b/test/FunctionalTests/Infrastructure/MessageHelpers.cs
@@ -1,0 +1,168 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    internal static class MessageHelpers
+    {
+        public const int MessageDelimiterSize = 4;
+
+        public static T AssertReadMessage<T>(byte[] messageData) where T : IMessage, new()
+        {
+            Assert.AreEqual(0, messageData[0]);
+
+            var messageLength = DecodeMessageLength(messageData.AsSpan(1, 4));
+
+            int expectedLength = MessageDelimiterSize + 1 + messageLength;
+
+            Assert.AreEqual(expectedLength, messageData.Length);
+
+            var message = new T();
+            message.MergeFrom(messageData.AsSpan(5).ToArray());
+
+            return message;
+        }
+
+        public static async Task<T> AssertReadMessageAsync<T>(Stream stream) where T : IMessage, new()
+        {
+            var messageData = await ReadMessageAsync(stream);
+            if (messageData == null)
+            {
+                return default;
+            }
+
+            var message = new T();
+            message.MergeFrom(messageData);
+
+            return message;
+        }
+
+        public static async Task<byte[]> ReadMessageAsync(Stream stream)
+        {
+            // read Compressed-Flag and Message-Length
+            // as described in https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+            var delimiterBuffer = new byte[1 + MessageDelimiterSize];
+            if (!await ReadExactlyBytesOrNothing(stream, delimiterBuffer, 0, delimiterBuffer.Length))
+            {
+                return null;
+            }
+
+            var compressionFlag = delimiterBuffer[0];
+            var messageLength = DecodeMessageLength(new ReadOnlySpan<byte>(delimiterBuffer, 1, MessageDelimiterSize));
+
+            if (compressionFlag != 0)
+            {
+                // TODO(jtattermusch): support compressed messages
+                throw new IOException("Compressed messages are not yet supported.");
+            }
+
+            var msgBuffer = new byte[messageLength];
+            if (!await ReadExactlyBytesOrNothing(stream, msgBuffer, 0, msgBuffer.Length))
+            {
+                throw new IOException("Unexpected end of stream.");
+            }
+            return msgBuffer;
+        }
+
+        private static async Task<bool> ReadExactlyBytesOrNothing(Stream stream, byte[] buffer, int offset, int count)
+        {
+            bool noBytesRead = true;
+            while (count > 0)
+            {
+                int bytesRead = await stream.ReadAsync(buffer, offset, count);
+                if (bytesRead == 0)
+                {
+                    if (noBytesRead)
+                    {
+                        return false;
+                    }
+                    throw new IOException("Unexpected end of stream.");
+                }
+                noBytesRead = false;
+                offset += bytesRead;
+                count -= bytesRead;
+            }
+            return true;
+        }
+
+        public static async Task WriteMessageAsync<T>(Stream stream, T message) where T : IMessage
+        {
+            var messageData = message.ToByteArray();
+
+            await WriteMessageAsync(stream, messageData, 0, messageData.Length);
+        }
+
+        public static async Task WriteMessageAsync(Stream stream, byte[] buffer, int offset, int count, bool flush = false)
+        {
+            var delimiterBuffer = new byte[1 + MessageDelimiterSize];
+            delimiterBuffer[0] = 0; // = non-compressed
+            EncodeMessageLength(count, new Span<byte>(delimiterBuffer, 1, MessageDelimiterSize));
+            await stream.WriteAsync(delimiterBuffer, 0, delimiterBuffer.Length);
+
+            await stream.WriteAsync(buffer, offset, count);
+
+            if (flush)
+            {
+                await stream.FlushAsync();
+            }
+        }
+
+        public static int DecodeMessageLength(ReadOnlySpan<byte> buffer)
+        {
+            if (buffer.Length < MessageDelimiterSize)
+            {
+                throw new ArgumentException("Buffer too small to decode message length.");
+            }
+
+            var result = 0UL;
+            for (var i = 0; i < MessageDelimiterSize; i++)
+            {
+                // msg length stored in big endian
+                result = (result << 8) + buffer[i];
+            }
+
+            if (result > int.MaxValue)
+            {
+                throw new IOException("Message too large: " + result);
+            }
+            return (int)result;
+        }
+
+        public static void EncodeMessageLength(int messageLength, Span<byte> destination)
+        {
+            if (destination.Length < MessageDelimiterSize)
+            {
+                throw new ArgumentException("Buffer too small to encode message length.");
+            }
+
+            var unsignedValue = (ulong)messageLength;
+            for (var i = MessageDelimiterSize - 1; i >= 0; i--)
+            {
+                // msg length stored in big endian
+                destination[i] = (byte)(unsignedValue & 0xff);
+                unsignedValue >>= 8;
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/Infrastructure/TaskExtensions.cs
+++ b/test/FunctionalTests/Infrastructure/TaskExtensions.cs
@@ -1,0 +1,95 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    internal static class TaskExtensions
+    {
+        public static Task<T> DefaultTimeout<T>(this Task<T> task,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = default)
+        {
+            return task.TimeoutAfter(TimeSpan.FromSeconds(5), filePath, lineNumber);
+        }
+
+        public static Task DefaultTimeout(this Task task,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = default)
+        {
+            return task.TimeoutAfter(TimeSpan.FromSeconds(5), filePath, lineNumber);
+        }
+
+        public static async Task<T> TimeoutAfter<T>(this Task<T> task, TimeSpan timeout,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = default)
+        {
+            // Don't create a timer if the task is already completed
+            // or the debugger is attached
+            if (task.IsCompleted || Debugger.IsAttached)
+            {
+                return await task;
+            }
+
+            var cts = new CancellationTokenSource();
+            if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+            {
+                cts.Cancel();
+                return await task;
+            }
+            else
+            {
+                throw new TimeoutException(CreateMessage(timeout, filePath, lineNumber));
+            }
+        }
+
+        public static async Task TimeoutAfter(this Task task, TimeSpan timeout,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = default)
+        {
+            // Don't create a timer if the task is already completed
+            // or the debugger is attached
+            if (task.IsCompleted || Debugger.IsAttached)
+            {
+                await task;
+                return;
+            }
+
+            var cts = new CancellationTokenSource();
+            if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+            {
+                cts.Cancel();
+                await task;
+            }
+            else
+            {
+                throw new TimeoutException(CreateMessage(timeout, filePath, lineNumber));
+            }
+        }
+
+        private static string CreateMessage(TimeSpan timeout, string filePath, int lineNumber)
+            => string.IsNullOrEmpty(filePath)
+            ? $"The operation timed out after reaching the limit of {timeout.TotalMilliseconds}ms."
+            : $"The operation at {filePath}:{lineNumber} timed out after reaching the limit of {timeout.TotalMilliseconds}ms.";
+    }
+}

--- a/test/FunctionalTests/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/ServerStreamingMethodTests.cs
@@ -1,0 +1,79 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Greet;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests
+{
+    [TestFixture]
+    public class ServerStreamingMethodTests : FunctionalTestBase
+    {
+        [Test]
+        public async Task SayHellos_NoBuffering_SuccessResponsesStreamed()
+        {
+            // Arrange
+            var requestMessage = new HelloRequest
+            {
+                Name = "World"
+            };
+
+            var requestStream = new MemoryStream();
+            await MessageHelpers.WriteMessageAsync(requestStream, requestMessage).DefaultTimeout();
+
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHellos");
+            httpRequest.Content = new StreamContent(requestStream);
+
+            // Act
+            var response = await Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
+            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+
+            var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
+
+            for (var i = 0; i < 3; i++)
+            {
+                var greetingTask = MessageHelpers.AssertReadMessageAsync<HelloReply>(responseStream);
+
+                // The first response comes with the headers
+                // Additional responses are streamed
+                Assert.AreEqual(i == 0, greetingTask.IsCompleted);
+
+                var greeting = await greetingTask.DefaultTimeout();
+
+                Assert.AreEqual($"How are you World? {i}", greeting.Message);
+            }
+
+            var goodbyeTask = MessageHelpers.AssertReadMessageAsync<HelloReply>(responseStream);
+            Assert.False(goodbyeTask.IsCompleted);
+            Assert.AreEqual("Goodbye World!", (await goodbyeTask.DefaultTimeout()).Message);
+
+            var finishedTask = MessageHelpers.AssertReadMessageAsync<HelloReply>(responseStream);
+            Assert.IsNull(await finishedTask.DefaultTimeout());
+        }
+    }
+}

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -1,0 +1,59 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Greet;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests
+{
+    [TestFixture]
+    public class UnaryMethodTests : FunctionalTestBase
+    {
+        [Test]
+        public async Task SayHello_ValidRequest_SuccessResponse()
+        {
+            // Arrange
+            var requestMessage = new HelloRequest
+            {
+                Name = "World"
+            };
+
+            var stream = new MemoryStream();
+            await MessageHelpers.WriteMessageAsync(stream, requestMessage).DefaultTimeout();
+
+            // Act
+            var response = await Fixture.Client.PostAsync(
+                "Greet.Greeter/SayHello",
+                new StreamContent(stream)).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
+            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+
+            var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
+            Assert.AreEqual("Hello World", responseMessage.Message);
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
@@ -1,0 +1,51 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using NUnit.Framework;
+using Moq;
+using System;
+using Grpc.AspNetCore.Server.Internal;
+
+namespace Grpc.AspNetCore.Server.Tests
+{
+    [TestFixture]
+    public class DefaultGrpcServiceActivatorTests
+    {
+        public class GrpcService { }
+
+        [Test]
+        public void GrpcServiceCreatedIfNotResolvedFromServiceProvider()
+        {
+            Assert.NotNull(
+                new DefaultGrpcServiceActivator<GrpcService>(Mock.Of<IServiceProvider>()).Create());
+        }
+
+        [Test]
+        public void GrpcServiceCanBeResolvedFromServiceProvider()
+        {
+            var service = Mock.Of<GrpcService>();
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            mockServiceProvider
+                .Setup(sp => sp.GetService(typeof(GrpcService)))
+                .Returns(service);
+
+            Assert.AreSame(service,
+                new DefaultGrpcServiceActivator<GrpcService>(mockServiceProvider.Object).Create());
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Proto\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
+
+    <None Remove="@(Protobuf)" />
+    <Content Include="@(Protobuf)" LinkBase="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
+
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -1,0 +1,144 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using NUnit.Framework;
+using Moq;
+using System;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Builder;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Greet;
+using System.Linq;
+
+namespace Grpc.AspNetCore.Server.Tests
+{
+    [TestFixture]
+    public class GrpcEndpointRouteBuilderExtensionsTests
+    {
+        [Test]
+        public void MapGrpcService_WithoutServices_RaiseError()
+        {
+            // Arrange
+            ServiceCollection services = new ServiceCollection();
+
+            var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider());
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => routeBuilder.MapGrpcService<Greeter.GreeterBase>());
+            Assert.AreEqual("Unable to find the required services. Please add all the required services by calling " +
+                    "'IServiceCollection.AddGrpc' inside the call to 'ConfigureServices(...)' in the application startup code.", ex.Message);
+        }
+
+        [Test]
+        public void MapGrpcService_CantBind_RaiseError()
+        {
+            // Arrange
+            ServiceCollection services = new ServiceCollection();
+            services.AddGrpc();
+
+            var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider());
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => routeBuilder.MapGrpcService<object>());
+            Assert.AreEqual("Unable to map gRPC service 'Object'.", ex.Message);
+            Assert.AreEqual($"Cannot locate BindService(ServiceBinderBase, ServiceBase) method for the current service type: {typeof(object).FullName}. The type must be an implementation of a gRPC service.", ex.InnerException.Message);
+        }
+
+        [Test]
+        public void MapGrpcService_CanBind_CreatesEndpoints()
+        {
+            // Arrange
+            ServiceCollection services = new ServiceCollection();
+            services.AddGrpc();
+
+            var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider());
+
+            // Act
+            routeBuilder.MapGrpcService<GreeterService>();
+
+            // Assert
+            var dataSource = routeBuilder.DataSources.Single();
+            Assert.AreEqual(2, dataSource.Endpoints.Count);
+
+            var routeEndpoint1 = (RouteEndpoint)dataSource.Endpoints[0];
+            Assert.AreEqual("/Greet.Greeter/SayHello", routeEndpoint1.RoutePattern.RawText);
+            Assert.AreEqual("POST", ((IHttpMethodMetadata)routeEndpoint1.Metadata.Single()).HttpMethods.Single());
+
+            var routeEndpoint2 = (RouteEndpoint)dataSource.Endpoints[1];
+            Assert.AreEqual("/Greet.Greeter/SayHellos", routeEndpoint2.RoutePattern.RawText);
+            Assert.AreEqual("POST", ((IHttpMethodMetadata)routeEndpoint2.Metadata.Single()).HttpMethods.Single());
+        }
+
+        [Test]
+        public void MapGrpcService_ConventionBuilder_AddsMetadata()
+        {
+            // Arrange
+            ServiceCollection services = new ServiceCollection();
+            services.AddGrpc();
+
+            var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider());
+
+            // Act
+            routeBuilder.MapGrpcService<GreeterService>().Apply(builder =>
+            {
+                builder.Metadata.Add(new CustomMetadata());
+            });
+
+            // Assert
+            var dataSource = routeBuilder.DataSources.Single();
+            Assert.AreEqual(2, dataSource.Endpoints.Count);
+
+            var routeEndpoint1 = (RouteEndpoint)dataSource.Endpoints[0];
+            Assert.AreEqual("/Greet.Greeter/SayHello", routeEndpoint1.RoutePattern.RawText);
+            Assert.NotNull(routeEndpoint1.Metadata.GetMetadata<CustomMetadata>());
+
+            var routeEndpoint2 = (RouteEndpoint)dataSource.Endpoints[1];
+            Assert.AreEqual("/Greet.Greeter/SayHellos", routeEndpoint2.RoutePattern.RawText);
+            Assert.NotNull(routeEndpoint2.Metadata.GetMetadata<CustomMetadata>());
+        }
+
+        private class GreeterService : Greeter.GreeterBase
+        {
+        }
+
+        private class CustomMetadata
+        {
+        }
+
+        private IEndpointRouteBuilder CreateTestEndpointRouteBuilder(IServiceProvider serviceProvider)
+        {
+            return new TestEndpointRouteBuilder
+            {
+                ServiceProvider = serviceProvider
+            };
+        }
+
+        private class TestEndpointRouteBuilder : IEndpointRouteBuilder
+        {
+            public IServiceProvider ServiceProvider { get; set; }
+
+            public ICollection<EndpointDataSource> DataSources { get; } = new List<EndpointDataSource>();
+
+            public IApplicationBuilder CreateApplicationBuilder()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/Proto/greet.proto
+++ b/test/Grpc.AspNetCore.Server.Tests/Proto/greet.proto
@@ -1,0 +1,34 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package Greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/testassets/FunctionalTestsWebsite/Chatter.cs
+++ b/testassets/FunctionalTestsWebsite/Chatter.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Chat;
+using Microsoft.Extensions.Logging;
+
+namespace FunctionalTestsWebsite
+{
+    public class ChatterService : Chatter.ChatterBase
+    {
+        private readonly ILogger _logger;
+
+        public ChatterService(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<ChatterService>();
+        }
+
+        private static HashSet<IServerStreamWriter<ChatMessage>> _subscribers = new HashSet<IServerStreamWriter<ChatMessage>>();
+
+        public override async Task Chat(IAsyncStreamReader<ChatMessage> requestStream, IServerStreamWriter<ChatMessage> responseStream, ServerCallContext context)
+        {
+            if (!await requestStream.MoveNext())
+            {
+                // No messages so don't register and just exit.
+                return;
+            }
+
+            var user = requestStream.Current.Name;
+
+            // Warning, the following is very racy but good enough for a proof of concept
+            // Register subscriber
+            _logger.LogInformation($"{user} connected");
+            _subscribers.Add(responseStream);
+
+            do
+            {
+                await BroadcastMessageAsync(requestStream.Current, _logger);
+            } while (await requestStream.MoveNext());
+
+            _subscribers.Remove(responseStream);
+            _logger.LogInformation($"{user} disconnected");
+        }
+
+        private static async Task BroadcastMessageAsync(ChatMessage message, ILogger logger)
+        {
+            foreach (var subscriber in _subscribers)
+            {
+                logger.LogInformation($"Broadcasting: {message.Name} - {message.Message}");
+                await subscriber.WriteAsync(message);
+            }
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Counter.cs
+++ b/testassets/FunctionalTestsWebsite/Counter.cs
@@ -1,0 +1,67 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Count;
+using Microsoft.Extensions.Logging;
+using FunctionalTestsWebsite.Infrastructure;
+using System.Threading;
+
+namespace FunctionalTestsWebsite
+{
+    public class CounterService : Counter.CounterBase
+    {
+        private readonly ILogger _logger;
+        private readonly IncrementingCounter _counter;
+        private readonly Signaler _signaler;
+
+        public CounterService(IncrementingCounter counter, ILoggerFactory loggerFactory, Signaler signaler)
+        {
+            _counter = counter;
+            _signaler = signaler;
+            _logger = loggerFactory.CreateLogger<CounterService>();
+        }
+
+        public override Task<CounterReply> IncrementCount(Empty request, ServerCallContext context)
+        {
+            _logger.LogInformation("Incrementing count by 1");
+            _counter.Increment(1);
+            return Task.FromResult(new CounterReply { Count = _counter.Count });
+        }
+
+        public override async Task<CounterReply> AccumulateCount(IAsyncStreamReader<CounterRequest> requestStream, ServerCallContext context)
+        {
+            while (await requestStream.MoveNext(CancellationToken.None))
+            {
+                _logger.LogInformation($"Incrementing count by {requestStream.Current.Count}");
+
+                _counter.Increment(requestStream.Current.Count);
+
+                // Signal client that message was received
+                _signaler.Set();
+            }
+
+            // Signal client that exiting
+            _signaler.Set();
+
+            return new CounterReply { Count = _counter.Count };
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
+    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
+    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
+    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
+    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
+    <Protobuf Include="..\Proto\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
+
+    <None Remove="@(Protobuf)" />
+    <Content Include="@(Protobuf)" LinkBase="" />
+
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
+
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/testassets/FunctionalTestsWebsite/Greeter.cs
+++ b/testassets/FunctionalTestsWebsite/Greeter.cs
@@ -1,0 +1,58 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading.Tasks;
+using Grpc.Core;
+using Greet;
+using Microsoft.Extensions.Logging;
+
+class GreeterService : Greeter.GreeterBase
+{
+    private readonly ILogger _logger;
+
+    public GreeterService(ILoggerFactory loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger<GreeterService>();
+    }
+
+    //Server side handler of the SayHello RPC
+    public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+    {
+        _logger.LogInformation($"Sending hello to {request.Name}");
+        return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+    }
+
+    public override async Task SayHellos(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            // Gotta look busy
+            await Task.Delay(100);
+
+            var message = $"How are you {request.Name}? {i}";
+            _logger.LogInformation($"Sending greeting {message}");
+            await responseStream.WriteAsync(new HelloReply { Message = message });
+        }
+
+        // Gotta look busy
+        await Task.Delay(100);
+
+        _logger.LogInformation("Sending goodbye");
+        await responseStream.WriteAsync(new HelloReply { Message = $"Goodbye {request.Name}!" });
+    }
+}

--- a/testassets/FunctionalTestsWebsite/IncrementingCounter.cs
+++ b/testassets/FunctionalTestsWebsite/IncrementingCounter.cs
@@ -1,0 +1,30 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace FunctionalTestsWebsite
+{
+    public class IncrementingCounter
+    {
+        public void Increment(int amount)
+        {
+            Count += amount;
+        }
+
+        public int Count { get; private set; }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Infrastructure/Signaler.cs
+++ b/testassets/FunctionalTestsWebsite/Infrastructure/Signaler.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading.Tasks;
+
+namespace FunctionalTestsWebsite.Infrastructure
+{
+    public class Signaler
+    {
+        private TaskCompletionSource<object> _tcs;
+
+        public Signaler()
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            _tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public void Set()
+        {
+            _tcs.SetResult(null);
+        }
+
+        public Task Task => _tcs.Task;
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Infrastructure/TestHttpResponseTrailersFeature.cs
+++ b/testassets/FunctionalTestsWebsite/Infrastructure/TestHttpResponseTrailersFeature.cs
@@ -1,0 +1,28 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace FunctionalTestsWebsite.Infrastructure
+{
+    public class TestHttpResponseTrailersFeature : IHttpResponseTrailersFeature
+    {
+        public IHeaderDictionary Trailers { get; set; }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Program.cs
+++ b/testassets/FunctionalTestsWebsite/Program.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+namespace FunctionalTestsWebsite
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .ConfigureKestrel(options =>
+                {
+                    options.Limits.MinRequestBodyDataRate = null;
+                    options.ListenLocalhost(50051, listenOptions =>
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http2;
+                    });
+                })
+                .UseStartup<Startup>();
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -1,0 +1,70 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using FunctionalTestsWebsite.Infrastructure;
+using Grpc.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace FunctionalTestsWebsite
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddGrpc();
+            services.AddSingleton<IncrementingCounter>();
+
+            // When the site is run from the test project a signaler will already be registered
+            // This will add a default one if the site is run standalone
+            services.TryAddSingleton<Signaler>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            // Workaround for https://github.com/aspnet/AspNetCore/issues/6880
+            app.Use((context, next) =>
+            {
+                if (!context.Response.SupportsTrailers())
+                {
+                    context.Features.Set<IHttpResponseTrailersFeature>(new TestHttpResponseTrailersFeature
+                    {
+                        Trailers = new HttpResponseTrailers()
+                    });
+                }
+
+                return next();
+            });
+
+            app.UseEndpointRouting(builder =>
+            {
+                builder.MapGrpcService<ChatterService>();
+                builder.MapGrpcService<CounterService>();
+                builder.MapGrpcService<GreeterService>();
+            });
+        }
+    }
+}

--- a/testassets/Proto/chat.proto
+++ b/testassets/Proto/chat.proto
@@ -1,0 +1,29 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package Chat;
+
+// The greeting service definition.
+service Chatter {
+  // Sends a greeting
+  rpc Chat (stream ChatMessage) returns (stream ChatMessage) {}
+}
+
+// The chat message.
+message ChatMessage {
+  string name = 1;
+  string message = 2;
+}

--- a/testassets/Proto/count.proto
+++ b/testassets/Proto/count.proto
@@ -1,0 +1,36 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+package Count;
+
+// The counter service definition.
+service Counter {
+  // Get current count
+  rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {}
+  // Increment count through multiple counts
+  rpc AccumulateCount (stream CounterRequest) returns (CounterReply) {}
+}
+
+// The request message containing the count to increment by
+message CounterRequest {
+  int32 count = 1;
+}
+
+// The response message containing the current count
+message CounterReply {
+  int32 count = 1;
+}

--- a/testassets/Proto/greet.proto
+++ b/testassets/Proto/greet.proto
@@ -1,0 +1,34 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package Greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
This is the follow up to https://github.com/grpc/grpc-dotnet/pull/48. All current PRs should be unblocked after this.