### PR TITLE
Add back "echo metadata" logic to interop server

### DIFF
--- a/testassets/InteropTestsWebsite/TestServiceImpl.cs
+++ b/testassets/InteropTestsWebsite/TestServiceImpl.cs
@@ -94,20 +94,18 @@ namespace Grpc.Testing
             return new Payload { Body = ByteString.CopyFrom(new byte[size]) };
         }
 
-        private static Task EnsureEchoMetadataAsync(ServerCallContext context)
+        private static async Task EnsureEchoMetadataAsync(ServerCallContext context)
         {
-            return Task.CompletedTask;
-            // TODO(jtattermusch): uncomment once ServerCallContext is populated.
-            //var echoInitialList = context.RequestHeaders.Where((entry) => entry.Key == "x-grpc-test-echo-initial").ToList();
-            //if (echoInitialList.Any()) {
-            //    var entry = echoInitialList.Single();
-            //    await context.WriteResponseHeadersAsync(new Metadata { entry });
-            //}
+            var echoInitialList = context.RequestHeaders.Where((entry) => entry.Key == "x-grpc-test-echo-initial").ToList();
+            if (echoInitialList.Any()) {
+                var entry = echoInitialList.Single();
+                await context.WriteResponseHeadersAsync(new Metadata { entry });
+            }
 
-            //var echoTrailingList = context.RequestHeaders.Where((entry) => entry.Key == "x-grpc-test-echo-trailing-bin").ToList();
-            //if (echoTrailingList.Any()) {
-            //    context.ResponseTrailers.Add(echoTrailingList.Single());
-            //}
+            var echoTrailingList = context.RequestHeaders.Where((entry) => entry.Key == "x-grpc-test-echo-trailing-bin").ToList();
+            if (echoTrailingList.Any()) {
+                context.ResponseTrailers.Add(echoTrailingList.Single());
+            }
         }
 
         private static void EnsureEchoStatus(EchoStatus responseStatus, ServerCallContext context)


### PR DESCRIPTION
Now that ServerCallContext is populated, we can add back interop server logic that touches it.

I ran the test manually and these tests are currently passing:

all "basic" tests: empty_unary, large_unary, client_streaming, server_streaming, ping_pong, empty_stream

a few "advanced" ones are passing too:
status_code_and_message, cancel_after_begin, cancel_after_first_response

For other tests, we will need binary metadata support and timeout support.
So far I tested everything with plaintext, we still need to test with TLS.