### PR TITLE
 Only depend on Grpc.Core.Api

### DIFF
--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Grpc.Core" Version="$(GrpcCorePackageVersion)" />
+    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcCorePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/testassets/InteropTestsWebsite/AsyncStreamExtensions.cs
+++ b/testassets/InteropTestsWebsite/AsyncStreamExtensions.cs
@@ -1,0 +1,41 @@
+#region Copyright notice and license
+
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace InteropTestsWebsite
+{
+    // Implementation copied from https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.Core/Utils/AsyncStreamExtensions.cs
+    internal static class AsyncStreamExtensions
+    {
+        /// <summary>
+        /// Reads the entire stream and executes an async action for each element.
+        /// </summary>
+        public static async Task ForEachAsync<T>(this IAsyncStreamReader<T> streamReader, Func<T, Task> asyncAction)
+            where T : class
+        {
+            while (await streamReader.MoveNext().ConfigureAwait(false))
+            {
+                await asyncAction(streamReader.Current).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/testassets/InteropTestsWebsite/TestServiceImpl.cs
+++ b/testassets/InteropTestsWebsite/TestServiceImpl.cs
@@ -23,7 +23,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Grpc.Core;
-using Grpc.Core.Utils;
+using InteropTestsWebsite;
 
 namespace Grpc.Testing
 {

--- a/testassets/InteropTestsWebsite/TestServiceImpl.cs
+++ b/testassets/InteropTestsWebsite/TestServiceImpl.cs
@@ -64,7 +64,7 @@ namespace Grpc.Testing
             await requestStream.ForEachAsync(request =>
             {
                 sum += request.Payload.Body.Length;
-                return TaskUtils.CompletedTask;
+                return Task.CompletedTask;
             });
             return new StreamingInputCallResponse { AggregatedPayloadSize = sum };
         }


### PR DESCRIPTION
We forgot to switch to dependency only on the Api package.

- work in progress, we need to figure out if stream extensions should be moved to Grpc.Core.Api, redefined in Grpc.AspNetCore.Server  or if we should just not support them.

