### PR TITLE
Add configuration for nuget building job

### DIFF
--- a/kokoro/README.md
+++ b/kokoro/README.md
@@ -1,0 +1,1 @@
+Configuration files and helper scripts for Google-internal CI tool called "Kokoro".

--- a/kokoro/build_nuget.sh
+++ b/kokoro/build_nuget.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd $(dirname $0)/..
+
+# Install dotnet SDK
+# copied from .travis.yml
+curl -o dotnet-sdk.tar.gz -sSL https://download.visualstudio.microsoft.com/download/pr/efa6dde9-a5ee-4322-b13c-a2a02d3980f0/dad445eba341c1d806bae5c8afb47015/dotnet-sdk-3.0.100-preview-010184-linux-x64.tar.gz
+mkdir -p $PWD/dotnet
+tar zxf dotnet-sdk.tar.gz -C $PWD/dotnet
+export PATH="$PWD/dotnet:$PATH"
+
+# TODO(jtattermusch): remove this before release, otherwise 
+# references will be broken.
+./build/get-grpc.sh
+
+mkdir -p artifacts
+
+# TODO(jtattermusch): set the package version in csproj files.
+(cd src/Grpc.AspNetCore.Server && dotnet pack -p:PackageVersion=0.0.1-dev --configuration Release --output ../../artifacts)

--- a/kokoro/linux.cfg
+++ b/kokoro/linux.cfg
@@ -1,0 +1,26 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-dotnet/kokoro/build_nuget.sh"
+timeout_mins: 30
+
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc-dotnet/artifacts/**"
+  }
+}


### PR DESCRIPTION
The job will run on google-internal CI "Kokoro". Another step in the internal pipeline (not visible externally) will be used to sign the nuget and contained `dll`s.