### PR TITLE
Add grpc-status check on server

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -65,5 +65,21 @@ namespace Grpc.AspNetCore.Server.Internal
 
             throw new InvalidOperationException("Error reading grpc-timeout value.");
         }
+
+        public static void CheckStatus(HttpContext httpContext)
+        {
+            //TODO: is status like " 0" valid?
+            const string ValidRequestGrpcStatus = "0";
+
+            if (!httpContext.Request.Headers.TryGetValue(GrpcProtocolConstants.StatusTrailer, out var values))
+            {
+                return;
+            }
+
+            if (values.Count > 1 || !ValidRequestGrpcStatus.Equals(values.ToString()))
+            {
+                throw new InvalidOperationException("Invalid request status");
+            }
+        }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -66,6 +66,10 @@ namespace Grpc.AspNetCore.Server.Internal
             throw new InvalidOperationException("Error reading grpc-timeout value.");
         }
 
+        /// <summary>
+        /// Check if grpc-status header in the request is valid
+        /// </summary>
+        /// <param name="httpContext">Http context of the request.</param>
         public static void CheckStatus(HttpContext httpContext)
         {
             //TODO: is status like " 0" valid?

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -153,9 +153,11 @@ namespace Grpc.AspNetCore.Server.Internal
 
             return HttpContext.Response.Body.FlushAsync();
         }
-		
+
         public void Initialize()
         {
+            GrpcProtocolHelpers.CheckStatus(HttpContext);
+
             var timeout = GrpcProtocolHelpers.GetTimeout(HttpContext);
 
             if (timeout != TimeSpan.MaxValue)


### PR DESCRIPTION
With regards to #81 , there are some grpc-specific headers that need special processing. 

This PR adds checking for `grpc-status` header in the request. The behavior implemented in the native library is that only "0" is a valid value: https://github.com/grpc/grpc/blob/ff51441a29403c50495dc6ee3708e04ff088871d/src/core/ext/transport/chttp2/transport/parsing.cc#L425. 