### PR TITLE
Improve functional test

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -40,11 +41,31 @@ namespace Grpc.AspNetCore.Server.Internal
             return new UnaryServerCallHandler<TRequest, TResponse, TService>(method, _serviceOptions, _loggerFactory);
         }
 
+        public UnaryServerCallHandler<TRequest, TResponse, TService> CreateUnary<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            Func<IServiceProvider, TService> createService,
+            Action<TService> releaseService)
+                where TRequest : class
+                where TResponse : class
+        {
+            return new UnaryServerCallHandler<TRequest, TResponse, TService>(method, _serviceOptions, _loggerFactory, createService, releaseService);
+        }
+
         public ClientStreamingServerCallHandler<TRequest, TResponse, TService> CreateClientStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method)
             where TRequest : class
             where TResponse : class
         {
             return new ClientStreamingServerCallHandler<TRequest, TResponse, TService>(method, _serviceOptions, _loggerFactory);
+        }
+
+        public ClientStreamingServerCallHandler<TRequest, TResponse, TService> CreateClientStreaming<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            Func<IServiceProvider, TService> createService,
+            Action<TService> releaseService)
+            where TRequest : class
+            where TResponse : class
+        {
+            return new ClientStreamingServerCallHandler<TRequest, TResponse, TService>(method, _serviceOptions, _loggerFactory, createService, releaseService);
         }
 
         public DuplexStreamingServerCallHandler<TRequest, TResponse, TService> CreateDuplexStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method)

--- a/src/Grpc.AspNetCore.Server/Internal/UnaryServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/UnaryServerCallHandler.cs
@@ -36,12 +36,25 @@ namespace Grpc.AspNetCore.Server.Internal
         private delegate Task<TResponse> UnaryServerMethod(TService service, TRequest request, ServerCallContext serverCallContext);
 
         private readonly UnaryServerMethod _invoker;
+        private readonly Func<IServiceProvider, TService> _createService;
+        private readonly Action<TService> _releaseService;
 
         public UnaryServerCallHandler(Method<TRequest, TResponse> method, GrpcServiceOptions serviceOptions, ILoggerFactory loggerFactory) : base(method, serviceOptions, loggerFactory)
         {
             var handlerMethod = typeof(TService).GetMethod(Method.Name);
-
             _invoker = (UnaryServerMethod)Delegate.CreateDelegate(typeof(UnaryServerMethod), handlerMethod);
+        }
+
+        public UnaryServerCallHandler(
+            Method<TRequest, TResponse> method,
+            GrpcServiceOptions serviceOptions,
+            ILoggerFactory loggerFactory,
+            Func<IServiceProvider, TService> createService,
+            Action<TService> releaseService)
+                : this(method, serviceOptions, loggerFactory)
+        {
+            _createService = createService;
+            _releaseService = releaseService;
         }
 
         public override async Task HandleCallAsync(HttpContext httpContext)
@@ -57,9 +70,21 @@ namespace Grpc.AspNetCore.Server.Internal
             var serverCallContext = new HttpContextServerCallContext(httpContext, Logger);
             serverCallContext.Initialize();
 
-            // Activate the implementation type via DI.
-            var activator = httpContext.RequestServices.GetRequiredService<IGrpcServiceActivator<TService>>();
-            var service = activator.Create();
+            TService service;
+            IGrpcServiceActivator<TService> activator = null;
+            
+            if (_createService != null)
+            {
+                // create the service instance via lambda function
+                service = _createService(httpContext.RequestServices);
+                //TODO check service is null
+            }
+            else
+            {
+                // Activate the implementation type via DI.
+                activator = httpContext.RequestServices.GetRequiredService<IGrpcServiceActivator<TService>>();
+                service = activator.Create();
+            }
 
             TResponse response;
 
@@ -75,7 +100,14 @@ namespace Grpc.AspNetCore.Server.Internal
             }
             finally
             {
-                activator.Release(service);
+                if (activator != null)
+                {
+                    activator.Release(service);
+                }
+                else if (_releaseService != null)
+                {
+                    _releaseService(service);
+                }
             }
 
             // TODO(JunTaoLuo, JamesNK): make sure the response is not null

--- a/test/FunctionalTests/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/DuplexStreamingMethodTests.cs
@@ -28,6 +28,7 @@ using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
 using Grpc.Core;
 using NUnit.Framework;
+using Moq;
 
 namespace Grpc.AspNetCore.FunctionalTests
 {
@@ -37,6 +38,8 @@ namespace Grpc.AspNetCore.FunctionalTests
         [Test]
         public async Task MultipleMessagesFromOneClient_SuccessResponses()
         {
+            var moq = new Mock<Greet.Greeter.GreeterBase>();
+
             // Arrange
             var ms = new MemoryStream();
             MessageHelpers.WriteMessage(ms, new ChatMessage

--- a/test/FunctionalTests/Infrastructure/UniversalTestServerBuilder.cs
+++ b/test/FunctionalTests/Infrastructure/UniversalTestServerBuilder.cs
@@ -1,0 +1,86 @@
+using System;
+using FunctionalTestsWebsite.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class UniversalTestServerBuilder
+    {
+        public class ServiceRegistor
+        {
+            private readonly IEndpointRouteBuilder _routeBuilder;
+            public ServiceRegistor(IEndpointRouteBuilder routeBuilder)
+            {
+                _routeBuilder = routeBuilder;
+            }
+
+            public void Register<TService>(Func<TService> create) where TService : class
+            {
+                _routeBuilder.MapGrpcService<TService>(ctx => create());
+            }
+        }
+
+        private readonly Action<ServiceRegistor> _register;
+
+        private UniversalTestServerBuilder(Action<ServiceRegistor> register)
+        {
+            _register = register;
+        }
+
+        public static UniversalTestServerBuilder WithServices(Action<ServiceRegistor> register)
+        {
+            if (register == null)
+            {
+                throw new ArgumentNullException(nameof(register));
+            }
+            var instance = new UniversalTestServerBuilder(register);
+            return instance;
+        }
+
+        public TestServer Build()
+        {
+            var builder = new WebHostBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddGrpc();
+                })
+                .Configure(app =>
+                {
+                    app.Use((context, next) =>
+                    {
+                        // Workaround for https://github.com/aspnet/AspNetCore/issues/6880
+                        if (!context.Response.SupportsTrailers())
+                        {
+                            context.Features.Set<IHttpResponseTrailersFeature>(new TestHttpResponseTrailersFeature
+                            {
+                                Trailers = new HttpResponseTrailers()
+                            });
+                        }
+
+                        // Workaround for https://github.com/aspnet/AspNetCore/issues/7449
+                        context.Features.Set<IHttpRequestLifetimeFeature>(new TestHttpRequestLifetimeFeature());
+
+                        return next();
+                    });
+
+                    app.UseRouting(b =>
+                    {
+                        var registor = new ServiceRegistor(b);
+                        _register(registor);
+                    });
+                });
+
+            var server = new TestServer(builder);
+            server.BaseAddress = new System.Uri("http://localhost:5002");
+            return server;
+        }
+    }
+}


### PR DESCRIPTION
Hi, in this PR I'd like to introduce an approach to address #80 .
The idea is to expand `MapGrpcService` to allow services to be registered using custom service creation and dispose functions: 
```csharp
public static IEndpointConventionBuilder MapGrpcService<TService>(
            this IEndpointRouteBuilder builder,
            Func<IServiceProvider, TService> createService,
            Action<TService> releaseService = null) where TService : class
```
Services registered with this method would bypass the lifecycle managed by `IGrpcServiceActivator` and instead invoke these functions on creation/release. Functional test methods can then create an ASP.NET core `TestServer` as part of the arrange phase and providing custom service implementation (either some test implementation or mocked objects) 
```csharp
var gMock = new Mock<Greeter.GreeterBase>();
gMock
    .Setup(g => g.SayHello(It.IsAny<HelloRequest>(), It.IsAny<ServerCallContext>()))
    .Returns((HelloRequest r, ServerCallContext ctx) =>
    {
        return Task.FromResult(new HelloReply { Message = message });
    });
var obj = gMock.Object;
TestServer server = UniversalTestServerBuilder.WithServices(r =>
{
    r.Register(() => obj);
}).Build();
using (server)
using (var client = server.CreateClient())
{
...
```
I believe with this approach the static test website would no longer be necessary.
This PR is not meant to be complete (some implementations are not done yet and unit tests are missing) but rather a POC to (hopefully) get some feedback.