### PR TITLE
Parse un-padded value in binary header

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -65,5 +65,30 @@ namespace Grpc.AspNetCore.Server.Internal
             timeout = TimeSpan.Zero;
             return false;
         }
+
+        public static byte[] ParseBinaryHeader(string base64)
+        {
+            string decodable;
+            switch (base64.Length % 4)
+            {
+                case 0:
+                    // base64 has the required padding 
+                    decodable = base64;
+                    break;
+                case 2:
+                    // 2 chars padding
+                    decodable = base64 + "==";
+                    break;
+                case 3:
+                    // 3 chars padding
+                    decodable = base64 + "=";
+                    break;
+                default:
+                    // length%4 == 1 should be illegal
+                    throw new FormatException("Invalid base64 header value");
+            }
+
+            return Convert.FromBase64String(decodable);
+        }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -92,7 +92,7 @@ namespace Grpc.AspNetCore.Server.Internal
                         }
                         else if (header.Key.EndsWith(Metadata.BinaryHeaderSuffix, StringComparison.OrdinalIgnoreCase))
                         {
-                            _requestHeaders.Add(header.Key, ParseBinaryHeader(header.Value));
+                            _requestHeaders.Add(header.Key, GrpcProtocolHelpers.ParseBinaryHeader(header.Value));
                         }
                         else
                         {
@@ -207,30 +207,6 @@ namespace Grpc.AspNetCore.Server.Internal
         public void Dispose()
         {
             _deadlineTimer?.Dispose();
-        }
-
-        private static byte[] ParseBinaryHeader(string base64)
-        {
-            string decodable;
-            switch (base64.Length % 4)
-            {
-                case 0:
-                    // no padding
-                    decodable = base64;
-                    break;
-                case 2:
-                    // 2 chars
-                    decodable = base64 + "==";
-                    break;
-                case 3:
-                    decodable = base64 + "=";
-                    break;
-                default:
-                    // length%4 == 1 should be illegal
-                    throw new FormatException("Invalid base64 header value");
-            }
-
-            return Convert.FromBase64String(decodable);
         }
     }
 }

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -143,18 +143,40 @@ namespace Grpc.AspNetCore.Server.Tests
             CollectionAssert.AreEqual(headerBytes, header.ValueBytes);
         }
 
-        [Test]
-        public void RequestHeaders_ThrowsForNonBase64EncodedBinaryHeader()
+        [TestCase("a;b")]
+        [TestCase("ZG9uZ")]
+        public void RequestHeaders_ThrowsForNonBase64EncodedBinaryHeader(string header)
         {
             // Arrange
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers["test-bin"] = "a;b";
+            httpContext.Request.Headers["test-bin"] = header;
 
             // Act
             var serverCallContext = CreateServerCallContext(httpContext);
 
             // Assert
             Assert.Throws<FormatException>(() => serverCallContext.RequestHeaders.Clear());
+        }
+
+        [TestCase("ZG9uZQ==")]
+        [TestCase("AADQA7MnHnYTan7LCInL3K+EAfkpLdnnVVO1AgA=")]
+        public void Base64Binaryheader_WithNoPadding(string base64)
+        {
+            // Arrange
+            // strip the padding from the base64, assume that '='s are only at the end
+            var testSink = new TestSink();
+            var testLogger = new TestLogger(string.Empty, testSink, true);
+            var headerValue = base64.Replace("=", "");
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["header-bin"] = headerValue;
+            var context = CreateServerCallContext(httpContext, testLogger);
+
+            // Act
+            context.Initialize();
+
+            // Assert
+            context.RequestHeaders[0].ValueBytes.SequenceEqual(Convert.FromBase64String(base64));
         }
 
         [TestCase("trailer-name", "trailer-value", "trailer-name", "trailer-value")]
@@ -245,7 +267,7 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             public IHeaderDictionary Trailers { get; set; } = new HttpResponseTrailers();
         }
-		
+
         private static readonly ISystemClock TestClock = new TestSystemClock(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         private const long TicksPerMicrosecond = 10;
         private const long NanosecondsPerTick = 100;

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -163,9 +163,9 @@ namespace Grpc.AspNetCore.Server.Tests
         public void Base64Binaryheader_WithNoPadding(string base64)
         {
             // Arrange
-            // strip the padding from the base64, assume that '='s are only at the end
             var testSink = new TestSink();
             var testLogger = new TestLogger(string.Empty, testSink, true);
+            // strip the padding from base64, assuming that '='s are only at the end
             var headerValue = base64.Replace("=", "");
 
             var httpContext = new DefaultHttpContext();
@@ -176,7 +176,7 @@ namespace Grpc.AspNetCore.Server.Tests
             context.Initialize();
 
             // Assert
-            context.RequestHeaders[0].ValueBytes.SequenceEqual(Convert.FromBase64String(base64));
+            Assert.IsTrue(context.RequestHeaders[0].ValueBytes.SequenceEqual(Convert.FromBase64String(base64)));
         }
 
         [TestCase("trailer-name", "trailer-value", "trailer-name", "trailer-value")]


### PR DESCRIPTION
Addresses #97 .
Could be done more efficiently (for the rare case of un-padded headers) but enough to make grpc-java interop test pass. 