### PR TITLE
WIP Dynamic service methods in functional tests

### DIFF
--- a/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddRouting();
             services.AddOptions();
+            services.AddLogging();
             services.TryAddSingleton<GrpcMarkerService>();
             services.TryAddSingleton(typeof(ServerCallHandlerFactory<>));
             services.TryAddScoped(typeof(IGrpcServiceActivator<>), typeof(DefaultGrpcServiceActivator<>));

--- a/test/FunctionalTests/Infrastructure/DynamicGrpcService.cs
+++ b/test/FunctionalTests/Infrastructure/DynamicGrpcService.cs
@@ -1,0 +1,106 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FunctionalTestsWebsite.Infrastructure;
+using Google.Protobuf;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder.Internal;
+using Microsoft.AspNetCore.Routing;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class DynamicGrpcService
+    {
+        private readonly DynamicEndpointDataSource _endpointDataSource;
+        private readonly IServiceProvider _serviceProvider;
+
+        public DynamicGrpcService(DynamicEndpointDataSource endpointDataSource, IServiceProvider serviceProvider)
+        {
+            _endpointDataSource = endpointDataSource;
+            _serviceProvider = serviceProvider;
+        }
+
+        public string AddUnaryMethod<TService, TRequest, TResponse>(string methodName)
+            where TService : class
+            where TRequest : class, IMessage, new()
+            where TResponse : class, IMessage, new()
+        {
+            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.Unary, methodName);
+
+            var routeBuilder = new DynamicEndpointRouteBuilder(_serviceProvider);
+            routeBuilder.MapGrpcService<TService>(binder =>
+            {
+                binder.AddMethod(method, (UnaryServerMethod<TRequest, TResponse>)null);
+            });
+
+            var endpoints = routeBuilder.DataSources.SelectMany(ds => ds.Endpoints).ToList();
+
+            _endpointDataSource.AddEndpoints(endpoints);
+
+            return method.FullName;
+        }
+
+        private Method<TRequest, TResponse> CreateMethod<TService, TRequest, TResponse>(MethodType methodType, string methodName)
+            where TRequest : class, IMessage, new()
+            where TResponse : class, IMessage, new()
+        {
+            return new Method<TRequest, TResponse>(
+                methodType,
+                typeof(TService).Name,
+                methodName,
+                CreateMarshaller<TRequest>(),
+                CreateMarshaller<TResponse>());
+        }
+
+        private Marshaller<TMessage> CreateMarshaller<TMessage>()
+              where TMessage : class, IMessage, new()
+        {
+            return new Marshaller<TMessage>(
+                m => m.ToByteArray(),
+                d =>
+                {
+                    var m = new TMessage();
+                    m.MergeFrom(d);
+                    return m;
+                });
+        }
+
+        private class DynamicEndpointRouteBuilder : IEndpointRouteBuilder
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public DynamicEndpointRouteBuilder(IServiceProvider serviceProvider)
+            {
+                _serviceProvider = serviceProvider;
+            }
+
+            public IServiceProvider ServiceProvider => _serviceProvider;
+
+            public ICollection<EndpointDataSource> DataSources { get; } = new List<EndpointDataSource>();
+
+            public IApplicationBuilder CreateApplicationBuilder()
+            {
+                return new ApplicationBuilder(_serviceProvider);
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -38,6 +38,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
                 // Register trailers container so tests can assert trailer headers
                 // Not thread safe for parallel calls
                 services.AddSingleton(TrailersContainer);
+
+                // Registers a service for tests to add new methods
+                services.AddSingleton<DynamicGrpcService>();
             };
 
             var builder = new WebHostBuilder()
@@ -46,11 +49,15 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 
             _server = new TestServer(builder);
 
+            DynamicGrpc = _server.Host.Services.GetRequiredService<DynamicGrpcService>();
+
             Client = _server.CreateClient();
             Client.BaseAddress = new Uri("http://localhost");
         }
 
         public TrailersContainer TrailersContainer { get; }
+
+        public DynamicGrpcService DynamicGrpc { get; }
 
         public HttpClient Client { get; }
 

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -56,7 +56,7 @@ namespace Grpc.AspNetCore.Server.Tests
             // Act & Assert
             var ex = Assert.Throws<InvalidOperationException>(() => routeBuilder.MapGrpcService<object>());
             Assert.AreEqual("Unable to map gRPC service 'Object'.", ex.Message);
-            Assert.AreEqual($"Cannot locate BindService(ServiceBinderBase, ServiceBase) method for the current service type: {typeof(object).FullName}. The type must be an implementation of a gRPC service.", ex.InnerException.Message);
+            Assert.AreEqual($"Cannot locate BindService(ServiceBinderBase, ServiceBase) method for the current service type: {typeof(object).FullName}.", ex.InnerException.Message);
         }
 
         [Test]

--- a/testassets/FunctionalTestsWebsite/Greeter.cs
+++ b/testassets/FunctionalTestsWebsite/Greeter.cs
@@ -116,20 +116,4 @@ class GreeterService : Greeter.GreeterBase
         _logger.LogInformation("Sending goodbye");
         await responseStream.WriteAsync(new HelloReply { Message = $"Goodbye {request.Name}!" });
     }
-
-    public override Task<HelloReply> SayHelloSendHeadersTwice(HelloRequest request, ServerCallContext context)
-    {
-        context.WriteResponseHeadersAsync(null);
-
-        try
-        {
-            context.WriteResponseHeadersAsync(null);
-        }
-        catch (InvalidOperationException e) when (e.Message == "Response headers can only be sent once per call.")
-        {
-            return Task.FromResult(new HelloReply { Message = "Exception validated" });
-        }
-
-        return Task.FromResult(new HelloReply { Message = "No exception thrown" });
-    }
 }

--- a/testassets/FunctionalTestsWebsite/Infrastructure/DynamicEndpointDataSource.cs
+++ b/testassets/FunctionalTestsWebsite/Infrastructure/DynamicEndpointDataSource.cs
@@ -1,0 +1,68 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+
+namespace FunctionalTestsWebsite.Infrastructure
+{
+    /// <summary>
+    /// This endpoint data source can be modified and will raise a change token event.
+    /// It can be used to add new endpoints after the application has started.
+    /// </summary>
+    public class DynamicEndpointDataSource : EndpointDataSource
+    {
+        private readonly List<Endpoint> _endpoints = new List<Endpoint>();
+        private CancellationTokenSource _cts;
+        private CancellationChangeToken _cct;
+
+        public override IReadOnlyList<Endpoint> Endpoints => _endpoints;
+
+        public override IChangeToken GetChangeToken()
+        {
+            if (_cts == null)
+            {
+                _cts = new CancellationTokenSource();
+                _cct = new CancellationChangeToken(_cts.Token);
+            }
+
+            return _cct;
+        }
+
+        public void AddEndpoints(IEnumerable<Endpoint> endpoints)
+        {
+            _endpoints.AddRange(endpoints);
+
+            if (_cts != null)
+            {
+                var localCts = _cts;
+
+                _cts = null;
+                _cct = null;
+
+                localCts.Cancel();
+            }
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -43,6 +43,8 @@ namespace FunctionalTestsWebsite
             // When the site is run from the test project a signaler will already be registered
             // This will add a default one if the site is run standalone
             services.TryAddSingleton<TrailersContainer>();
+
+            services.TryAddSingleton<DynamicEndpointDataSource>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -67,9 +69,14 @@ namespace FunctionalTestsWebsite
 
             app.UseRouting(builder =>
             {
+                // Bind via reflection
                 builder.MapGrpcService<ChatterService>();
                 builder.MapGrpcService<CounterService>();
-                builder.MapGrpcService<GreeterService>();
+
+                // Bind via configure method
+                builder.MapGrpcService<GreeterService>(binder => Greet.Greeter.BindService(binder, null));
+
+                builder.DataSources.Add(builder.ServiceProvider.GetRequiredService<DynamicEndpointDataSource>());
             });
 
             app.Use(async (context, next) =>

--- a/testassets/Proto/greet.proto
+++ b/testassets/Proto/greet.proto
@@ -21,7 +21,6 @@ service Greeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply) {}
   rpc SayHelloSendLargeReply (HelloRequest) returns (HelloReply) {}
-  rpc SayHelloSendHeadersTwice (HelloRequest) returns (HelloReply) {}
   rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
   rpc SayHellosSendHeadersFirst (HelloRequest) returns (stream HelloReply) {}
   rpc SayHellosBufferHint (HelloRequest) returns (stream HelloReply) {}


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/80

Also adds a `MapGrpcService` that allows explicit binding. This is for code gen services that place BindService in a different class structure.