### PR TITLE
Dynamic service methods in functional tests - with invoker factory

### DIFF
--- a/perf/Grpc.AspNetCore.Microbenchmarks/UnaryServerCallHandlerBenchmark.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/UnaryServerCallHandlerBenchmark.cs
@@ -35,7 +35,7 @@ namespace Grpc.AspNetCore.Microbenchmarks
 {
     public class UnaryServerCallHandlerBenchmark
     {
-        private UnaryServerCallHandler<ChatMessage, ChatMessage, TestService> _callHandler;
+        private UnaryServerCallHandler<TestService, ChatMessage, ChatMessage> _callHandler;
         private ServiceProvider _requestServices;
         private DefaultHttpContext _httpContext;
         private HeaderDictionary _trailers;
@@ -46,7 +46,12 @@ namespace Grpc.AspNetCore.Microbenchmarks
         {
             var marshaller = Marshallers.Create((arg) => MessageExtensions.ToByteArray(arg), bytes => new ChatMessage());
             var method = new Method<ChatMessage, ChatMessage>(MethodType.Unary, typeof(TestService).FullName, nameof(TestService.SayHello), marshaller, marshaller);
-            _callHandler = new UnaryServerCallHandler<ChatMessage, ChatMessage, TestService>(method, new GrpcServiceOptions<TestService>(), NullLoggerFactory.Instance);
+            var result = Task.FromResult(new ChatMessage());
+            _callHandler = new UnaryServerCallHandler<TestService, ChatMessage, ChatMessage>(
+                method,
+                (service, request, context) => result,
+                new GrpcServiceOptions(),
+                NullLoggerFactory.Instance);
 
             _trailers = new HeaderDictionary();
 

--- a/src/Grpc.AspNetCore.Server/GrpcBindingOptions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcBindingOptions.cs
@@ -16,24 +16,23 @@
 
 #endregion
 
+using System;
+using Grpc.AspNetCore.Server.Internal;
+using Grpc.Core;
+
 namespace Grpc.AspNetCore.Server
 {
     /// <summary>
-    /// A <see cref="TGrpcService"/> activator abstraction.
+    /// Options used to configure the binding of a gRPC service.
     /// </summary>
-    /// <typeparam name="TGrpcService">The service type.</typeparam>
-    public interface IGrpcServiceActivator<TGrpcService> where TGrpcService : class
+    public class GrpcBindingOptions<TService>
     {
         /// <summary>
-        /// Creates a service.
+        /// The action invoked to get service metadata via <see cref="ServiceBinderBase"/>.
         /// </summary>
-        /// <returns>The created service.</returns>
-        TGrpcService Create();
+        public Action<ServiceBinderBase, TService> BindAction { get; set; }
 
-        /// <summary>
-        /// Releases the specified service.
-        /// </summary>
-        /// <param name="hub">The service to release.</param>
-        void Release(TGrpcService service);
+        // Currently internal. It is set in tests via InternalVisibleTo. Can be made public if there is demand for it
+        internal IGrpcMethodInvokerFactory<TService> InvokerFactory { get; set; }
     }
 }

--- a/src/Grpc.AspNetCore.Server/GrpcEndpointRouteBuilderExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcEndpointRouteBuilderExtensions.cs
@@ -17,19 +17,44 @@
 #endregion
 
 using System;
+using System.Reflection;
 using Grpc.AspNetCore.Server;
 using Grpc.AspNetCore.Server.Internal;
 using Grpc.Core;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to add gRPC service endpoints.
+    /// </summary>
     public static class GrpcEndpointRouteBuilderExtensions
     {
+        /// <summary>
+        /// Maps incoming requests to the specified <see cref="TService"/> type.
+        /// </summary>
+        /// <typeparam name="TService">The service type to map requests to.</typeparam>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the service.</returns>
         public static IEndpointConventionBuilder MapGrpcService<TService>(this IEndpointRouteBuilder builder) where TService : class
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.MapGrpcService<TService>(configureOptions: null);
+        }
+
+        /// <summary>
+        /// Maps incoming requests to the specified <see cref="TService"/> type.
+        /// </summary>
+        /// <typeparam name="TService">The service type to map requests to.</typeparam>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="configureOptions">A callback to configure binding options.</param>
+        /// <returns>An <see cref="IEndpointConventionBuilder"/> for endpoints associated with the service.</returns>
+        public static IEndpointConventionBuilder MapGrpcService<TService>(this IEndpointRouteBuilder builder, Action<GrpcBindingOptions<TService>> configureOptions) where TService : class
         {
             if (builder == null)
             {
@@ -38,42 +63,47 @@ namespace Microsoft.AspNetCore.Builder
 
             ValidateServicesRegistered(builder.ServiceProvider);
 
-            var service = typeof(TService);
+            var options = new GrpcBindingOptions<TService>();
+            options.BindAction = ReflectionBind<TService>;
+            options.InvokerFactory = new ReflectionMethodInvokerFactory<TService>();
+
+            configureOptions?.Invoke(options);
+
+            var callHandlerFactory = builder.ServiceProvider.GetRequiredService<ServerCallHandlerFactory<TService>>();
+            var serviceBinder = new GrpcServiceBinder<TService>(builder, callHandlerFactory, options.InvokerFactory);
 
             try
             {
-                // TService is an implementation of the gRPC service. It ultimately derives from Foo.TServiceBase base class.
-                // We need to access the static BindService method on Foo which implicitly derives from Object.
-                var baseType = service.BaseType;
-                while (baseType?.BaseType?.BaseType != null)
-                {
-                    baseType = baseType.BaseType;
-                }
-
-                // We need to call Foo.BindService from the declaring type.
-                var declaringType = baseType?.DeclaringType;
-
-                // The method we want to call is public static void BindService(ServiceBinderBase, BaseType)
-                var bindService = declaringType?.GetMethod("BindService", new[] { typeof(ServiceBinderBase), baseType });
-
-                if (bindService == null)
-                {
-                    throw new InvalidOperationException($"Cannot locate BindService(ServiceBinderBase, ServiceBase) method for the current service type: {service.FullName}. The type must be an implementation of a gRPC service.");
-                }
-
-                var callHandlerFactory = builder.ServiceProvider.GetRequiredService<ServerCallHandlerFactory<TService>>();
-
-                var serviceBinder = new GrpcServiceBinder<TService>(builder, callHandlerFactory);
-
-                // Invoke
-                bindService.Invoke(null, new object[] { serviceBinder, null });
-
-                return new CompositeEndpointConventionBuilder(serviceBinder.EndpointConventionBuilders);
+                options.BindAction(serviceBinder, null);
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException($"Unable to map gRPC service '{service.Name}'.", ex);
+                throw new InvalidOperationException($"Error binding gRPC service '{typeof(TService).Name}'.", ex);
             }
+
+            return new CompositeEndpointConventionBuilder(serviceBinder.EndpointConventionBuilders);
+        }
+
+        private static void ReflectionBind<TService>(ServiceBinderBase binder, TService service)
+        {
+            var serviceType = typeof(TService);
+
+            // TService is an implementation of the gRPC service. It ultimately derives from Foo.TServiceBase base class.
+            // We need to access the static BindService method on Foo which implicitly derives from Object.
+            var baseType = serviceType.BaseType;
+
+            // We need to call Foo.BindService from the declaring type.
+            var declaringType = baseType?.DeclaringType;
+
+            // The method we want to call is public static void BindService(ServiceBinderBase, BaseType)
+            var bindService = declaringType?.GetMethod("BindService", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(ServiceBinderBase), baseType }, Array.Empty<ParameterModifier>());
+
+            if (bindService == null)
+            {
+                throw new InvalidOperationException($"Cannot locate BindService(ServiceBinderBase, ServiceBase) method for the current service type: {serviceType.FullName}.");
+            }
+
+            bindService.Invoke(null, new object[] { binder, service });
         }
 
         private static void ValidateServicesRegistered(IServiceProvider serviceProvider)

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
@@ -25,23 +25,20 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers
 {
-    internal class ClientStreamingServerCallHandler<TRequest, TResponse, TService> : ServerCallHandlerBase<TRequest, TResponse, TService>
+    internal class ClientStreamingServerCallHandler<TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
         where TRequest : class
         where TResponse : class
         where TService : class
     {
-        // We're using an open delegate (the first argument is the TService instance) to represent the call here since the instance is create per request.
-        // This is the reason we're not using the delegates defined in Grpc.Core. This delegate maps to ClientStreamingServerMethod<TRequest, TResponse>
-        // with an instance parameter.
-        private delegate Task<TResponse> ClientStreamingServerMethod(TService service, IAsyncStreamReader<TRequest> stream, ServerCallContext serverCallContext);
+        private readonly ClientStreamingServerMethod<TService, TRequest, TResponse> _invoker;
 
-        private readonly ClientStreamingServerMethod _invoker;
-
-        public ClientStreamingServerCallHandler(Method<TRequest, TResponse> method, GrpcServiceOptions serviceOptions, ILoggerFactory loggerFactory) : base(method, serviceOptions, loggerFactory)
+        public ClientStreamingServerCallHandler(
+            Method<TRequest, TResponse> method,
+            ClientStreamingServerMethod<TService, TRequest, TResponse> invoker,
+            GrpcServiceOptions serviceOptions,
+            ILoggerFactory loggerFactory) : base(method, serviceOptions, loggerFactory)
         {
-            var handlerMethod = typeof(TService).GetMethod(Method.Name);
-
-            _invoker = (ClientStreamingServerMethod)Delegate.CreateDelegate(typeof(ClientStreamingServerMethod), handlerMethod);
+            _invoker = invoker;
         }
 
         public override async Task HandleCallAsync(HttpContext httpContext)

--- a/src/Grpc.AspNetCore.Server/Internal/IGrpcMethodInvokerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/IGrpcMethodInvokerFactory.cs
@@ -1,0 +1,34 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.Core;
+
+namespace Grpc.AspNetCore.Server.Internal
+{
+    /// <summary>
+    /// An interface for creating delegates used to invoke service methods on .NET types.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    internal interface IGrpcMethodInvokerFactory<TService>
+    {
+        UnaryServerMethod<TService, TRequest, TResponse> CreateUnaryInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method);
+        ClientStreamingServerMethod<TService, TRequest, TResponse> CreateClientStreamingInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method);
+        ServerStreamingServerMethod<TService, TRequest, TResponse> CreateServerStreamingInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method);
+        DuplexStreamingServerMethod<TService, TRequest, TResponse> CreateDuplexStreamingInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method);
+    }
+}

--- a/src/Grpc.AspNetCore.Server/Internal/ReflectionMethodInvokerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ReflectionMethodInvokerFactory.cs
@@ -1,0 +1,60 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.Core;
+
+namespace Grpc.AspNetCore.Server.Internal
+{
+    /// <summary>
+    /// Uses reflection to create delegates used to invoke service methods on .NET types.
+    /// </summary>
+    internal class ReflectionMethodInvokerFactory<TService> : IGrpcMethodInvokerFactory<TService>
+    {
+        public ClientStreamingServerMethod<TService, TRequest, TResponse> CreateClientStreamingInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        {
+            return CreateInvokerCore<ClientStreamingServerMethod<TService, TRequest, TResponse>>(method.Name);
+        }
+
+        public DuplexStreamingServerMethod<TService, TRequest, TResponse> CreateDuplexStreamingInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        {
+            return CreateInvokerCore<DuplexStreamingServerMethod<TService, TRequest, TResponse>>(method.Name);
+        }
+
+        public ServerStreamingServerMethod<TService, TRequest, TResponse> CreateServerStreamingInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        {
+            return CreateInvokerCore<ServerStreamingServerMethod<TService, TRequest, TResponse>>(method.Name);
+        }
+
+        public UnaryServerMethod<TService, TRequest, TResponse> CreateUnaryInvoker<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        {
+            return CreateInvokerCore<UnaryServerMethod<TService, TRequest, TResponse>>(method.Name);
+        }
+
+        private TDelegate CreateInvokerCore<TDelegate>(string methodName) where TDelegate : Delegate
+        {
+            var handlerMethod = typeof(TService).GetMethod(methodName);
+            if (handlerMethod == null)
+            {
+                throw new InvalidOperationException($"Could not find '{methodName}' on {typeof(TService)}.");
+            }
+
+            return (TDelegate)Delegate.CreateDelegate(typeof(TDelegate), handlerMethod);
+        }
+    }
+}

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerBase.cs
@@ -24,7 +24,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal
 {
-    internal abstract class ServerCallHandlerBase<TRequest, TResponse, TService> : IServerCallHandler
+    internal abstract class ServerCallHandlerBase<TService, TRequest, TResponse> : IServerCallHandler
     {
         protected Method<TRequest, TResponse> Method { get; }
         protected GrpcServiceOptions ServiceOptions { get; }

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -23,6 +23,9 @@ using Microsoft.Extensions.Options;
 
 namespace Grpc.AspNetCore.Server.Internal
 {
+    /// <summary>
+    /// Creates server call handlers. Provides a place to get services that call handlers will use.
+    /// </summary>
     internal class ServerCallHandlerFactory<TService> where TService : class
     {
         private readonly ILoggerFactory _loggerFactory;
@@ -45,32 +48,32 @@ namespace Grpc.AspNetCore.Server.Internal
             };
         }
 
-        public UnaryServerCallHandler<TRequest, TResponse, TService> CreateUnary<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        public UnaryServerCallHandler<TService, TRequest, TResponse> CreateUnary<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
-            return new UnaryServerCallHandler<TRequest, TResponse, TService>(method, _resolvedOptions, _loggerFactory);
+            return new UnaryServerCallHandler<TService, TRequest, TResponse>(method, invoker, _resolvedOptions, _loggerFactory);
         }
 
-        public ClientStreamingServerCallHandler<TRequest, TResponse, TService> CreateClientStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        public ClientStreamingServerCallHandler<TService, TRequest, TResponse> CreateClientStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
-            return new ClientStreamingServerCallHandler<TRequest, TResponse, TService>(method, _resolvedOptions, _loggerFactory);
+            return new ClientStreamingServerCallHandler<TService, TRequest, TResponse>(method, invoker, _resolvedOptions, _loggerFactory);
         }
 
-        public DuplexStreamingServerCallHandler<TRequest, TResponse, TService> CreateDuplexStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        public DuplexStreamingServerCallHandler<TService, TRequest, TResponse> CreateDuplexStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
-            return new DuplexStreamingServerCallHandler<TRequest, TResponse, TService>(method, _resolvedOptions, _loggerFactory);
+            return new DuplexStreamingServerCallHandler<TService, TRequest, TResponse>(method, invoker, _resolvedOptions, _loggerFactory);
         }
 
-        public ServerStreamingServerCallHandler<TRequest, TResponse, TService> CreateServerStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method)
+        public ServerStreamingServerCallHandler<TService, TRequest, TResponse> CreateServerStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
-            return new ServerStreamingServerCallHandler<TRequest, TResponse, TService>(method, _resolvedOptions, _loggerFactory);
+            return new ServerStreamingServerCallHandler<TService, TRequest, TResponse>(method, invoker, _resolvedOptions, _loggerFactory);
         }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/ServerMethods.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerMethods.cs
@@ -1,0 +1,34 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Grpc.AspNetCore.Server.Internal
+{
+    // Open delegate (the first argument is the TService instance) versions of the service call types.
+    // Needed because methods are executed with a new service instance each request.
+
+    internal delegate Task<TResponse> UnaryServerMethod<TService, TRequest, TResponse>(TService service, TRequest request, ServerCallContext serverCallContext);
+
+    internal delegate Task<TResponse> ClientStreamingServerMethod<TService, TRequest, TResponse>(TService service, IAsyncStreamReader<TRequest> stream, ServerCallContext serverCallContext);
+
+    internal delegate Task ServerStreamingServerMethod<TService, TRequest, TResponse>(TService service, TRequest request, IServerStreamWriter<TResponse> stream, ServerCallContext serverCallContext);
+
+    internal delegate Task DuplexStreamingServerMethod<TService, TRequest, TResponse>(TService service, IAsyncStreamReader<TRequest> input, IServerStreamWriter<TResponse> output, ServerCallContext serverCallContext);
+}

--- a/src/Grpc.AspNetCore.Server/Properties/AssemblyInfo.cs
+++ b/src/Grpc.AspNetCore.Server/Properties/AssemblyInfo.cs
@@ -35,3 +35,10 @@ using System.Runtime.CompilerServices;
     "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
     "27fc95aff3dc604a6971417453f9483c7b5e836756d5b271bf8f2403fe186e31956148c03d804487cf642f8cc0" +
     "71394ee9672dfe5b55ea0f95dfd5a7f77d22c962ccf51320d3")]
+
+// For Moq. This assembly needs access to internal types via InternalVisibleTo to be able to mock them
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602" +
+    "000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02ba" +
+    "a56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667" +
+    "bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6" +
+    "a7d3113e92484cf7045cc7")] 

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -2,10 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/FunctionalTests/Infrastructure/DynamicGrpcServiceRegistry.cs
+++ b/test/FunctionalTests/Infrastructure/DynamicGrpcServiceRegistry.cs
@@ -1,0 +1,116 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FunctionalTestsWebsite.Infrastructure;
+using Google.Protobuf;
+using Grpc.AspNetCore.Server;
+using Grpc.AspNetCore.Server.Internal;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder.Internal;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    /// <summary>
+    /// Used by tests to add new service methods.
+    /// </summary>
+    public class DynamicGrpcServiceRegistry
+    {
+        private readonly DynamicEndpointDataSource _endpointDataSource;
+        private readonly IServiceProvider _serviceProvider;
+
+        public DynamicGrpcServiceRegistry(DynamicEndpointDataSource endpointDataSource, IServiceProvider serviceProvider)
+        {
+            _endpointDataSource = endpointDataSource;
+            _serviceProvider = serviceProvider;
+        }
+
+        public string AddUnaryMethod<TService, TRequest, TResponse>(UnaryServerMethod<TRequest, TResponse> callHandler)
+            where TService : class
+            where TRequest : class, IMessage, new()
+            where TResponse : class, IMessage, new()
+        {
+            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.Unary, Guid.NewGuid().ToString());
+
+            Mock<IGrpcMethodInvokerFactory<TService>> mockInvoker = new Mock<IGrpcMethodInvokerFactory<TService>>();
+            mockInvoker.Setup(m => m.CreateUnaryInvoker(method)).Returns(() => new UnaryServerMethod<TService, TRequest, TResponse>((service, request, context) => callHandler(request, context)));
+
+            var routeBuilder = new DynamicEndpointRouteBuilder(_serviceProvider);
+            routeBuilder.MapGrpcService<TService>(options =>
+            {
+                options.BindAction = (binder, _) => binder.AddMethod(method, (UnaryServerMethod<TRequest, TResponse>)null);
+                options.InvokerFactory = mockInvoker.Object;
+            });
+
+            var endpoints = routeBuilder.DataSources.SelectMany(ds => ds.Endpoints).ToList();
+
+            _endpointDataSource.AddEndpoints(endpoints);
+
+            return method.FullName;
+        }
+
+        private Method<TRequest, TResponse> CreateMethod<TService, TRequest, TResponse>(MethodType methodType, string methodName)
+            where TRequest : class, IMessage, new()
+            where TResponse : class, IMessage, new()
+        {
+            return new Method<TRequest, TResponse>(
+                methodType,
+                typeof(TService).Name,
+                methodName,
+                CreateMarshaller<TRequest>(),
+                CreateMarshaller<TResponse>());
+        }
+
+        private Marshaller<TMessage> CreateMarshaller<TMessage>()
+              where TMessage : class, IMessage, new()
+        {
+            return new Marshaller<TMessage>(
+                m => m.ToByteArray(),
+                d =>
+                {
+                    var m = new TMessage();
+                    m.MergeFrom(d);
+                    return m;
+                });
+        }
+
+        private class DynamicEndpointRouteBuilder : IEndpointRouteBuilder
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public DynamicEndpointRouteBuilder(IServiceProvider serviceProvider)
+            {
+                _serviceProvider = serviceProvider;
+            }
+
+            public IServiceProvider ServiceProvider => _serviceProvider;
+
+            public ICollection<EndpointDataSource> DataSources { get; } = new List<EndpointDataSource>();
+
+            public IApplicationBuilder CreateApplicationBuilder()
+            {
+                return new ApplicationBuilder(_serviceProvider);
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -39,6 +39,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
                 // Register trailers container so tests can assert trailer headers
                 // Not thread safe for parallel calls
                 services.AddSingleton(TrailersContainer);
+
+                // Registers a service for tests to add new methods
+                services.AddSingleton<DynamicGrpcServiceRegistry>();
             };
 
             var builder = new WebHostBuilder()
@@ -47,11 +50,15 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 
             _server = new TestServer(builder);
 
+            DynamicGrpc = _server.Host.Services.GetRequiredService<DynamicGrpcServiceRegistry>();
+
             Client = _server.CreateClient();
             Client.BaseAddress = new Uri("http://localhost");
         }
 
         public TrailersContainer TrailersContainer { get; }
+
+        public DynamicGrpcServiceRegistry DynamicGrpc { get; }
 
         public HttpClient Client { get; }
 

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -49,14 +49,15 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             // Arrange
             ServiceCollection services = new ServiceCollection();
+            services.AddLogging();
             services.AddGrpc();
 
             var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider());
 
             // Act & Assert
             var ex = Assert.Throws<InvalidOperationException>(() => routeBuilder.MapGrpcService<object>());
-            Assert.AreEqual("Unable to map gRPC service 'Object'.", ex.Message);
-            Assert.AreEqual($"Cannot locate BindService(ServiceBinderBase, ServiceBase) method for the current service type: {typeof(object).FullName}. The type must be an implementation of a gRPC service.", ex.InnerException.Message);
+            Assert.AreEqual("Error binding gRPC service 'Object'.", ex.Message);
+            Assert.AreEqual($"Cannot locate BindService(ServiceBinderBase, ServiceBase) method for the current service type: {typeof(object).FullName}.", ex.InnerException.Message);
         }
 
         [Test]

--- a/testassets/FunctionalTestsWebsite/Greeter.cs
+++ b/testassets/FunctionalTestsWebsite/Greeter.cs
@@ -148,14 +148,4 @@ class GreeterService : Greeter.GreeterBase
         _logger.LogInformation("Sending goodbye");
         await responseStream.WriteAsync(new HelloReply { Message = $"Goodbye {request.Name}!" });
     }
-
-    public override async Task<HelloReply> SayHelloSendHeadersTwice(HelloRequest request, ServerCallContext context)
-    {
-        await context.WriteResponseHeadersAsync(null);
-
-        // This will throw an error
-        await context.WriteResponseHeadersAsync(null);
-
-        return new HelloReply { Message = "Should never reach here." };
-    }
 }

--- a/testassets/FunctionalTestsWebsite/Infrastructure/DynamicEndpointDataSource.cs
+++ b/testassets/FunctionalTestsWebsite/Infrastructure/DynamicEndpointDataSource.cs
@@ -1,0 +1,68 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+
+namespace FunctionalTestsWebsite.Infrastructure
+{
+    /// <summary>
+    /// This endpoint data source can be modified and will raise a change token event.
+    /// It can be used to add new endpoints after the application has started.
+    /// </summary>
+    public class DynamicEndpointDataSource : EndpointDataSource
+    {
+        private readonly List<Endpoint> _endpoints = new List<Endpoint>();
+        private CancellationTokenSource _cts;
+        private CancellationChangeToken _cct;
+
+        public override IReadOnlyList<Endpoint> Endpoints => _endpoints;
+
+        public override IChangeToken GetChangeToken()
+        {
+            if (_cts == null)
+            {
+                _cts = new CancellationTokenSource();
+                _cct = new CancellationChangeToken(_cts.Token);
+            }
+
+            return _cct;
+        }
+
+        public void AddEndpoints(IEnumerable<Endpoint> endpoints)
+        {
+            _endpoints.AddRange(endpoints);
+
+            if (_cts != null)
+            {
+                var localCts = _cts;
+
+                _cts = null;
+                _cct = null;
+
+                localCts.Cancel();
+            }
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -49,6 +49,8 @@ namespace FunctionalTestsWebsite
             // When the site is run from the test project a signaler will already be registered
             // This will add a default one if the site is run standalone
             services.TryAddSingleton<TrailersContainer>();
+
+            services.TryAddSingleton<DynamicEndpointDataSource>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -75,9 +77,14 @@ namespace FunctionalTestsWebsite
 
             app.UseRouting(builder =>
             {
+                // Bind via reflection
                 builder.MapGrpcService<ChatterService>();
                 builder.MapGrpcService<CounterService>();
-                builder.MapGrpcService<GreeterService>();
+
+                // Bind via configure method
+                builder.MapGrpcService<GreeterService>(options => options.BindAction = Greet.Greeter.BindService);
+
+                builder.DataSources.Add(builder.ServiceProvider.GetRequiredService<DynamicEndpointDataSource>());
             });
 
             app.Use(async (context, next) =>

--- a/testassets/Proto/greet.proto
+++ b/testassets/Proto/greet.proto
@@ -25,7 +25,6 @@ service Greeter {
   rpc SayHelloWithHttpContextAccessor (HelloRequest) returns (HelloReply) {}
   rpc SayHelloWithHttpContextExtensionMethod (HelloRequest) returns (HelloReply) {}
   rpc SayHelloSendLargeReply (HelloRequest) returns (HelloReply) {}
-  rpc SayHelloSendHeadersTwice (HelloRequest) returns (HelloReply) {}
   rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
   rpc SayHellosSendHeadersFirst (HelloRequest) returns (stream HelloReply) {}
   rpc SayHellosBufferHint (HelloRequest) returns (stream HelloReply) {}


### PR DESCRIPTION
Addresses #80

Builds on top of https://github.com/grpc/grpc-dotnet/pull/103 and adds an invoker factory.

The invoker factory provides a way for developers to inject custom logic to control how the service method is invoked. The default logic is still to use the method name to get a method via `typeof(Service).GetMethod(Method.Name)` and wrap it in a delegate.

Update: Made invoker factory internal. It can be made public in the future if there is user demand for it.