### PR TITLE
Set nuget version to 0.1.19-pre1

### DIFF
--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
-    <VersionPrefix>0.0.1-dev</VersionPrefix>
+    <VersionPrefix>0.1.19-pre1</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
I'll merge this later this week once we're ready to cut the prerelease.

After merging, I'll tag (`v0.1.19-pre1`), create the release in https://github.com/grpc/grpc-dotnet/releases  and push the nuget to nuget.org. 