### PR TITLE
Validate request content type

### DIFF
--- a/perf/Grpc.AspNetCore.Microbenchmarks/UnaryServerCallHandlerBenchmark.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/UnaryServerCallHandlerBenchmark.cs
@@ -23,7 +23,7 @@ using Chat;
 using Google.Protobuf;
 using Grpc.AspNetCore.Microbenchmarks.Internal;
 using Grpc.AspNetCore.Server;
-using Grpc.AspNetCore.Server.Internal;
+using Grpc.AspNetCore.Server.Internal.CallHandlers;
 using Grpc.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
@@ -41,7 +41,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             _invoker = invoker;
         }
 
-        public override async Task HandleCallAsync(HttpContext httpContext)
+        protected override async Task HandleCallAsyncCore(HttpContext httpContext)
         {
             httpContext.Response.ContentType = "application/grpc";
             httpContext.Response.Headers.Append("grpc-encoding", "identity");

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
@@ -37,7 +37,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             _invoker = invoker;
         }
 
-        public override async Task HandleCallAsync(HttpContext httpContext)
+        protected override async Task HandleCallAsyncCore(HttpContext httpContext)
         {
             httpContext.Response.ContentType = "application/grpc";
             httpContext.Response.Headers.Append("grpc-encoding", "identity");

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -22,7 +22,7 @@ using Grpc.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
-namespace Grpc.AspNetCore.Server.Internal
+namespace Grpc.AspNetCore.Server.Internal.CallHandlers
 {
     internal abstract class ServerCallHandlerBase<TService, TRequest, TResponse> : IServerCallHandler
     {
@@ -37,6 +37,16 @@ namespace Grpc.AspNetCore.Server.Internal
             Logger = loggerFactory.CreateLogger(typeof(TService));
         }
 
-        public abstract Task HandleCallAsync(HttpContext httpContext);
+        public Task HandleCallAsync(HttpContext httpContext)
+        {
+            if (!GrpcProtocolHelpers.IsValidContentType(httpContext, out var error))
+            {
+                return GrpcProtocolHelpers.SendHttpError(httpContext.Response, StatusCode.Internal, error);
+            }
+
+            return HandleCallAsyncCore(httpContext);
+        }
+
+        protected abstract Task HandleCallAsyncCore(HttpContext httpContext);
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerStreamingServerCallHandler.cs
@@ -37,7 +37,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             _invoker = invoker;
         }
 
-        public override async Task HandleCallAsync(HttpContext httpContext)
+        protected override async Task HandleCallAsyncCore(HttpContext httpContext)
         {
             httpContext.Response.ContentType = "application/grpc";
             httpContext.Response.Headers.Append("grpc-encoding", "identity");

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
@@ -23,7 +23,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Grpc.AspNetCore.Server.Internal
+namespace Grpc.AspNetCore.Server.Internal.CallHandlers
 {
     internal class UnaryServerCallHandler<TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
         where TRequest : class
@@ -38,7 +38,7 @@ namespace Grpc.AspNetCore.Server.Internal
             _invoker = invoker;
         }
 
-        public override async Task HandleCallAsync(HttpContext httpContext)
+        protected override async Task HandleCallAsyncCore(HttpContext httpContext)
         {
             httpContext.Response.ContentType = "application/grpc";
             httpContext.Response.Headers.Append("grpc-encoding", "identity");

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -90,13 +90,8 @@ namespace Grpc.AspNetCore.Server.Internal
             }
             if (nextChar == '+')
             {
-                // Currently only +proto is supported
-                if (contentType
-                    .AsSpan(GrpcProtocolConstants.GrpcContentType.Length)
-                    .Equals("+proto", StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
+                // Accept any message format. Marshaller could be set to support third-party formats
+                return true;
             }
 
             return false;

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -18,6 +18,9 @@
 
 using System;
 using System.Globalization;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace Grpc.AspNetCore.Server.Internal
@@ -64,6 +67,64 @@ namespace Grpc.AspNetCore.Server.Internal
 
             timeout = TimeSpan.Zero;
             return false;
+        }
+
+        public static bool IsGrpcContentType(string contentType)
+        {
+            if (!contentType.StartsWith(GrpcProtocolConstants.GrpcContentType, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (contentType.Length == GrpcProtocolConstants.GrpcContentType.Length)
+            {
+                // Exact match
+                return true;
+            }
+
+            // Support variations on the content-type (e.g. +proto, +json)
+            char nextChar = contentType[GrpcProtocolConstants.GrpcContentType.Length];
+            if (nextChar == ';')
+            {
+                return true;
+            }
+            if (nextChar == '+')
+            {
+                // Currently only +proto is supported
+                if (contentType
+                    .AsSpan(GrpcProtocolConstants.GrpcContentType.Length)
+                    .Equals("+proto", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool IsValidContentType(HttpContext httpContext, out string error)
+        {
+            if (httpContext.Request.ContentType == null)
+            {
+                error = "Content-Type is missing from the request.";
+                return false;
+            }
+            else if (!IsGrpcContentType(httpContext.Request.ContentType))
+            {
+                error = $"Content-Type '{httpContext.Request.ContentType}' is not supported.";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        public static Task SendHttpError(HttpResponse response, StatusCode statusCode, string message)
+        {
+            response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+            response.AppendTrailer(GrpcProtocolConstants.StatusTrailer, statusCode.ToTrailerString());
+            response.AppendTrailer(GrpcProtocolConstants.MessageTrailer, message);
+            return response.WriteAsync(message);
         }
 
         public static byte[] ParseBinaryHeader(string base64)

--- a/test/FunctionalTests/ClientStreamingMethodTests.cs
+++ b/test/FunctionalTests/ClientStreamingMethodTests.cs
@@ -198,7 +198,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);

--- a/test/FunctionalTests/ClientStreamingMethodTests.cs
+++ b/test/FunctionalTests/ClientStreamingMethodTests.cs
@@ -49,7 +49,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Count.Counter/AccumulateCount");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -98,7 +98,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Count.Counter/AccumulateCount");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -142,7 +142,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             var response = await Fixture.Client.PostAsync(
                 "Count.Counter/IncrementCountReturnNull",
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);

--- a/test/FunctionalTests/DeadlineTests.cs
+++ b/test/FunctionalTests/DeadlineTests.cs
@@ -128,7 +128,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
             httpRequest.Headers.Add(GrpcProtocolConstants.TimeoutHeader, "200m");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var response = await Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();

--- a/test/FunctionalTests/DeadlineTests.cs
+++ b/test/FunctionalTests/DeadlineTests.cs
@@ -49,7 +49,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, requestUri);
             httpRequest.Headers.Add(GrpcProtocolConstants.TimeoutHeader, "200m");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var response = await Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();

--- a/test/FunctionalTests/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/DuplexStreamingMethodTests.cs
@@ -50,7 +50,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Chat.Chatter/Chat");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -121,7 +121,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -129,7 +129,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             Assert.IsFalse(responseTask.IsCompleted, "Server should wait for first message from client");
 
-            await requestStream.AddDataAndWait(ms.ToArray());
+            await requestStream.AddDataAndWait(ms.ToArray()).DefaultTimeout();
             Assert.IsFalse(responseTask.IsCompleted, "Server is buffering response");
 
             ms = new MemoryStream();
@@ -139,10 +139,10 @@ namespace Grpc.AspNetCore.FunctionalTests
                 Message = "Hello John"
             });
 
-            await requestStream.AddDataAndWait(ms.ToArray());
+            await requestStream.AddDataAndWait(ms.ToArray()).DefaultTimeout();
             Assert.IsFalse(responseTask.IsCompleted, "Server is buffering response");
 
-            await requestStream.AddDataAndWait(Array.Empty<byte>());
+            await requestStream.AddDataAndWait(Array.Empty<byte>()).DefaultTimeout();
 
             var response = await responseTask.DefaultTimeout();
 

--- a/test/FunctionalTests/HttpContextTests.cs
+++ b/test/FunctionalTests/HttpContextTests.cs
@@ -47,7 +47,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             MessageHelpers.WriteMessage(requestStream, requestMessage);
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHelloWithHttpContextAccessor?query=extra");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var response = await Fixture.Client.SendAsync(httpRequest).DefaultTimeout();
@@ -72,7 +72,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             MessageHelpers.WriteMessage(requestStream, requestMessage);
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHelloWithHttpContextExtensionMethod?query=extra");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var response = await Fixture.Client.SendAsync(httpRequest).DefaultTimeout();

--- a/test/FunctionalTests/Infrastructure/GrpcStreamContent.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcStreamContent.cs
@@ -16,14 +16,21 @@
 
 #endregion
 
-namespace Grpc.AspNetCore.Server.Internal
-{
-    internal static class GrpcProtocolConstants
-    {
-        internal const string GrpcContentType = "application/grpc";
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Grpc.AspNetCore.Server.Internal;
 
-        internal const string TimeoutHeader = "grpc-timeout";
-        internal const string StatusTrailer = "grpc-status";
-        internal const string MessageTrailer = "grpc-message";
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class GrpcStreamContent : StreamContent
+    {
+        public GrpcStreamContent(Stream content) : base(content)
+        {
+            Headers.ContentType = new MediaTypeHeaderValue(GrpcProtocolConstants.GrpcContentType);
+        }
     }
 }

--- a/test/FunctionalTests/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/MaxMessageSizeTests.cs
@@ -58,7 +58,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             await Fixture.Client.PostAsync(
                 "Greet.Greeter/SayHello",
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(StatusCode.ResourceExhausted.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
@@ -88,7 +88,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             await Fixture.Client.PostAsync(
                 "Greet.Greeter/SayHelloSendLargeReply",
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(StatusCode.ResourceExhausted.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());

--- a/test/FunctionalTests/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/ServerStreamingMethodTests.cs
@@ -48,7 +48,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             MessageHelpers.WriteMessage(requestStream, requestMessage);
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHellos");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var response = await Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
@@ -93,7 +93,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             MessageHelpers.WriteMessage(requestStream, requestMessage);
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHellosSendHeadersFirst");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var response = await Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
@@ -149,7 +149,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             MessageHelpers.WriteMessage(requestStream, requestMessage);
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -345,8 +345,6 @@ namespace Grpc.AspNetCore.FunctionalTests
         [TestCase("application/json", "Content-Type 'application/json' is not supported.")]
         [TestCase("application/binary", "Content-Type 'application/binary' is not supported.")]
         [TestCase("application/grpc-web", "Content-Type 'application/grpc-web' is not supported.")]
-        [TestCase("application/grpc+", "Content-Type 'application/grpc+' is not supported.")]
-        [TestCase("application/grpc+json", "Content-Type 'application/grpc+json' is not supported.")]
         public async Task InvalidContentType_Return415Response(string contentType, string responseMessage)
         {
             // Arrange
@@ -379,6 +377,7 @@ namespace Grpc.AspNetCore.FunctionalTests
         [TestCase("APPLICATION/GRPC")]
         [TestCase("application/grpc+proto")]
         [TestCase("APPLICATION/GRPC+PROTO")]
+        [TestCase("application/grpc+json")] // Accept any message format. A Method+marshaller may have been set that reads and writes JSON
         [TestCase("application/grpc; param=one")]
         public async Task ValidContentType_ReturnValidResponse(string contentType)
         {

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using FunctionalTestsWebsite;
 using Google.Protobuf.WellKnownTypes;
@@ -51,7 +52,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             var response = await Fixture.Client.PostAsync(
                 "Greet.Greeter/SayHello",
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -79,7 +80,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHello");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -122,7 +123,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHello");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -161,7 +162,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var requestStream = new SyncPointMemoryStream();
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "Greet.Greeter/SayHello");
-            httpRequest.Content = new StreamContent(requestStream);
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -220,7 +221,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             var response = await Fixture.Client.PostAsync(
                 url,
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -254,7 +255,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             var response = await Fixture.Client.PostAsync(
                 "Greet.Greeter/SayHelloReturnNull",
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -286,7 +287,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             var response = await Fixture.Client.PostAsync(
                 "Greet.Greeter/SayHelloThrowExceptionWithTrailers",
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -319,7 +320,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Act
             var response = await Fixture.Client.PostAsync(
                 url,
-                new StreamContent(ms)).DefaultTimeout();
+                new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -338,6 +339,70 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             Assert.AreEqual(string.Empty, Fixture.TrailersContainer.Trailers["Test-Peer"].ToString());
             Assert.AreEqual("localhost", Fixture.TrailersContainer.Trailers["Test-Host"].ToString());
+        }
+
+        [TestCase(null, "Content-Type is missing from the request.")]
+        [TestCase("application/json", "Content-Type 'application/json' is not supported.")]
+        [TestCase("application/binary", "Content-Type 'application/binary' is not supported.")]
+        [TestCase("application/grpc-web", "Content-Type 'application/grpc-web' is not supported.")]
+        [TestCase("application/grpc+", "Content-Type 'application/grpc+' is not supported.")]
+        [TestCase("application/grpc+json", "Content-Type 'application/grpc+json' is not supported.")]
+        public async Task InvalidContentType_Return415Response(string contentType, string responseMessage)
+        {
+            // Arrange
+            var requestMessage = new HelloRequest
+            {
+                Name = "World"
+            };
+
+            var ms = new MemoryStream();
+            MessageHelpers.WriteMessage(ms, requestMessage);
+            var streamContent = new StreamContent(ms);
+            streamContent.Headers.ContentType = contentType != null ? new MediaTypeHeaderValue(contentType) : null;
+
+            // Act
+            var response = await Fixture.Client.PostAsync(
+                "Greet.Greeter/SayHello",
+                streamContent).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+
+            var content = await response.Content.ReadAsStringAsync().DefaultTimeout();
+            Assert.AreEqual(responseMessage, content);
+
+            Assert.AreEqual(StatusCode.Internal.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Assert.AreEqual(responseMessage, Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+        }
+
+        [TestCase("application/grpc")]
+        [TestCase("APPLICATION/GRPC")]
+        [TestCase("application/grpc+proto")]
+        [TestCase("APPLICATION/GRPC+PROTO")]
+        [TestCase("application/grpc; param=one")]
+        public async Task ValidContentType_ReturnValidResponse(string contentType)
+        {
+            // Arrange
+            var requestMessage = new HelloRequest
+            {
+                Name = "World"
+            };
+
+            var ms = new MemoryStream();
+            MessageHelpers.WriteMessage(ms, requestMessage);
+            var streamContent = new StreamContent(ms);
+            streamContent.Headers.ContentType = contentType != null ? MediaTypeHeaderValue.Parse(contentType) : null;
+
+            // Act
+            var response = await Fixture.Client.PostAsync(
+                "Greet.Greeter/SayHello",
+                streamContent).DefaultTimeout();
+
+            // Assert
+            var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
+            Assert.AreEqual("Hello World", responseMessage.Message);
+
+            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
         }
     }
 }


### PR DESCRIPTION
Accept application/grpc and application/grpc+proto. Other message formats, and requests with no content type get a 415 response. Matches grpc-java behaviour.