### PR TITLE
Verify server logging

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
@@ -66,7 +66,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
                 if (response == null)
                 {
                     // This is consistent with Grpc.Core when a null value is returned
-                    throw new RpcException(new Status(StatusCode.Cancelled, "Cancelled"));
+                    throw new RpcException(new Status(StatusCode.Cancelled, "No message returned from method."));
                 }
 
                 var responseBodyPipe = httpContext.Response.BodyPipe;

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
@@ -67,7 +67,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 if (response == null)
                 {
                     // This is consistent with Grpc.Core when a null value is returned
-                    throw new RpcException(new Status(StatusCode.Cancelled, "Cancelled"));
+                    throw new RpcException(new Status(StatusCode.Cancelled, "No message returned from method."));
                 }
 
                 var responseBodyPipe = httpContext.Response.BodyPipe;

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
@@ -56,7 +56,7 @@ namespace Grpc.AspNetCore.Server.Internal
             _errorExecutingServiceMethod(logger, serviceMethod, ex);
         }
 
-        public static void RpcConnectionError(ILogger logger, StatusCode statusCode, string detail, Exception ex)
+        public static void RpcConnectionError(ILogger logger, StatusCode statusCode, Exception ex)
         {
             _rpcConnectionError(logger, statusCode, ex);
         }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
@@ -56,7 +56,7 @@ namespace Grpc.AspNetCore.Server.Internal
             _errorExecutingServiceMethod(logger, serviceMethod, ex);
         }
 
-        public static void RpcConnectionError(ILogger logger, StatusCode statusCode, Exception ex)
+        public static void RpcConnectionError(ILogger logger, StatusCode statusCode, string detail, Exception ex)
         {
             _rpcConnectionError(logger, statusCode, ex);
         }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -112,7 +112,7 @@ namespace Grpc.AspNetCore.Server.Internal
         {
             if (ex is RpcException rpcException)
             {
-                RpcConnectionError(_logger, rpcException.StatusCode, ex);
+                RpcConnectionError(_logger, rpcException.StatusCode, rpcException.Status.Detail, ex);
 
                 // There are two sources of metadata entries on the server-side:
                 // 1. serverCallContext.ResponseTrailers
@@ -158,7 +158,6 @@ namespace Grpc.AspNetCore.Server.Internal
 
         protected override WriteOptions WriteOptionsCore { get; set; }
 
-        // TODO(JunTaoLuo, JamesNK): implement this
         protected override AuthContext AuthContextCore
         {
             get

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -112,7 +112,7 @@ namespace Grpc.AspNetCore.Server.Internal
         {
             if (ex is RpcException rpcException)
             {
-                RpcConnectionError(_logger, rpcException.StatusCode, rpcException.Status.Detail, ex);
+                RpcConnectionError(_logger, rpcException.StatusCode, ex);
 
                 // There are two sources of metadata entries on the server-side:
                 // 1. serverCallContext.ResponseTrailers

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -46,6 +46,11 @@ namespace Grpc.AspNetCore.Server.Internal
                 throw new ArgumentNullException(nameof(message));
             }
 
+            if (_context.CancellationToken.IsCancellationRequested)
+            {
+                throw new InvalidOperationException("Cannot write message after request is complete.");
+            }
+
             return _context.HttpContext.Response.BodyPipe.WriteMessageAsync(message, _context, _serializer);
         }
     }

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerBase.cs
@@ -34,7 +34,7 @@ namespace Grpc.AspNetCore.Server.Internal
         {
             Method = method;
             ServiceOptions = serviceOptions;
-            Logger = loggerFactory.CreateLogger(GetType());
+            Logger = loggerFactory.CreateLogger(typeof(TService));
         }
 
         public abstract Task HandleCallAsync(HttpContext httpContext);

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -19,8 +19,6 @@
 using System;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Logging.Testing;
 using NUnit.Framework;
 
 namespace Grpc.AspNetCore.FunctionalTests
@@ -52,7 +50,13 @@ namespace Grpc.AspNetCore.FunctionalTests
         [TearDown]
         public void TearDown()
         {
+            // This will verify only expected errors were logged on the server for the previous test.
             _scope?.Dispose();
+        }
+
+        protected void SetExpectedErrorsFilter(Func<LogRecord, bool> expectedErrorsFilter)
+        {
+            _scope.ExpectedErrorsFilter = expectedErrorsFilter;
         }
 
         protected static string GetRpcExceptionDetail(Exception ex)
@@ -63,11 +67,6 @@ namespace Grpc.AspNetCore.FunctionalTests
             }
 
             return null;
-        }
-
-        protected void SetExpectedErrorsFilter(Func<WriteContext, bool> expectedErrorsFilter)
-        {
-            _scope.ExpectedErrorsFilter = expectedErrorsFilter;
         }
     }
 }

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\testassets\FunctionalTestsWebsite\FunctionalTestsWebsite.csproj" />
 
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/FunctionalTests/Infrastructure/DynamicGrpcServiceRegistry.cs
+++ b/test/FunctionalTests/Infrastructure/DynamicGrpcServiceRegistry.cs
@@ -45,12 +45,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
             _serviceProvider = serviceProvider;
         }
 
-        public string AddUnaryMethod<TService, TRequest, TResponse>(UnaryServerMethod<TRequest, TResponse> callHandler)
+        public string AddUnaryMethod<TService, TRequest, TResponse>(UnaryServerMethod<TRequest, TResponse> callHandler, string methodName = null)
             where TService : class
             where TRequest : class, IMessage, new()
             where TResponse : class, IMessage, new()
         {
-            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.Unary, Guid.NewGuid().ToString());
+            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.Unary, methodName ?? Guid.NewGuid().ToString());
 
             Mock<IGrpcMethodInvokerFactory<TService>> mockInvoker = new Mock<IGrpcMethodInvokerFactory<TService>>();
             mockInvoker.Setup(m => m.CreateUnaryInvoker(method)).Returns(() => new UnaryServerMethod<TService, TRequest, TResponse>((service, request, context) => callHandler(request, context)));
@@ -60,12 +60,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
             return method.FullName;
         }
 
-        public string AddServerStreamingMethod<TService, TRequest, TResponse>(ServerStreamingServerMethod<TRequest, TResponse> callHandler)
+        public string AddServerStreamingMethod<TService, TRequest, TResponse>(ServerStreamingServerMethod<TRequest, TResponse> callHandler, string methodName = null)
             where TService : class
             where TRequest : class, IMessage, new()
             where TResponse : class, IMessage, new()
         {
-            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.ServerStreaming, Guid.NewGuid().ToString());
+            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.ServerStreaming, methodName ?? Guid.NewGuid().ToString());
 
             Mock<IGrpcMethodInvokerFactory<TService>> mockInvoker = new Mock<IGrpcMethodInvokerFactory<TService>>();
             mockInvoker.Setup(m => m.CreateServerStreamingInvoker(method)).Returns(() => new ServerStreamingServerMethod<TService, TRequest, TResponse>((service, request, stream, context) => callHandler(request, stream, context)));
@@ -75,12 +75,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
             return method.FullName;
         }
 
-        public string AddClientStreamingMethod<TService, TRequest, TResponse>(ClientStreamingServerMethod<TRequest, TResponse> callHandler)
+        public string AddClientStreamingMethod<TService, TRequest, TResponse>(ClientStreamingServerMethod<TRequest, TResponse> callHandler, string methodName = null)
             where TService : class
             where TRequest : class, IMessage, new()
             where TResponse : class, IMessage, new()
         {
-            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.ClientStreaming, Guid.NewGuid().ToString());
+            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.ClientStreaming, methodName ?? Guid.NewGuid().ToString());
 
             Mock<IGrpcMethodInvokerFactory<TService>> mockInvoker = new Mock<IGrpcMethodInvokerFactory<TService>>();
             mockInvoker.Setup(m => m.CreateClientStreamingInvoker(method)).Returns(() => new ClientStreamingServerMethod<TService, TRequest, TResponse>((service, stream, context) => callHandler(stream, context)));
@@ -90,12 +90,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
             return method.FullName;
         }
 
-        public string AddDuplexStreamingMethod<TService, TRequest, TResponse>(DuplexStreamingServerMethod<TRequest, TResponse> callHandler)
+        public string AddDuplexStreamingMethod<TService, TRequest, TResponse>(DuplexStreamingServerMethod<TRequest, TResponse> callHandler, string methodName = null)
             where TService : class
             where TRequest : class, IMessage, new()
             where TResponse : class, IMessage, new()
         {
-            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.DuplexStreaming, Guid.NewGuid().ToString());
+            var method = CreateMethod<TService, TRequest, TResponse>(MethodType.DuplexStreaming, methodName ?? Guid.NewGuid().ToString());
 
             Mock<IGrpcMethodInvokerFactory<TService>> mockInvoker = new Mock<IGrpcMethodInvokerFactory<TService>>();
             mockInvoker.Setup(m => m.CreateDuplexStreamingInvoker(method)).Returns(() => new DuplexStreamingServerMethod<TService, TRequest, TResponse>((service, input, output, context) => callHandler(input, output, context)));

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 {
@@ -34,6 +35,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         {
             TrailersContainer = new TrailersContainer();
 
+            LoggerFactory = new LoggerFactory();
+
             Action<IServiceCollection> configureServices = services =>
             {
                 // Register trailers container so tests can assert trailer headers
@@ -42,6 +45,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 
                 // Registers a service for tests to add new methods
                 services.AddSingleton<DynamicGrpcServiceRegistry>();
+
+                services.AddSingleton<ILoggerFactory>(LoggerFactory);
             };
 
             var builder = new WebHostBuilder()
@@ -57,7 +62,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         }
 
         public TrailersContainer TrailersContainer { get; }
-
+        public LoggerFactory LoggerFactory { get; }
         public DynamicGrpcServiceRegistry DynamicGrpc { get; }
 
         public HttpClient Client { get; }

--- a/test/FunctionalTests/Infrastructure/LogRecord.cs
+++ b/test/FunctionalTests/Infrastructure/LogRecord.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class LogRecord
+    {
+        public DateTime Timestamp { get; set; }
+
+        public LogLevel LogLevel { get; set; }
+
+        public EventId EventId { get; set; }
+
+        public object State { get; set; }
+
+        public Exception Exception { get; set; }
+
+        public Func<object, Exception, string> Formatter { get; set; }
+
+        public object Scope { get; set; }
+
+        public string LoggerName { get; set; }
+
+        public string Message => Formatter(State, Exception);
+    }
+}

--- a/test/FunctionalTests/Infrastructure/LogSinkProvider.cs
+++ b/test/FunctionalTests/Infrastructure/LogSinkProvider.cs
@@ -1,0 +1,130 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace FunctionalTestsWebsite.Infrastructure
+{
+    public class LogRecord
+    {
+        public DateTime Timestamp { get; }
+        public WriteContext Write { get; }
+
+        public LogRecord(DateTime timestamp, WriteContext write)
+        {
+            Timestamp = timestamp;
+            Write = write;
+        }
+    }
+
+    public class LogSinkProvider : ILoggerProvider, ISupportExternalScope
+    {
+        private readonly ConcurrentQueue<LogRecord> _logs = new ConcurrentQueue<LogRecord>();
+
+        private IExternalScopeProvider _scopeProvider;
+
+        public event Action<LogRecord> RecordLogged;
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new LogSinkLogger(categoryName, this, _scopeProvider);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public IList<LogRecord> GetLogs() => _logs.ToList();
+
+        public void Log<TState>(string categoryName, LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var sb = new StringBuilder();
+            _scopeProvider.ForEachScope((scope, builder) =>
+            {
+                builder.AppendLine(scope?.ToString());
+            }, sb);
+
+            var stringsds = sb.ToString();
+
+            var record = new LogRecord(
+                DateTime.Now,
+                new WriteContext
+                {
+                    LoggerName = categoryName,
+                    LogLevel = logLevel,
+                    EventId = eventId,
+                    State = state,
+                    Exception = exception,
+                    Formatter = (o, e) => formatter((TState)o, e),
+                });
+            _logs.Enqueue(record);
+
+            RecordLogged?.Invoke(record);
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            _scopeProvider = scopeProvider;
+        }
+
+        private class LogSinkLogger : ILogger
+        {
+            private readonly string _categoryName;
+            private readonly LogSinkProvider _logSinkProvider;
+            private readonly IExternalScopeProvider _scopeProvider;
+
+            public LogSinkLogger(string categoryName, LogSinkProvider logSinkProvider, IExternalScopeProvider scopeProvider)
+            {
+                _categoryName = categoryName;
+                _logSinkProvider = logSinkProvider;
+                _scopeProvider = scopeProvider;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return _scopeProvider != null ? _scopeProvider.Push(state) : NullScope.Instance;
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                _logSinkProvider.Log(_categoryName, logLevel, eventId, state, exception, formatter);
+            }
+        }
+
+        private class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new NullScope();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/Infrastructure/LogSinkProvider.cs
+++ b/test/FunctionalTests/Infrastructure/LogSinkProvider.cs
@@ -20,25 +20,10 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Testing;
 
-namespace FunctionalTestsWebsite.Infrastructure
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 {
-    public class LogRecord
-    {
-        public DateTime Timestamp { get; }
-        public WriteContext Write { get; }
-
-        public LogRecord(DateTime timestamp, WriteContext write)
-        {
-            Timestamp = timestamp;
-            Write = write;
-        }
-    }
-
     public class LogSinkProvider : ILoggerProvider, ISupportExternalScope
     {
         private readonly ConcurrentQueue<LogRecord> _logs = new ConcurrentQueue<LogRecord>();
@@ -60,25 +45,16 @@ namespace FunctionalTestsWebsite.Infrastructure
 
         public void Log<TState>(string categoryName, LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            var sb = new StringBuilder();
-            _scopeProvider.ForEachScope((scope, builder) =>
+            var record = new LogRecord
             {
-                builder.AppendLine(scope?.ToString());
-            }, sb);
-
-            var stringsds = sb.ToString();
-
-            var record = new LogRecord(
-                DateTime.Now,
-                new WriteContext
-                {
-                    LoggerName = categoryName,
-                    LogLevel = logLevel,
-                    EventId = eventId,
-                    State = state,
-                    Exception = exception,
-                    Formatter = (o, e) => formatter((TState)o, e),
-                });
+                Timestamp = DateTime.Now,
+                LoggerName = categoryName,
+                LogLevel = logLevel,
+                EventId = eventId,
+                State = state,
+                Exception = exception,
+                Formatter = (o, e) => formatter((TState)o, e),
+            };
             _logs.Enqueue(record);
 
             RecordLogged?.Invoke(record);

--- a/test/FunctionalTests/Infrastructure/VerifyNoErrorsScope.cs
+++ b/test/FunctionalTests/Infrastructure/VerifyNoErrorsScope.cs
@@ -1,0 +1,83 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FunctionalTestsWebsite.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class VerifyNoErrorsScope : IDisposable
+    {
+        private readonly IDisposable _wrappedDisposable;
+        private readonly LogSinkProvider _sink;
+
+        public Func<WriteContext, bool> ExpectedErrorsFilter { get; set; }
+        public ILoggerFactory LoggerFactory { get; }
+
+        public VerifyNoErrorsScope(ILoggerFactory loggerFactory = null, IDisposable wrappedDisposable = null, Func<WriteContext, bool> expectedErrorsFilter = null)
+        {
+            _wrappedDisposable = wrappedDisposable;
+            ExpectedErrorsFilter = expectedErrorsFilter;
+            _sink = new LogSinkProvider();
+
+            LoggerFactory = loggerFactory ?? new LoggerFactory();
+            LoggerFactory.AddProvider(_sink);
+        }
+
+        public void Dispose()
+        {
+            _wrappedDisposable?.Dispose();
+
+            var results = _sink.GetLogs().Where(w => w.Write.LogLevel >= LogLevel.Error || w.Write.EventId.Name == "RpcConnectionError").ToList();
+
+            if (ExpectedErrorsFilter != null)
+            {
+                results = results.Where(w => !ExpectedErrorsFilter(w.Write)).ToList();
+            }
+
+            if (results.Count > 0)
+            {
+                string errorMessage = $"{results.Count} error(s) logged.";
+                errorMessage += Environment.NewLine;
+                errorMessage += string.Join(Environment.NewLine, results.Select(record =>
+                {
+                    var r = record.Write;
+
+                    string lineMessage = r.LoggerName + " - " + r.EventId.ToString() + " - " + r.Formatter(r.State, r.Exception);
+                    if (r.Exception != null)
+                    {
+                        lineMessage += Environment.NewLine;
+                        lineMessage += "===================";
+                        lineMessage += Environment.NewLine;
+                        lineMessage += r.Exception;
+                        lineMessage += Environment.NewLine;
+                        lineMessage += "===================";
+                    }
+                    return lineMessage;
+                }));
+
+                throw new Exception(errorMessage);
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/MaxMessageSizeTests.cs
@@ -43,7 +43,8 @@ namespace Grpc.AspNetCore.FunctionalTests
             {
                 return writeContext.LoggerName == typeof(GreeterService).FullName &&
                        writeContext.EventId.Name == "RpcConnectionError" &&
-                       writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised.";
+                       writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised." &&
+                       GetRpcExceptionDetail(writeContext.Exception) == "Received message exceeds the maximum configured message size.";
             });
 
             var requestMessage = new HelloRequest
@@ -72,7 +73,8 @@ namespace Grpc.AspNetCore.FunctionalTests
             {
                 return writeContext.LoggerName == typeof(GreeterService).FullName &&
                        writeContext.EventId.Name == "RpcConnectionError" &&
-                       writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised.";
+                       writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised." &&
+                       GetRpcExceptionDetail(writeContext.Exception) == "Sending message exceeds the maximum configured message size.";
             });
 
             var requestMessage = new HelloRequest

--- a/test/FunctionalTests/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/MaxMessageSizeTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FunctionalTestsWebsite;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
@@ -38,6 +39,13 @@ namespace Grpc.AspNetCore.FunctionalTests
         public async Task ReceivedMessageExceedsSize_ThrowError()
         {
             // Arrange
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                return writeContext.LoggerName == typeof(GreeterService).FullName &&
+                       writeContext.EventId.Name == "RpcConnectionError" &&
+                       writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised.";
+            });
+
             var requestMessage = new HelloRequest
             {
                 Name = "World" + new string('!', 64 * 1024)
@@ -60,6 +68,13 @@ namespace Grpc.AspNetCore.FunctionalTests
         public async Task SentMessageExceedsSize_ThrowError()
         {
             // Arrange
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                return writeContext.LoggerName == typeof(GreeterService).FullName &&
+                       writeContext.EventId.Name == "RpcConnectionError" &&
+                       writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised.";
+            });
+
             var requestMessage = new HelloRequest
             {
                 Name = "World"

--- a/test/FunctionalTests/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/ServerStreamingMethodTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FunctionalTestsWebsite;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;

--- a/testassets/FunctionalTestsWebsite/Greeter.cs
+++ b/testassets/FunctionalTestsWebsite/Greeter.cs
@@ -24,119 +24,126 @@ using Grpc.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
-public class GreeterService : Greeter.GreeterBase
+namespace FunctionalTestsWebsite
 {
-    private readonly ILogger _logger;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-
-    public GreeterService(ILoggerFactory loggerFactory, IHttpContextAccessor httpContextAccessor)
+    public class GreeterService : Greeter.GreeterBase
     {
-        _logger = loggerFactory.CreateLogger<GreeterService>();
-        _httpContextAccessor = httpContextAccessor;
-    }
+        private readonly ILogger _logger;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-    //Server side handler of the SayHello RPC
-    public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
-    {
-        _logger.LogInformation($"Sending hello to {request.Name}");
-        return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
-    }
-
-    public override Task<HelloReply> SayHelloWithHttpContextAccessor(HelloRequest request, ServerCallContext context)
-    {
-        var httpContext = _httpContextAccessor.HttpContext;
-        context.ResponseTrailers.Add("Test-HttpContext-PathAndQueryString", httpContext.Request.Path + httpContext.Request.QueryString);
-
-        return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
-    }
-
-    public override Task<HelloReply> SayHelloWithHttpContextExtensionMethod(HelloRequest request, ServerCallContext context)
-    {
-        var httpContext = context.GetHttpContext();
-        context.ResponseTrailers.Add("Test-HttpContext-PathAndQueryString", httpContext.Request.Path + httpContext.Request.QueryString);
-
-        return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
-    }
-
-    public override Task<HelloReply> SayHelloReturnNull(HelloRequest request, ServerCallContext context)
-    {
-        return Task.FromResult<HelloReply>(null);
-    }
-
-    public override Task<HelloReply> SayHelloThrowExceptionWithTrailers(HelloRequest request, ServerCallContext context)
-    {
-        var trailers = new Metadata();
-        trailers.Add(new Metadata.Entry("test-trailer", "A value!"));
-
-        return Task.FromException<HelloReply>(new RpcException(new Status(StatusCode.Unknown, "User error"), trailers));
-    }
-
-    public override Task<HelloReply> SayHelloSendLargeReply(HelloRequest request, ServerCallContext context)
-    {
-        _logger.LogInformation($"Sending hello to {request.Name}");
-        return Task.FromResult(new HelloReply { Message = "Hello " + request.Name + new string('!', 1000000) });
-    }
-	
-    public override async Task SayHellos(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
-    {
-        // Explicitly send the response headers before any streamed content
-        Metadata responseHeaders = new Metadata();
-        responseHeaders.Add("test-response-header", "value");
-        await context.WriteResponseHeadersAsync(responseHeaders);
-
-        await SayHellosCore(request, responseStream);
-    }
-
-    public override async Task SayHellosSendHeadersFirst(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
-    {
-        await context.WriteResponseHeadersAsync(null);
-
-        await SayHellosCore(request, responseStream);
-    }
-
-    public override async Task SayHellosDeadline(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
-    {
-        var i = 0;
-        while (DateTime.UtcNow < context.Deadline)
+        public GreeterService(ILoggerFactory loggerFactory, IHttpContextAccessor httpContextAccessor)
         {
-            var message = $"How are you {request.Name}? {i}";
-            await responseStream.WriteAsync(new HelloReply { Message = message });
-
-            i++;
+            _logger = loggerFactory.CreateLogger<GreeterService>();
+            _httpContextAccessor = httpContextAccessor;
         }
 
-        // Ensure deadline timer has run
-        var tcs = new TaskCompletionSource<object>();
-        context.CancellationToken.Register(() => tcs.SetResult(null));
-        await tcs.Task;
-    }
-
-    public override async Task SayHellosDeadlineCancellationToken(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
-    {
-        var i = 0;
-        while (!context.CancellationToken.IsCancellationRequested)
+        //Server side handler of the SayHello RPC
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
         {
-            var message = $"How are you {request.Name}? {i}";
-            await responseStream.WriteAsync(new HelloReply { Message = message });
-
-            i++;
+            _logger.LogInformation($"Sending hello to {request.Name}");
+            return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
         }
-    }
 
-    public static async Task SayHellosCore(HelloRequest request, IServerStreamWriter<HelloReply> responseStream)
-    {
-        for (var i = 0; i < 3; i++)
+        public override Task<HelloReply> SayHelloWithHttpContextAccessor(HelloRequest request, ServerCallContext context)
         {
+            var httpContext = _httpContextAccessor.HttpContext;
+            context.ResponseTrailers.Add("Test-HttpContext-PathAndQueryString", httpContext.Request.Path + httpContext.Request.QueryString);
+
+            return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+        }
+
+        public override Task<HelloReply> SayHelloWithHttpContextExtensionMethod(HelloRequest request, ServerCallContext context)
+        {
+            var httpContext = context.GetHttpContext();
+            context.ResponseTrailers.Add("Test-HttpContext-PathAndQueryString", httpContext.Request.Path + httpContext.Request.QueryString);
+
+            return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+        }
+
+        public override Task<HelloReply> SayHelloReturnNull(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult<HelloReply>(null);
+        }
+
+        public override Task<HelloReply> SayHelloThrowExceptionWithTrailers(HelloRequest request, ServerCallContext context)
+        {
+            var trailers = new Metadata();
+            trailers.Add(new Metadata.Entry("test-trailer", "A value!"));
+
+            return Task.FromException<HelloReply>(new RpcException(new Status(StatusCode.Unknown, "User error"), trailers));
+        }
+
+        public override Task<HelloReply> SayHelloSendLargeReply(HelloRequest request, ServerCallContext context)
+        {
+            _logger.LogInformation($"Sending hello to {request.Name}");
+            return Task.FromResult(new HelloReply { Message = "Hello " + request.Name + new string('!', 1000000) });
+        }
+
+        public override async Task SayHellos(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            // Explicitly send the response headers before any streamed content
+            Metadata responseHeaders = new Metadata();
+            responseHeaders.Add("test-response-header", "value");
+            await context.WriteResponseHeadersAsync(responseHeaders);
+
+            await SayHellosCore(request, responseStream);
+        }
+
+        public override async Task SayHellosSendHeadersFirst(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            await context.WriteResponseHeadersAsync(null);
+
+            await SayHellosCore(request, responseStream);
+        }
+
+        public override async Task SayHellosDeadline(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            var i = 0;
+            while (DateTime.UtcNow < context.Deadline)
+            {
+                var message = $"How are you {request.Name}? {i}";
+                await responseStream.WriteAsync(new HelloReply { Message = message });
+
+                i++;
+
+                await Task.Delay(110);
+            }
+
+            // Ensure deadline timer has run
+            var tcs = new TaskCompletionSource<object>();
+            context.CancellationToken.Register(() => tcs.SetResult(null));
+            await tcs.Task;
+        }
+
+        public override async Task SayHellosDeadlineCancellationToken(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            var i = 0;
+            while (!context.CancellationToken.IsCancellationRequested)
+            {
+                var message = $"How are you {request.Name}? {i}";
+                await responseStream.WriteAsync(new HelloReply { Message = message });
+
+                i++;
+
+                await Task.Delay(110);
+            }
+        }
+
+        public static async Task SayHellosCore(HelloRequest request, IServerStreamWriter<HelloReply> responseStream)
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                // Gotta look busy
+                await Task.Delay(100);
+
+                var message = $"How are you {request.Name}? {i}";
+                await responseStream.WriteAsync(new HelloReply { Message = message });
+            }
+
             // Gotta look busy
             await Task.Delay(100);
 
-            var message = $"How are you {request.Name}? {i}";
-            await responseStream.WriteAsync(new HelloReply { Message = message });
+            await responseStream.WriteAsync(new HelloReply { Message = $"Goodbye {request.Name}!" });
         }
-
-        // Gotta look busy
-        await Task.Delay(100);
-
-        await responseStream.WriteAsync(new HelloReply { Message = $"Goodbye {request.Name}!" });
     }
 }


### PR DESCRIPTION
Update functional tests to inject a logger factory into the test website and inspects log messages at the end of each test. Verifies no unexpected exceptions are thrown.

Also explicitly throw an error when attempting to write a message after the deadline has passed.