### PR TITLE
Add BenchmarkWorker compatible with gRPC benchmarking infrastructure 

### DIFF
--- a/Grpc.AspNetCore.sln
+++ b/Grpc.AspNetCore.sln
@@ -85,6 +85,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.Microbenchm
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InteropTestsWebsite", "testassets\InteropTestsWebsite\InteropTestsWebsite.csproj", "{A551D7B1-D75A-43F0-A8E3-BAEA5EDF616A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testassets", "testassets", "{D4F0A67C-935C-429A-8785-22AE92FD37F6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkWorkerWebsite", "testassets\BenchmarkWorkerWebsite\BenchmarkWorkerWebsite.csproj", "{C3D6C3BD-4E56-4B0F-88FD-4F2D68F0CD25}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +147,10 @@ Global
 		{A551D7B1-D75A-43F0-A8E3-BAEA5EDF616A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A551D7B1-D75A-43F0-A8E3-BAEA5EDF616A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A551D7B1-D75A-43F0-A8E3-BAEA5EDF616A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3D6C3BD-4E56-4B0F-88FD-4F2D68F0CD25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3D6C3BD-4E56-4B0F-88FD-4F2D68F0CD25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3D6C3BD-4E56-4B0F-88FD-4F2D68F0CD25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3D6C3BD-4E56-4B0F-88FD-4F2D68F0CD25}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -170,6 +178,7 @@ Global
 		{310E5783-455A-4D09-A7AE-39DC2AB09504} = {1B8B6117-CE39-4580-BAFA-D8026102767A}
 		{98500D54-FC3F-4A42-B74D-51930C19B175} = {4163E1B3-4D75-46B4-9107-9A158FD708FC}
 		{A551D7B1-D75A-43F0-A8E3-BAEA5EDF616A} = {59C7B1F0-EE4D-4098-8596-0ADDBC305234}
+		{C3D6C3BD-4E56-4B0F-88FD-4F2D68F0CD25} = {D4F0A67C-935C-429A-8785-22AE92FD37F6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD5C2B19-49B4-480A-990C-36D98A719B07}

--- a/testassets/BenchmarkWorkerWebsite/AsyncStreamExtensions.cs
+++ b/testassets/BenchmarkWorkerWebsite/AsyncStreamExtensions.cs
@@ -1,0 +1,41 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace BenchmarkWorkerWebsite
+{
+    // Implementation copied from https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.Core/Utils/AsyncStreamExtensions.cs
+    internal static class AsyncStreamExtensions
+    {
+        /// <summary>
+        /// Reads the entire stream and executes an async action for each element.
+        /// </summary>
+        public static async Task ForEachAsync<T>(this IAsyncStreamReader<T> streamReader, Func<T, Task> asyncAction)
+            where T : class
+        {
+            while (await streamReader.MoveNext().ConfigureAwait(false))
+            {
+                await asyncAction(streamReader.Current).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkServiceImpl.cs
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkServiceImpl.cs
@@ -1,0 +1,57 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Core.Utils;
+using BenchmarkWorkerWebsite;
+
+namespace Grpc.Testing
+{
+    // Implementation copied from https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceImpl.cs
+    public class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
+    {
+        public BenchmarkServiceImpl()
+        {
+        }
+
+        public override Task<SimpleResponse> UnaryCall(SimpleRequest request, ServerCallContext context)
+        {
+            var response = new SimpleResponse { Payload = CreateZerosPayload(request.ResponseSize) };
+            return Task.FromResult(response);
+        }
+
+        public override async Task StreamingCall(IAsyncStreamReader<SimpleRequest> requestStream, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
+        {
+            await requestStream.ForEachAsync(async request =>
+            {
+                var response = new SimpleResponse { Payload = CreateZerosPayload(request.ResponseSize) };
+                await responseStream.WriteAsync(response);
+            });
+        }
+
+        private static Payload CreateZerosPayload(int size)
+        {
+            return new Payload { Body = ByteString.CopyFrom(new byte[size]) };
+        }
+    }
+}

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
+    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
+    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
+    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
+    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
+    <Protobuf Include="grpc\core\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
+    <Protobuf Include="grpc\testing\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
+
+    <None Remove="@(Protobuf)" />
+    <Content Include="@(Protobuf)" LinkBase="" />
+
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
+
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/testassets/BenchmarkWorkerWebsite/IServerRunner.cs
+++ b/testassets/BenchmarkWorkerWebsite/IServerRunner.cs
@@ -1,0 +1,45 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading.Tasks;
+using Grpc.Testing;
+
+namespace BenchmarkWorkerWebsite
+{
+    // copied from https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/IServerRunner.cs
+    public interface IServerRunner
+    {
+        /// <summary>
+        /// Port on which the server is listening.
+        /// </summary>
+        int BoundPort { get; }
+        
+        /// <summary>
+        /// Gets server stats.
+        /// </summary>
+        /// <returns>The stats.</returns>
+        ServerStats GetStats(bool reset);
+
+        /// <summary>
+        /// Asynchronously stops the server.
+        /// </summary>
+        /// <returns>Task that finishes when server has shutdown.</returns>
+        Task StopAsync();
+    }
+        
+}

--- a/testassets/BenchmarkWorkerWebsite/Program.cs
+++ b/testassets/BenchmarkWorkerWebsite/Program.cs
@@ -1,0 +1,57 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+
+namespace BenchmarkWorkerWebsite
+{
+    public class Program
+    {
+        static readonly CancellationTokenSource QuitWorkerCts = new CancellationTokenSource();
+        public static async Task Main(string[] args)
+        {
+            await CreateWebHostBuilder(args).Build().RunAsync(QuitWorkerCts.Token);
+        }
+
+        public static void QuitWorker()
+        {
+            QuitWorkerCts.Cancel();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .ConfigureKestrel((context, options) =>
+                {
+                    // Port on which to listen to commands from QpsDriver
+                    int driverPort = context.Configuration.GetValue<int>("driver_port", 50053);
+
+                    options.Limits.MinRequestBodyDataRate = null;
+                    options.ListenAnyIP(driverPort, listenOptions =>
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http2;
+                    });
+                })
+                .UseStartup<Startup>();
+    }
+}

--- a/testassets/BenchmarkWorkerWebsite/README.md
+++ b/testassets/BenchmarkWorkerWebsite/README.md
@@ -1,0 +1,4 @@
+Implementation of benchmark worker that is compatible with the gRPC benchmarking stack:
+https://grpc.io/docs/guides/benchmarking.html
+
+

--- a/testassets/BenchmarkWorkerWebsite/ServerRunners.cs
+++ b/testassets/BenchmarkWorkerWebsite/ServerRunners.cs
@@ -98,6 +98,9 @@ namespace BenchmarkWorkerWebsite
                throw new ArgumentException("Unsupported ServerType");
             }
 
+            // Don't log requests handled by the benchmarking service
+            webHostBuilder.ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));
+
             var webHost = webHostBuilder.Build();
             webHost.Start();
             return new ServerRunnerImpl(webHost, logger, port);

--- a/testassets/BenchmarkWorkerWebsite/ServerRunners.cs
+++ b/testassets/BenchmarkWorkerWebsite/ServerRunners.cs
@@ -1,0 +1,194 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+using Grpc.Core;
+using Grpc.Core.Utils;
+using Grpc.Testing;
+
+namespace BenchmarkWorkerWebsite
+{
+    /// <summary>
+    /// Helper methods to start server runners for performance testing.
+    /// </summary>
+    public class ServerRunners
+    {
+        /// <summary>
+        /// Creates a started server runner.
+        /// </summary>
+        public static IServerRunner CreateStarted(ServerConfig config, ILogger logger)
+        {
+            logger.LogInformation("ServerConfig: {0}", config);
+
+            var webHostBuilder = WebHost.CreateDefaultBuilder();
+
+            if (config.AsyncServerThreads != 0)
+            {
+                logger.LogWarning("ServerConfig.AsyncServerThreads is not supported for C#. Ignoring the value");
+            }
+            if (config.CoreLimit != 0)
+            {
+                logger.LogWarning("ServerConfig.CoreLimit is not supported for C#. Ignoring the value");
+            }
+            if (config.CoreList.Count > 0)
+            {
+                logger.LogWarning("ServerConfig.CoreList is not supported for C#. Ignoring the value");
+            }
+            if (config.ChannelArgs.Count > 0)
+            {
+                logger.LogWarning("ServerConfig.ChannelArgs is not supported for C#. Ignoring the value");
+            }
+
+            int port = config.Port;
+            if (port == 0)
+            {
+                // TODO(jtattermusch): add support for port autoselection
+                port = 50055;
+                logger.LogWarning("Grpc.AspNetCore server doesn't support autoselecting of listening port. Setting port explictly to " + port);
+            }
+
+            webHostBuilder.ConfigureKestrel((context, options) =>
+            {
+                options.Limits.MinRequestBodyDataRate = null;
+                options.ListenAnyIP(port, listenOptions =>
+                {
+                    // TODO(jtattermusch): use TLS if config.SecurityParams != null
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                });
+            });
+
+            if (config.ServerType == ServerType.AsyncServer)
+            {
+               GrpcPreconditions.CheckArgument(config.PayloadConfig == null,
+                   "ServerConfig.PayloadConfig shouldn't be set for BenchmarkService based server.");
+               webHostBuilder.UseStartup<BenchmarkServiceStartup>();
+            }
+            else if (config.ServerType == ServerType.AsyncGenericServer)
+            {
+               var genericService = new GenericServiceImpl(config.PayloadConfig.BytebufParams.RespSize);
+               // TODO(jtattermusch): use startup with given generic service
+               throw new ArgumentException("Generice service is not yet implemented.");
+            }
+            else
+            {
+               throw new ArgumentException("Unsupported ServerType");
+            }
+
+            var webHost = webHostBuilder.Build();
+            webHost.Start();
+            return new ServerRunnerImpl(webHost, logger, port);
+        }
+
+        private class BenchmarkServiceStartup
+        {
+            // This method gets called by the runtime. Use this method to add services to the container.
+            // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddGrpc();
+            }
+
+            // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseRouting(builder =>
+                {
+                    builder.MapGrpcService<BenchmarkServiceImpl>();
+                });
+            }
+        }
+
+        private class GenericServiceImpl
+        {
+            readonly byte[] response;
+
+            public GenericServiceImpl(int responseSize)
+            {
+                this.response = new byte[responseSize];
+            }
+
+            /// <summary>
+            /// Generic streaming call handler.
+            /// </summary>
+            public async Task StreamingCall(IAsyncStreamReader<byte[]> requestStream, IServerStreamWriter<byte[]> responseStream, ServerCallContext context)
+            {
+                await requestStream.ForEachAsync(async request =>
+                {
+                    await responseStream.WriteAsync(response);
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Server runner.
+    /// </summary>
+    public class ServerRunnerImpl : IServerRunner
+    {
+        readonly IWebHost webHost;
+        readonly ILogger logger;
+        readonly int boundPort;
+        readonly TimeStats timeStats = new TimeStats();
+
+        public ServerRunnerImpl(IWebHost webHost, ILogger logger, int boundPort)
+        {
+            this.webHost = webHost;
+            this.logger = logger;
+            this.boundPort = boundPort;
+        }
+
+        public int BoundPort => boundPort;
+
+        /// <summary>
+        /// Gets server stats.
+        /// </summary>
+        /// <returns>The stats.</returns>
+        public ServerStats GetStats(bool reset)
+        {
+            var timeSnapshot = timeStats.GetSnapshot(reset);
+
+            logger.LogInformation("[ServerRunner.GetStats] GC collection counts: gen0 {0}, gen1 {1}, gen2 {2}, (seconds since last reset {3})",
+                GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2), timeSnapshot.WallClockTime.TotalSeconds);
+
+            return new ServerStats
+            {
+                TimeElapsed = timeSnapshot.WallClockTime.TotalSeconds,
+                TimeUser = timeSnapshot.UserProcessorTime.TotalSeconds,
+                TimeSystem = timeSnapshot.PrivilegedProcessorTime.TotalSeconds
+            };
+        }
+
+        /// <summary>
+        /// Asynchronously stops the server.
+        /// </summary>
+        /// <returns>Task that finishes when server has shutdown.</returns>
+        public Task StopAsync()
+        {
+            return webHost.StopAsync();
+        }
+    }        
+}

--- a/testassets/BenchmarkWorkerWebsite/Startup.cs
+++ b/testassets/BenchmarkWorkerWebsite/Startup.cs
@@ -1,0 +1,43 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Grpc.Testing;
+
+namespace BenchmarkWorkerWebsite
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddGrpc();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting(builder =>
+            {
+                builder.MapGrpcService<WorkerServiceImpl>();
+            });
+        }
+    }
+}

--- a/testassets/BenchmarkWorkerWebsite/TimeStats.cs
+++ b/testassets/BenchmarkWorkerWebsite/TimeStats.cs
@@ -1,0 +1,77 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Diagnostics;
+
+namespace BenchmarkWorkerWebsite
+{
+    // Copied from https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/TimeStats.cs
+    public class TimeStats
+    {
+        readonly object myLock = new object();
+        DateTime lastWallClock;
+        TimeSpan lastUserTime;
+        TimeSpan lastPrivilegedTime;
+
+        public TimeStats()
+        {
+            lastWallClock = DateTime.UtcNow;
+            lastUserTime = Process.GetCurrentProcess().UserProcessorTime;
+            lastPrivilegedTime = Process.GetCurrentProcess().PrivilegedProcessorTime;
+        }
+
+        public Snapshot GetSnapshot(bool reset)
+        {
+            lock (myLock)
+            {
+                var wallClock = DateTime.UtcNow;
+                var userTime = Process.GetCurrentProcess().UserProcessorTime;
+                var privilegedTime = Process.GetCurrentProcess().PrivilegedProcessorTime;
+                var snapshot = new Snapshot(wallClock - lastWallClock, userTime - lastUserTime, privilegedTime - lastPrivilegedTime);
+
+                if (reset)
+                {
+                    lastWallClock = wallClock;
+                    lastUserTime = userTime;
+                    lastPrivilegedTime = privilegedTime;
+                }
+                return snapshot;
+            }
+        }
+
+        public class Snapshot
+        {
+            public TimeSpan WallClockTime { get; }
+            public TimeSpan UserProcessorTime { get; }
+            public TimeSpan PrivilegedProcessorTime { get; }
+
+            public Snapshot(TimeSpan wallClockTime, TimeSpan userProcessorTime, TimeSpan privilegedProcessorTime)
+            {
+                this.WallClockTime = wallClockTime;
+                this.UserProcessorTime = userProcessorTime;
+                this.PrivilegedProcessorTime = privilegedProcessorTime;
+            }
+
+            public override string ToString()
+            {
+                return string.Format("[TimeStats.Snapshot: wallClock {0}, userProcessor {1}, privilegedProcessor {2}]", WallClockTime, UserProcessorTime, PrivilegedProcessorTime);
+            }
+        }
+    }
+}

--- a/testassets/BenchmarkWorkerWebsite/WorkerServiceImpl.cs
+++ b/testassets/BenchmarkWorkerWebsite/WorkerServiceImpl.cs
@@ -1,0 +1,81 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Core.Utils;
+using BenchmarkWorkerWebsite;
+
+namespace Grpc.Testing
+{
+    // modified version of https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/WorkerServiceImpl.cs
+    public class WorkerServiceImpl : WorkerService.WorkerServiceBase
+    {
+        readonly ILogger logger;
+
+        public WorkerServiceImpl(ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger<WorkerServiceImpl>();
+        }
+        
+        public override async Task RunServer(IAsyncStreamReader<ServerArgs> requestStream, IServerStreamWriter<ServerStatus> responseStream, ServerCallContext context)
+        {
+            GrpcPreconditions.CheckState(await requestStream.MoveNext());
+            var serverConfig = requestStream.Current.Setup;
+            var runner = ServerRunners.CreateStarted(serverConfig, logger);
+
+            await responseStream.WriteAsync(new ServerStatus
+            {
+                Stats = runner.GetStats(false),
+                Port = runner.BoundPort,
+                Cores = Environment.ProcessorCount,
+            });
+                
+            while (await requestStream.MoveNext())
+            {
+                var reset = requestStream.Current.Mark.Reset;
+                await responseStream.WriteAsync(new ServerStatus
+                {
+                    Stats = runner.GetStats(reset)
+                });
+            }
+            await runner.StopAsync();
+        }
+
+        public override Task RunClient(IAsyncStreamReader<ClientArgs> requestStream, IServerStreamWriter<ClientStatus> responseStream, ServerCallContext context)
+        {
+            throw new NotImplementedException("Clients are not yet supported.");
+        }
+
+        public override Task<CoreResponse> CoreCount(CoreRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new CoreResponse { Cores = Environment.ProcessorCount });
+        }
+
+        public override Task<Void> QuitWorker(Void request, ServerCallContext context)
+        {
+            Program.QuitWorker();
+            return Task.FromResult(new Void());
+        }
+    }
+}

--- a/testassets/BenchmarkWorkerWebsite/grpc/core/grpc_core_stats.proto
+++ b/testassets/BenchmarkWorkerWebsite/grpc/core/grpc_core_stats.proto
@@ -1,0 +1,38 @@
+// Copyright 2017 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.core;
+
+message Bucket {
+  double start = 1;
+  uint64 count = 2;
+}
+
+message Histogram {
+  repeated Bucket buckets = 1;
+}
+
+message Metric {
+  string name = 1;
+  oneof value {
+    uint64 count = 10;
+    Histogram histogram = 11;
+  }
+}
+
+message Stats {
+  repeated Metric metrics = 1;
+}

--- a/testassets/BenchmarkWorkerWebsite/grpc/testing/benchmark_service.proto
+++ b/testassets/BenchmarkWorkerWebsite/grpc/testing/benchmark_service.proto
@@ -1,0 +1,44 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+syntax = "proto3";
+
+import "grpc/testing/messages.proto";
+
+package grpc.testing;
+
+service BenchmarkService {
+  // One request followed by one response.
+  // The server returns the client payload as-is.
+  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // Repeated sequence of one request followed by one response.
+  // Should be called streaming ping-pong
+  // The server returns the client payload as-is on each response
+  rpc StreamingCall(stream SimpleRequest) returns (stream SimpleResponse);
+
+  // Single-sided unbounded streaming from client to server
+  // The server returns the client payload as-is once the client does WritesDone
+  rpc StreamingFromClient(stream SimpleRequest) returns (SimpleResponse);
+
+  // Single-sided unbounded streaming from server to client
+  // The server repeatedly returns the client payload as-is
+  rpc StreamingFromServer(SimpleRequest) returns (stream SimpleResponse);
+
+  // Two-sided unbounded streaming between server to client
+  // Both sides send the content of their own choice to the other
+  rpc StreamingBothWays(stream SimpleRequest) returns (stream SimpleResponse);
+}

--- a/testassets/BenchmarkWorkerWebsite/grpc/testing/control.proto
+++ b/testassets/BenchmarkWorkerWebsite/grpc/testing/control.proto
@@ -1,0 +1,278 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "grpc/testing/payloads.proto";
+import "grpc/testing/stats.proto";
+
+package grpc.testing;
+
+enum ClientType {
+  // Many languages support a basic distinction between using
+  // sync or async client, and this allows the specification
+  SYNC_CLIENT = 0;
+  ASYNC_CLIENT = 1;
+  OTHER_CLIENT = 2; // used for some language-specific variants
+  CALLBACK_CLIENT = 3;
+}
+
+enum ServerType {
+  SYNC_SERVER = 0;
+  ASYNC_SERVER = 1;
+  ASYNC_GENERIC_SERVER = 2;
+  OTHER_SERVER = 3; // used for some language-specific variants
+  CALLBACK_SERVER = 4;
+}
+
+enum RpcType {
+  UNARY = 0;
+  STREAMING = 1;
+  STREAMING_FROM_CLIENT = 2;
+  STREAMING_FROM_SERVER = 3;
+  STREAMING_BOTH_WAYS = 4;
+}
+
+// Parameters of poisson process distribution, which is a good representation
+// of activity coming in from independent identical stationary sources.
+message PoissonParams {
+  // The rate of arrivals (a.k.a. lambda parameter of the exp distribution).
+  double offered_load = 1;
+}
+
+// Once an RPC finishes, immediately start a new one.
+// No configuration parameters needed.
+message ClosedLoopParams {}
+
+message LoadParams {
+  oneof load {
+    ClosedLoopParams closed_loop = 1;
+    PoissonParams poisson = 2;
+  };
+}
+
+// presence of SecurityParams implies use of TLS
+message SecurityParams {
+  bool use_test_ca = 1;
+  string server_host_override = 2;
+  string cred_type = 3;
+}
+
+message ChannelArg {
+  string name = 1;
+  oneof value {
+    string str_value = 2;
+    int32 int_value = 3;
+  }
+}
+
+message ClientConfig {
+  // List of targets to connect to. At least one target needs to be specified.
+  repeated string server_targets = 1;
+  ClientType client_type = 2;
+  SecurityParams security_params = 3;
+  // How many concurrent RPCs to start for each channel.
+  // For synchronous client, use a separate thread for each outstanding RPC.
+  int32 outstanding_rpcs_per_channel = 4;
+  // Number of independent client channels to create.
+  // i-th channel will connect to server_target[i % server_targets.size()]
+  int32 client_channels = 5;
+  // Only for async client. Number of threads to use to start/manage RPCs.
+  int32 async_client_threads = 7;
+  RpcType rpc_type = 8;
+  // The requested load for the entire client (aggregated over all the threads).
+  LoadParams load_params = 10;
+  PayloadConfig payload_config = 11;
+  HistogramParams histogram_params = 12;
+
+  // Specify the cores we should run the client on, if desired
+  repeated int32 core_list = 13;
+  int32 core_limit = 14;
+
+  // If we use an OTHER_CLIENT client_type, this string gives more detail
+  string other_client_api = 15;
+
+  repeated ChannelArg channel_args = 16;
+
+  // Number of threads that share each completion queue
+  int32 threads_per_cq = 17;
+
+  // Number of messages on a stream before it gets finished/restarted
+  int32 messages_per_stream = 18;
+
+  // Use coalescing API when possible.
+  bool use_coalesce_api = 19;
+
+  // If 0, disabled. Else, specifies the period between gathering latency
+  // medians in milliseconds.
+  int32 median_latency_collection_interval_millis = 20;
+}
+
+message ClientStatus { ClientStats stats = 1; }
+
+// Request current stats
+message Mark {
+  // if true, the stats will be reset after taking their snapshot.
+  bool reset = 1;
+}
+
+message ClientArgs {
+  oneof argtype {
+    ClientConfig setup = 1;
+    Mark mark = 2;
+  }
+}
+
+message ServerConfig {
+  ServerType server_type = 1;
+  SecurityParams security_params = 2;
+  // Port on which to listen. Zero means pick unused port.
+  int32 port = 4;
+  // Only for async server. Number of threads used to serve the requests.
+  int32 async_server_threads = 7;
+  // Specify the number of cores to limit server to, if desired
+  int32 core_limit = 8;
+  // payload config, used in generic server.
+  // Note this must NOT be used in proto (non-generic) servers. For proto servers,
+  // 'response sizes' must be configured from the 'response_size' field of the
+  // 'SimpleRequest' objects in RPC requests.
+  PayloadConfig payload_config = 9;
+
+  // Specify the cores we should run the server on, if desired
+  repeated int32 core_list = 10;
+
+  // If we use an OTHER_SERVER client_type, this string gives more detail
+  string other_server_api = 11;
+
+  // Number of threads that share each completion queue
+  int32 threads_per_cq = 12;
+
+  // c++-only options (for now) --------------------------------
+
+  // Buffer pool size (no buffer pool specified if unset)
+  int32 resource_quota_size = 1001;
+  repeated ChannelArg channel_args = 1002;
+}
+
+message ServerArgs {
+  oneof argtype {
+    ServerConfig setup = 1;
+    Mark mark = 2;
+  }
+}
+
+message ServerStatus {
+  ServerStats stats = 1;
+  // the port bound by the server
+  int32 port = 2;
+  // Number of cores available to the server
+  int32 cores = 3;
+}
+
+message CoreRequest {
+}
+
+message CoreResponse {
+  // Number of cores available on the server
+  int32 cores = 1;
+}
+
+message Void {
+}
+
+// A single performance scenario: input to qps_json_driver
+message Scenario {
+  // Human readable name for this scenario
+  string name = 1;
+  // Client configuration
+  ClientConfig client_config = 2;
+  // Number of clients to start for the test
+  int32 num_clients = 3;
+  // Server configuration
+  ServerConfig server_config = 4;
+  // Number of servers to start for the test
+  int32 num_servers = 5;
+  // Warmup period, in seconds
+  int32 warmup_seconds = 6;
+  // Benchmark time, in seconds
+  int32 benchmark_seconds = 7;
+  // Number of workers to spawn locally (usually zero)
+  int32 spawn_local_worker_count = 8;
+}
+
+// A set of scenarios to be run with qps_json_driver
+message Scenarios {
+  repeated Scenario scenarios = 1;
+}
+
+// Basic summary that can be computed from ClientStats and ServerStats
+// once the scenario has finished.
+message ScenarioResultSummary
+{
+  // Total number of operations per second over all clients.
+  double qps = 1;
+  // QPS per one server core.
+  double qps_per_server_core = 2;
+  // server load based on system_time (0.85 => 85%)
+  double server_system_time = 3;
+  // server load based on user_time (0.85 => 85%)
+  double server_user_time = 4;
+  // client load based on system_time (0.85 => 85%)
+  double client_system_time = 5;
+  // client load based on user_time (0.85 => 85%)
+  double client_user_time = 6;
+
+  // X% latency percentiles (in nanoseconds)
+  double latency_50 = 7;
+  double latency_90 = 8;
+  double latency_95 = 9;
+  double latency_99 = 10;
+  double latency_999 = 11;
+
+  // server cpu usage percentage
+  double server_cpu_usage = 12;
+
+  // Number of requests that succeeded/failed
+  double successful_requests_per_second = 13;
+  double failed_requests_per_second = 14;
+
+  // Number of polls called inside completion queue per request
+  double client_polls_per_request = 15;
+  double server_polls_per_request = 16;
+
+  // Queries per CPU-sec over all servers or clients
+  double server_queries_per_cpu_sec = 17;
+  double client_queries_per_cpu_sec = 18;
+}
+
+// Results of a single benchmark scenario.
+message ScenarioResult {
+  // Inputs used to run the scenario.
+  Scenario scenario = 1;
+  // Histograms from all clients merged into one histogram.
+  HistogramData latencies = 2;
+  // Client stats for each client
+  repeated ClientStats client_stats = 3;
+  // Server stats for each server
+  repeated ServerStats server_stats = 4;
+  // Number of cores available to each server
+  repeated int32 server_cores = 5;
+  // An after-the-fact computed summary
+  ScenarioResultSummary summary = 6;
+  // Information on success or failure of each worker
+  repeated bool client_success = 7;
+  repeated bool server_success = 8;
+  // Number of failed requests (one row per status code seen)
+  repeated RequestResultCount request_results = 9;
+}

--- a/testassets/BenchmarkWorkerWebsite/grpc/testing/messages.proto
+++ b/testassets/BenchmarkWorkerWebsite/grpc/testing/messages.proto
@@ -1,0 +1,165 @@
+
+// Copyright 2015-2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Message definitions to be used by integration test service definitions.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+// TODO(dgq): Go back to using well-known types once
+// https://github.com/grpc/grpc/issues/6980 has been fixed.
+// import "google/protobuf/wrappers.proto";
+message BoolValue {
+  // The bool value.
+  bool value = 1;
+}
+
+// The type of payload that should be returned.
+enum PayloadType {
+  // Compressable text format.
+  COMPRESSABLE = 0;
+}
+
+// A block of data, to simply increase gRPC message size.
+message Payload {
+  // The type of data in body.
+  PayloadType type = 1;
+  // Primary contents of payload.
+  bytes body = 2;
+}
+
+// A protobuf representation for grpc status. This is used by test
+// clients to specify a status that the server should attempt to return.
+message EchoStatus {
+  int32 code = 1;
+  string message = 2;
+}
+
+// Unary request.
+message SimpleRequest {
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, server randomly chooses one from other formats.
+  PayloadType response_type = 1;
+
+  // Desired payload size in the response from the server.
+  int32 response_size = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether SimpleResponse should include username.
+  bool fill_username = 4;
+
+  // Whether SimpleResponse should include OAuth scope.
+  bool fill_oauth_scope = 5;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue response_compressed = 6;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+
+  // Whether the server should expect this request to be compressed.
+  BoolValue expect_compressed = 8;
+}
+
+// Unary response, as configured by the request.
+message SimpleResponse {
+  // Payload to increase message size.
+  Payload payload = 1;
+  // The user the request came from, for verifying authentication was
+  // successful when the client expected it.
+  string username = 2;
+  // OAuth scope.
+  string oauth_scope = 3;
+}
+
+// Client-streaming request.
+message StreamingInputCallRequest {
+  // Optional input payload sent along with the request.
+  Payload payload = 1;
+
+  // Whether the server should expect this request to be compressed. This field
+  // is "nullable" in order to interoperate seamlessly with servers not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the request's compression status.
+  BoolValue expect_compressed = 2;
+
+  // Not expecting any payload from the response.
+}
+
+// Client-streaming response.
+message StreamingInputCallResponse {
+  // Aggregated size of payloads received from the client.
+  int32 aggregated_payload_size = 1;
+}
+
+// Configuration for a particular response.
+message ResponseParameters {
+  // Desired payload sizes in responses from the server.
+  int32 size = 1;
+
+  // Desired interval between consecutive responses in the response stream in
+  // microseconds.
+  int32 interval_us = 2;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue compressed = 3;
+}
+
+// Server-streaming request.
+message StreamingOutputCallRequest {
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, the payload from each response in the stream
+  // might be of different types. This is to simulate a mixed type of payload
+  // stream.
+  PayloadType response_type = 1;
+
+  // Configuration for each expected response message.
+  repeated ResponseParameters response_parameters = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+}
+
+// Server-streaming response, as configured by the request and parameters.
+message StreamingOutputCallResponse {
+  // Payload to increase response size.
+  Payload payload = 1;
+}
+
+// For reconnect interop test only.
+// Client tells server what reconnection parameters it used.
+message ReconnectParams {
+  int32 max_reconnect_backoff_ms = 1;
+}
+
+// For reconnect interop test only.
+// Server tells client whether its reconnects are following the spec and the
+// reconnect backoffs it saw.
+message ReconnectInfo {
+  bool passed = 1;
+  repeated int32 backoff_ms = 2;
+}

--- a/testassets/BenchmarkWorkerWebsite/grpc/testing/payloads.proto
+++ b/testassets/BenchmarkWorkerWebsite/grpc/testing/payloads.proto
@@ -1,0 +1,40 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+message ByteBufferParams {
+  int32 req_size = 1;
+  int32 resp_size = 2;
+}
+
+message SimpleProtoParams {
+  int32 req_size = 1;
+  int32 resp_size = 2;
+}
+
+message ComplexProtoParams {
+  // TODO (vpai): Fill this in once the details of complex, representative
+  //              protos are decided
+}
+
+message PayloadConfig {
+  oneof payload {
+    ByteBufferParams bytebuf_params = 1;
+    SimpleProtoParams simple_params = 2;
+    ComplexProtoParams complex_params = 3;
+  }
+}

--- a/testassets/BenchmarkWorkerWebsite/grpc/testing/stats.proto
+++ b/testassets/BenchmarkWorkerWebsite/grpc/testing/stats.proto
@@ -1,0 +1,85 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+// TODO(jtattermusch): the .proto file was renamed to avoid conflict between
+// two Stats.cs generated files. See https://github.com/grpc/grpc/issues/17672
+import "grpc/core/grpc_core_stats.proto";
+
+message ServerStats {
+  // wall clock time change in seconds since last reset
+  double time_elapsed = 1;
+
+  // change in user time (in seconds) used by the server since last reset
+  double time_user = 2;
+
+  // change in server time (in seconds) used by the server process and all
+  // threads since last reset
+  double time_system = 3;
+
+  // change in total cpu time of the server (data from proc/stat)
+  uint64 total_cpu_time = 4;
+
+  // change in idle time of the server (data from proc/stat)
+  uint64 idle_cpu_time = 5;
+
+  // Number of polls called inside completion queue
+  uint64 cq_poll_count = 6;
+
+  // Core library stats
+  grpc.core.Stats core_stats = 7;
+}
+
+// Histogram params based on grpc/support/histogram.c
+message HistogramParams {
+  double resolution = 1;   // first bucket is [0, 1 + resolution)
+  double max_possible = 2; // use enough buckets to allow this value
+}
+
+// Histogram data based on grpc/support/histogram.c
+message HistogramData {
+  repeated uint32 bucket = 1;
+  double min_seen = 2;
+  double max_seen = 3;
+  double sum = 4;
+  double sum_of_squares = 5;
+  double count = 6;
+}
+
+message RequestResultCount {
+  int32 status_code = 1;
+  int64 count = 2;
+}
+
+message ClientStats {
+  // Latency histogram. Data points are in nanoseconds.
+  HistogramData latencies = 1;
+
+  // See ServerStats for details.
+  double time_elapsed = 2;
+  double time_user = 3;
+  double time_system = 4;
+
+  // Number of failed requests (one row per status code seen)
+  repeated RequestResultCount request_results = 5;
+
+  // Number of polls called inside completion queue
+  uint64 cq_poll_count = 6;
+
+  // Core library stats
+  grpc.core.Stats core_stats = 7;
+}

--- a/testassets/BenchmarkWorkerWebsite/grpc/testing/worker_service.proto
+++ b/testassets/BenchmarkWorkerWebsite/grpc/testing/worker_service.proto
@@ -1,0 +1,45 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+syntax = "proto3";
+
+import "grpc/testing/control.proto";
+
+package grpc.testing;
+
+service WorkerService {
+  // Start server with specified workload.
+  // First request sent specifies the ServerConfig followed by ServerStatus
+  // response. After that, a "Mark" can be sent anytime to request the latest
+  // stats. Closing the stream will initiate shutdown of the test server
+  // and once the shutdown has finished, the OK status is sent to terminate
+  // this RPC.
+  rpc RunServer(stream ServerArgs) returns (stream ServerStatus);
+
+  // Start client with specified workload.
+  // First request sent specifies the ClientConfig followed by ClientStatus
+  // response. After that, a "Mark" can be sent anytime to request the latest
+  // stats. Closing the stream will initiate shutdown of the test client
+  // and once the shutdown has finished, the OK status is sent to terminate
+  // this RPC.
+  rpc RunClient(stream ClientArgs) returns (stream ClientStatus);
+
+  // Just return the core count - unary call
+  rpc CoreCount(CoreRequest) returns (CoreResponse);
+
+  // Quit this worker
+  rpc QuitWorker(Void) returns (Void);
+}


### PR DESCRIPTION
The "qps_worker".
Basically reimplementation of https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/QpsWorker.cs.

I was able to run a few basic scenarios  between C++ client and Grpc.AspNetCore.Server