### PR TITLE
Tweak window sizes to make interop tests pass

### DIFF
--- a/testassets/InteropTestsWebsite/Program.cs
+++ b/testassets/InteropTestsWebsite/Program.cs
@@ -49,6 +49,12 @@ namespace InteropTestsWebsite
                         }
                         listenOptions.Protocols = HttpProtocols.Http2;
                     });
+
+                    // Tweak flow control options to make large_unary test pass.
+                    // TODO(jtattermusch): remove this hack once https://github.com/aspnet/AspNetCore/pull/8200
+                    // is fixed.
+                    options.Limits.Http2.InitialConnectionWindowSize = 4 * 1024 * 1024;
+                    options.Limits.Http2.InitialStreamWindowSize = 4 * 1024 * 1024;
                 })
                 .UseStartup<Startup>();
     }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/149.

I don't like this "fix" at all, because it just masks the fact that Grpc.AspNetCore.Server doesn't work with default params when client sends large messages. The point of "large_unary" test is to test that flow control works as expected (which it currently doesn't by default).

Can we come up with a better fix until https://github.com/aspnet/AspNetCore/pull/8200 is available?