### PR TITLE
Add functional test for singleton scenario

### DIFF
--- a/test/FunctionalTests/AuthorizationTests.cs
+++ b/test/FunctionalTests/AuthorizationTests.cs
@@ -17,7 +17,6 @@
 #endregion
 
 using System.IO;
-using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -25,7 +24,6 @@ using System.Threading.Tasks;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
-using Grpc.AspNetCore.Server.Tests;
 using Grpc.Core;
 using NUnit.Framework;
 
@@ -78,11 +76,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var response = await Fixture.Client.SendAsync(httpRequest);
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
-            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
-
-            var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
+            var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
             Assert.AreEqual("Hello World", responseMessage.Message);
 
             Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());

--- a/test/FunctionalTests/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/DuplexStreamingMethodTests.cs
@@ -20,11 +20,9 @@ using System;
 using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Chat;
-using FunctionalTestsWebsite;
 using FunctionalTestsWebsite.Services;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
@@ -61,10 +59,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             requestStream.AddData(ms.ToArray());
 
             var response = await responseTask.DefaultTimeout();
-
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
-            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+            response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
             var pipeReader = new StreamPipeReader(responseStream);
@@ -146,10 +141,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             await requestStream.AddDataAndWait(Array.Empty<byte>()).DefaultTimeout();
 
             var response = await responseTask.DefaultTimeout();
-
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
-            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+            response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
             var pipeReader = new StreamPipeReader(responseStream);

--- a/test/FunctionalTests/Infrastructure/GrpcStreamContent.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcStreamContent.cs
@@ -16,12 +16,9 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using Grpc.AspNetCore.Server.Internal;
 
 namespace Grpc.AspNetCore.FunctionalTests.Infrastructure

--- a/test/FunctionalTests/Infrastructure/HttpResponseMessageExtensions.cs
+++ b/test/FunctionalTests/Infrastructure/HttpResponseMessageExtensions.cs
@@ -1,0 +1,43 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    internal static class HttpResponseMessageExtensions
+    {
+        public static void AssertIsSuccessfulGrpcRequest(this HttpResponseMessage response)
+        {
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
+            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+        }
+
+        public static async Task<T> GetSuccessfulGrpcMessageAsync<T>(this HttpResponseMessage response) where T : IMessage, new()
+        {
+            response.AssertIsSuccessfulGrpcRequest();
+            return MessageHelpers.AssertReadMessage<T>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
+        }
+    }
+}

--- a/test/FunctionalTests/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/MaxMessageSizeTests.cs
@@ -16,13 +16,9 @@
 
 #endregion
 
-using System;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
-using FunctionalTestsWebsite;
 using FunctionalTestsWebsite.Services;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;

--- a/test/FunctionalTests/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/ServerStreamingMethodTests.cs
@@ -19,15 +19,12 @@
 using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FunctionalTestsWebsite;
 using FunctionalTestsWebsite.Services;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
-using Grpc.AspNetCore.Server.Tests;
 using Grpc.Core;
 using NUnit.Framework;
 
@@ -55,9 +52,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var response = await Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
-            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+            response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
             var pipeReader = new StreamPipeReader(responseStream);
@@ -100,9 +95,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var response = await Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
-            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+            response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
             var pipeReader = new StreamPipeReader(responseStream);
@@ -159,10 +152,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             Assert.IsFalse(responseTask.IsCompleted, "Server should wait for first message from client");
 
             var response = await responseTask;
-
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues("grpc-encoding").Single());
-            Assert.AreEqual("application/grpc", response.Content.Headers.ContentType.MediaType);
+            response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
             var pipeReader = new StreamPipeReader(responseStream);

--- a/test/FunctionalTests/UnimplementedTests.cs
+++ b/test/FunctionalTests/UnimplementedTests.cs
@@ -17,8 +17,6 @@
 #endregion
 
 using System.IO;
-using System.IO.Pipelines;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -26,7 +24,6 @@ using System.Threading.Tasks;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
-using Grpc.AspNetCore.Server.Tests;
 using Grpc.Core;
 using NUnit.Framework;
 
@@ -54,7 +51,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var response = await Fixture.Client.SendAsync(httpRequest).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            response.AssertIsSuccessfulGrpcRequest();
 
             Assert.AreEqual(StatusCode.Unimplemented.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
             Assert.AreEqual("Method is unimplemented.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
@@ -79,7 +76,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var response = await Fixture.Client.SendAsync(httpRequest).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            response.AssertIsSuccessfulGrpcRequest();
 
             Assert.AreEqual(StatusCode.Unimplemented.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
             Assert.AreEqual("Service is unimplemented.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());

--- a/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
@@ -19,7 +19,6 @@
 using System;
 using Grpc.AspNetCore.Server.Internal;
 using Moq;
-using Moq.Protected;
 using NUnit.Framework;
 
 namespace Grpc.AspNetCore.Server.Tests

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextStreamReaderTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextStreamReaderTests.cs
@@ -16,8 +16,6 @@
 
 #endregion
 
-using System;
-using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +23,6 @@ using Google.Protobuf;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
-using Grpc.Core;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextStreamWriterTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextStreamWriterTests.cs
@@ -16,12 +16,12 @@
 
 #endregion
 
-using System;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Greet;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
 using Grpc.Core;
 using Microsoft.AspNetCore.Http;

--- a/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
@@ -22,6 +22,7 @@ using System.IO.Pipelines;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.AspNetCore.Server.Internal;
 using Grpc.Core;
 using NUnit.Framework;

--- a/test/Shared/HttpContextServerCallContextHelpers.cs
+++ b/test/Shared/HttpContextServerCallContextHelpers.cs
@@ -16,12 +16,13 @@
 
 #endregion
 
+using Grpc.AspNetCore.Server;
 using Grpc.AspNetCore.Server.Internal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Grpc.AspNetCore.Server.Tests
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 {
     internal static class HttpContextServerCallContextHelper
     {

--- a/test/Shared/MessageHelpers.cs
+++ b/test/Shared/MessageHelpers.cs
@@ -21,10 +21,8 @@ using System.IO.Pipelines;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Grpc.AspNetCore.Server.Internal;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Grpc.AspNetCore.Server.Tests
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 {
     internal static class MessageHelpers
     {

--- a/testassets/FunctionalTestsWebsite/Services/Counter.cs
+++ b/testassets/FunctionalTestsWebsite/Services/Counter.cs
@@ -44,11 +44,6 @@ namespace FunctionalTestsWebsite.Services
             return Task.FromResult(new CounterReply { Count = _counter.Count });
         }
 
-        public override Task<CounterReply> IncrementCountReturnNull(Empty request, ServerCallContext context)
-        {
-            return Task.FromResult<CounterReply>(null);
-        }
-
         public override async Task<CounterReply> AccumulateCount(IAsyncStreamReader<CounterRequest> requestStream, ServerCallContext context)
         {
             while (await requestStream.MoveNext(CancellationToken.None))

--- a/testassets/FunctionalTestsWebsite/Services/SingletonCounterService.cs
+++ b/testassets/FunctionalTestsWebsite/Services/SingletonCounterService.cs
@@ -1,0 +1,50 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using SingletonCount;
+
+namespace FunctionalTestsWebsite.Services
+{
+    public class SingletonCounterService : Counter.CounterBase, IDisposable
+    {
+        private readonly ILogger _logger;
+        private int _count = 0;
+
+        public SingletonCounterService(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<CounterService>();
+        }
+
+        public void Dispose()
+        {
+            // Set the count value to some arbitrary value. This should never happen in any case.
+            _count = int.MinValue;
+        }
+
+        public override Task<CounterReply> IncrementCount(Empty request, ServerCallContext context)
+        {
+            _logger.LogInformation("Incrementing count by 1");
+            return Task.FromResult(new CounterReply { Count = ++_count });
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -85,6 +85,9 @@ namespace FunctionalTestsWebsite
             services.TryAddSingleton<TrailersContainer>();
 
             services.TryAddSingleton<DynamicEndpointDataSource>();
+
+            // Add a Singleton service
+            services.AddSingleton<SingletonCounterService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -114,9 +117,10 @@ namespace FunctionalTestsWebsite
                 // Bind via reflection
                 routes.MapGrpcService<ChatterService>();
                 routes.MapGrpcService<CounterService>();
-				routes.MapGrpcService<AuthorizedGreeter>();
-				routes.MapGrpcService<SecondGreeterService>();
-				routes.MapGrpcService<LifetimeService>();
+                routes.MapGrpcService<AuthorizedGreeter>();
+                routes.MapGrpcService<SecondGreeterService>();
+                routes.MapGrpcService<LifetimeService>();
+                routes.MapGrpcService<SingletonCounterService>();
 
                 // Bind via configure method
                 routes.MapGrpcService<GreeterService>(options => options.BindAction = Greet.Greeter.BindService);

--- a/testassets/Proto/greet.proto
+++ b/testassets/Proto/greet.proto
@@ -20,15 +20,10 @@ package Greet;
 service Greeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHelloReturnNull (HelloRequest) returns (HelloReply) {}
-  rpc SayHelloThrowExceptionWithTrailers (HelloRequest) returns (HelloReply) {}
   rpc SayHelloWithHttpContextAccessor (HelloRequest) returns (HelloReply) {}
-  rpc SayHelloWithHttpContextExtensionMethod (HelloRequest) returns (HelloReply) {}
   rpc SayHelloSendLargeReply (HelloRequest) returns (HelloReply) {}
   rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
   rpc SayHellosSendHeadersFirst (HelloRequest) returns (stream HelloReply) {}
-  rpc SayHellosDeadline (HelloRequest) returns (stream HelloReply) {}
-  rpc SayHellosDeadlineCancellationToken (HelloRequest) returns (stream HelloReply) {}
 }
 
 // Test multiple services in one package

--- a/testassets/Proto/singleton.proto
+++ b/testassets/Proto/singleton.proto
@@ -15,19 +15,12 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
-package Count;
+package SingletonCount;
 
 // The counter service definition.
 service Counter {
   // Get current count
   rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {}
-  // Increment count through multiple counts
-  rpc AccumulateCount (stream CounterRequest) returns (CounterReply) {}
-}
-
-// The request message containing the count to increment by
-message CounterRequest {
-  int32 count = 1;
 }
 
 // The response message containing the current count


### PR DESCRIPTION
Added a functional test for singleton services to ensure the scenario doesn't regress in the future. The unit tests in 
https://github.com/grpc/grpc-dotnet/blob/master/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs#L48-L77 
already cover the unit test scenarios pretty well.

I also cleaned up the tests a little bit while I was writing the new one.