### PR TITLE
Add source link

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -12,5 +12,6 @@
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <NunitPackageVersion>3.11.0</NunitPackageVersion>
     <Nunit3TestAdapterPackageVersion>3.12.0</Nunit3TestAdapterPackageVersion>
+    <SourceLinkCreateCommandLinePackageVersion>2.8.3</SourceLinkCreateCommandLinePackageVersion>
   </PropertyGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -12,6 +12,6 @@
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <NunitPackageVersion>3.11.0</NunitPackageVersion>
     <Nunit3TestAdapterPackageVersion>3.12.0</Nunit3TestAdapterPackageVersion>
-    <SourceLinkCreateCommandLinePackageVersion>2.8.3</SourceLinkCreateCommandLinePackageVersion>
+    <MicrosoftSourceLinkGitHubPackageVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkGitHubPackageVersion>
   </PropertyGroup>
 </Project>

--- a/kokoro/build_nuget.sh
+++ b/kokoro/build_nuget.sh
@@ -30,4 +30,4 @@ export PATH="$HOME/.dotnet/:$PATH"
 
 mkdir -p artifacts
 
-(cd src/Grpc.AspNetCore.Server && dotnet pack --configuration Release --output ../../artifacts)
+(cd src/Grpc.AspNetCore.Server && dotnet pack --configuration Release /p:SourceLinkCreate=true --output ../../artifacts)

--- a/kokoro/build_nuget.sh
+++ b/kokoro/build_nuget.sh
@@ -30,4 +30,4 @@ export PATH="$HOME/.dotnet/:$PATH"
 
 mkdir -p artifacts
 
-(cd src/Grpc.AspNetCore.Server && dotnet pack --configuration Release /p:SourceLinkCreate=true --output ../../artifacts)
+(cd src/Grpc.AspNetCore.Server && dotnet pack --configuration Release --output ../../artifacts)

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -9,8 +9,12 @@
     <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
     <VersionPrefix>0.1.20-dev</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="Grpc.Core.Api" Version="$(GrpcCorePackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" PrivateAssets="All" Version="$(SourceLinkCreateCommandLinePackageVersion)"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -9,6 +9,8 @@
     <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
     <VersionPrefix>0.1.20-dev</VersionPrefix>
+    <!-- Include PDB in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" PrivateAssets="All" Version="$(SourceLinkCreateCommandLinePackageVersion)"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/131

After applying this change, the resulting .nupkg file contains the PDB.

https://pantheon.corp.google.com/storage/browser/grpc-testing-kokoro-prod/test_result_public/prod/grpc/dotnet/master/linux/767/20190313-012403/github/grpc-dotnet/artifacts/

According the https://github.com/dotnet/sourcelink/, the sourcelink support should now be included in the dotnet SDK - we can experiment with it, but changes in this PR should work too (and it's what many other packages do).