### PR TITLE
Set version to 0.1.19-pre2

### DIFF
--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
-    <VersionPrefix>0.1.20-dev</VersionPrefix>
+    <VersionPrefix>0.1.19-pre2</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Grpc.NetCore.HttpClient/Grpc.NetCore.HttpClient.csproj
+++ b/src/Grpc.NetCore.HttpClient/Grpc.NetCore.HttpClient.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
-    <VersionPrefix>0.1.19-pre1</VersionPrefix>
+    <VersionPrefix>0.1.19-pre2</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Once this is merged, I'll build a nuget a push it to nuget.org

- note that the packages won't work with .NET Core preview3 (because of the API update we've merged recently), so users will need to use nightlies - I'm not thrilled about this.
- we should probably put the version in a .props file so that it's shared among all the nugets (we currently publish just one, but it would be good to get rid of the duplication).