### PR TITLE
Update development infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ global.json
 .vscode/
 *.binlog
 build/feed
+.dotnet/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ branches:
     - master
 install:
   - ./build/get-dotnet.sh
-  - export PATH="~/.dotnet/:$PATH"
+  - source ./activate.sh
 script:
   - ./build_and_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,5 @@ branches:
     - master
 install:
   - ./build/get-dotnet.sh
-  - source ./activate.sh
 script:
   - ./build_and_test.sh

--- a/README.md
+++ b/README.md
@@ -28,25 +28,35 @@ Documentation and guides are coming soon! In the mean time we suggest creating a
 
 ## To develop gRPC for ASP.NET Core
 
-Installing .NET Core SDK:
-```
-# Run this script before building the project.
-./build/get-dotnet.sh or ./build/get-dotnet.ps1
-```
-
-Setting up local feed with unreleased Grpc.* packages:
+Setting up local feed with unreleased Grpc.* packages (May not be necessary):
 ```
 # We may depend on unreleased Grpc.* packages.
 # Run this script before building the project.
 ./build/get-grpc.sh or ./build/get-grpc.ps1
 ```
 
-To build:
+Installing .NET Core SDK:
+```
+# Run this script before building the project.
+./build/get-dotnet.sh or ./build/get-dotnet.ps1
+```
+
+Activate the development environment:
+```
+# Source this script to use the installed .NET Core SDK.
+source activate.sh or . activate.ps1
+```
+To launch Visual Studio with the installed SDK:
+```
+startvs.cmd Grpc.AspNetCore.sln
+```
+
+To build from the command line:
 ```
 dotnet build Grpc.AspNetCore.sln
 ```
 
-To run tests:
+To run tests from the command line:
 ```
 dotnet test Grpc.AspNetCore.sln
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Documentation and guides are coming soon! In the mean time we suggest creating a
 
 ## To develop gRPC for ASP.NET Core
 
-Setting up local feed with unreleased Grpc.* packages (May not be necessary):
+Setting up local feed with unreleased Grpc.* packages:
 ```
 # We may depend on unreleased Grpc.* packages.
 # Run this script before building the project.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ source ./activate.sh or . ./activate.ps1
 To launch Visual Studio with the installed SDK:
 ```
 # activate.sh or activate.ps1 must be sourced first, see previous step
-startvs.cmd Grpc.AspNetCore.sln
+startvs.cmd
 ```
 
 To build from the command line:

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ Installing .NET Core SDK:
 ./build/get-dotnet.sh or ./build/get-dotnet.ps1
 ```
 
-Activate the development environment:
+Set up the development environment to use the installed .NET Core SDK:
 ```
 # Source this script to use the installed .NET Core SDK.
-source activate.sh or . activate.ps1
+source ./activate.sh or . ./activate.ps1
 ```
 To launch Visual Studio with the installed SDK:
 ```
+# activate.sh or activate.ps1 must be sourced first, see previous step
 startvs.cmd Grpc.AspNetCore.sln
 ```
 

--- a/activate.ps1
+++ b/activate.ps1
@@ -1,0 +1,64 @@
+#
+# This file must be used by invoking ". .\activate.ps1" from the command line.
+# You cannot run it directly. See https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scripts#script-scope-and-dot-sourcing
+#
+# To exit from the environment this creates, execute the 'deactivate' function.
+#
+
+if ($MyInvocation.CommandOrigin -eq 'runspace') {
+    Write-Host -f Red "This script cannot be invoked directly."
+    Write-Host -f Red "To function correctly, this script file must be 'dot sourced' by calling `". $PSCommandPath`" (notice the dot at the beginning)."
+    exit 1
+}
+
+function deactivate ([switch]$init) {
+
+    # reset old environment variables
+    if (Test-Path variable:_OLD_PATH) {
+        $env:PATH = $_OLD_PATH
+        Remove-Item variable:_OLD_PATH
+    }
+
+    if (test-path function:_old_prompt) {
+        Set-Item Function:prompt -Value $function:_old_prompt -ea ignore
+        remove-item function:_old_prompt
+    }
+
+    Remove-Item env:DOTNET_ROOT -ea ignore
+    Remove-Item env:DOTNET_MULTILEVEL_LOOKUP -ea ignore
+    if (-not $init) {
+        # Remove the deactivate function
+        Remove-Item function:deactivate
+    }
+}
+
+# Cleanup the environment
+deactivate -init
+
+$_OLD_PATH = $env:PATH
+# Tell dotnet where to find itself
+$env:DOTNET_ROOT = "$PSScriptRoot\.dotnet"
+# Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+# Put dotnet first on PATH
+$env:PATH = "${env:DOTNET_ROOT};${env:PATH}"
+
+# Set the shell prompt
+if (-not $env:DISABLE_CUSTOM_PROMPT) {
+    $function:_old_prompt = $function:prompt
+    function dotnet_prompt {
+        # Add a prefix to the current prompt, but don't discard it.
+        write-host "($( split-path $PSScriptRoot -leaf )) " -nonewline
+        & $function:_old_prompt
+    }
+
+    Set-Item Function:prompt -Value $function:dotnet_prompt -ea ignore
+}
+
+Write-Host -f Magenta "Enabled the .NET Core environment. Execute 'deactivate' to exit."
+if (-not (Test-Path "${env:DOTNET_ROOT}\dotnet.exe")) {
+    Write-Host -f Yellow ".NET Core has not been installed yet. Run $PSScriptRoot\build\get-dotnet.ps1 to install it."
+}
+else {
+    Write-Host "dotnet = ${env:DOTNET_ROOT}\dotnet.exe"
+}

--- a/activate.sh
+++ b/activate.sh
@@ -1,0 +1,94 @@
+#
+# This file must be used by invoking "source activate.sh" from the command line.
+# You cannot run it directly.
+# To exit from the environment this creates, execute the 'deactivate' function.
+
+_RED="\033[0;31m"
+_MAGENTA="\033[0;95m"
+_YELLOW="\033[0;33m"
+_RESET="\033[0m"
+
+# This detects if a script was sourced or invoked directly
+# See https://stackoverflow.com/a/28776166/2526265
+sourced=0
+if [ -n "$ZSH_EVAL_CONTEXT" ]; then
+  case $ZSH_EVAL_CONTEXT in *:file) sourced=1;; esac
+  THIS_SCRIPT="${0:-}"
+elif [ -n "$KSH_VERSION" ]; then
+  [ "$(cd $(dirname -- $0) && pwd -P)/$(basename -- $0)" != "$(cd $(dirname -- ${.sh.file}) && pwd -P)/$(basename -- ${.sh.file})" ] && sourced=1
+  THIS_SCRIPT="${0:-}"
+elif [ -n "$BASH_VERSION" ]; then
+  (return 2>/dev/null) && sourced=1
+  THIS_SCRIPT="$BASH_SOURCE"
+else # All other shells: examine $0 for known shell binary filenames
+  # Detects `sh` and `dash`; add additional shell filenames as needed.
+  case ${0##*/} in sh|dash) sourced=1;; esac
+  THIS_SCRIPT="${0:-}"
+fi
+
+if [ $sourced -eq 0 ]; then
+    printf "${_RED}This script cannot be invoked directly.${_RESET}\n"
+    printf "${_RED}To function correctly, this script file must be sourced by calling \"source $0\".${_RESET}\n"
+    exit 1
+fi
+
+deactivate () {
+
+    # reset old environment variables
+    if [ ! -z "${_OLD_PATH:-}" ] ; then
+        export PATH="$_OLD_PATH"
+        unset _OLD_PATH
+    fi
+
+    if [ ! -z "${_OLD_PS1:-}" ] ; then
+        export PS1="$_OLD_PS1"
+        unset _OLD_PS1
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+        hash -r 2>/dev/null
+    fi
+
+    unset DOTNET_ROOT
+    unset DOTNET_MULTILEVEL_LOOKUP
+    if [ ! "${1:-}" = "init" ] ; then
+        # Remove the deactivate function
+        unset -f deactivate
+    fi
+}
+
+# Cleanup the environment
+deactivate init
+
+DIR="$( cd "$( dirname "$THIS_SCRIPT" )" && pwd )"
+_OLD_PATH="$PATH"
+# Tell dotnet where to find itself
+export DOTNET_ROOT="$DIR/.dotnet"
+# Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
+export DOTNET_MULTILEVEL_LOOKUP=0
+# Put dotnet first on PATH
+export PATH="$DOTNET_ROOT:$PATH"
+
+# Set the shell prompt
+if [ -z "${DISABLE_CUSTOM_PROMPT:-}" ] ; then
+    _OLD_PS1="$PS1"
+    export PS1="(`basename \"$DIR\"`) $PS1"
+fi
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+    hash -r 2>/dev/null
+fi
+
+printf "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}\n"
+
+if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
+    printf "${_YELLOW}.NET Core has not been installed yet. Run $DIR/build/get-dotnet.sh to install it.${_RESET}\n"
+else
+    printf "dotnet = $DOTNET_ROOT/dotnet\n"
+fi

--- a/build/get-dotnet.ps1
+++ b/build/get-dotnet.ps1
@@ -22,6 +22,7 @@ $TempDir = Join-Path $WorkingDir 'obj'
 $InstallScriptUrl = 'https://dot.net/v1/dotnet-install.ps1'
 $InstallScriptPath = Join-Path $TempDir 'dotnet-install.ps1'
 $GlobalJsonPath = Join-Path $WorkingDir '..' | Join-Path -ChildPath 'global.json'
+$DotnetInstallPath = Join-Path $WorkingDir '..' | Join-Path -ChildPath '.dotnet'
 
 # Functions
 
@@ -41,4 +42,4 @@ $SDKVersion = $GlobalJson.sdk.version
 Ensure-Dir $TempDir
 Write-Host "Downloading install script: $InstallScriptUrl => $InstallScriptPath"
 Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $InstallScriptPath
-&$InstallScriptPath -Version $SDKVersion
+&$InstallScriptPath -Version $SDKVersion -InstallDir $DotnetInstallPath

--- a/build/get-dotnet.sh
+++ b/build/get-dotnet.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 OBJDIR="$DIR/obj"
 global_json_path="$DIR/../global.json"
+dotnet_install_path="$DIR/../.dotnet"
 install_script_url="https://dot.net/v1/dotnet-install.sh"
 install_script_path="$OBJDIR/dotnet-install.sh"
 
@@ -26,4 +27,4 @@ echo "Downloading install script: $install_script_url => $install_script_path"
 curl -sSL -o $install_script_path $install_script_url
 chmod +x $install_script_path
 
-$install_script_path -v $sdk_version
+$install_script_path -v $sdk_version -i $dotnet_install_path

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -15,6 +15,8 @@
 
 set -ex
 
+source activate.sh
+
 # Required when using nightly builds of gRPC packages
 # ./build/get-grpc.sh
 

--- a/kokoro/build_nuget.sh
+++ b/kokoro/build_nuget.sh
@@ -23,7 +23,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 # Install dotnet SDK
 sudo apt-get install -y jq
 ./build/get-dotnet.sh
-export PATH="$HOME/.dotnet/:$PATH"
+source ./activate.sh
 
 # Required when using nightly builds of gRPC packages
 # ./build/get-grpc.sh

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -1,0 +1,28 @@
+@ECHO OFF
+
+:: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
+
+:: This tells .NET Core to use the same dotnet.exe that build scripts use
+SET DOTNET_ROOT=%~dp0.dotnet
+
+:: This tells .NET Core not to go looking for .NET Core in other places
+SET DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+SET PATH=%DOTNET_ROOT%;%PATH%
+
+SET sln=%1
+
+IF "%sln%"=="" (
+    echo Error^: Expected argument ^<SLN_FILE^>
+    echo Usage^: startvs.cmd ^<SLN_FILE^>
+
+    exit /b 1
+)
+
+IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
+    echo .NET Core has not yet been installed. Run `%~dp0build\get-dotnet.ps1` to install tools and activate the environment with `. %~dp0activate.ps1`
+    exit /b 1
+)
+
+start %sln%

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -14,10 +14,7 @@ SET PATH=%DOTNET_ROOT%;%PATH%
 SET sln=%1
 
 IF "%sln%"=="" (
-    echo Error^: Expected argument ^<SLN_FILE^>
-    echo Usage^: startvs.cmd ^<SLN_FILE^>
-
-    exit /b 1
+    SET sln=Grpc.AspNetCore.sln
 )
 
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/175. Most of the infrastructure is taken from aspnet/AspNetCore.

The get-dotnet.ps1/sh will now install locally to {repoRoot}.dotnet/ and the activate.sh/ps1 will set the appropriate environment variables to use the installed SDK. Edited README to reflect the new workflow.