### PR TITLE
Add exception handling to deadline cancellation

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
@@ -42,7 +42,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, "EncodingNotInAcceptEncoding"), "Request grpc-encoding header value '{GrpcEncoding}' is not in grpc-accept-encoding.");
 
             private static readonly Action<ILogger, Exception> _deadlineCancellationError =
-                LoggerMessage.Define(LogLevel.Error, new EventId(6, "DeadlineCancellationError"), "Error canceling request because of the deadline.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(6, "DeadlineCancellationError"), "Error occurred while trying to cancel the request due to deadline exceeded.");
 
             public static void DeadlineExceeded(ILogger logger, TimeSpan timeout)
             {

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.Log.cs
@@ -41,6 +41,9 @@ namespace Grpc.AspNetCore.Server.Internal
             private static readonly Action<ILogger, string, Exception> _encodingNotInAcceptEncoding =
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, "EncodingNotInAcceptEncoding"), "Request grpc-encoding header value '{GrpcEncoding}' is not in grpc-accept-encoding.");
 
+            private static readonly Action<ILogger, Exception> _deadlineCancellationError =
+                LoggerMessage.Define(LogLevel.Error, new EventId(6, "DeadlineCancellationError"), "Error canceling request because of the deadline.");
+
             public static void DeadlineExceeded(ILogger logger, TimeSpan timeout)
             {
                 _deadlineExceeded(logger, timeout, null);
@@ -64,6 +67,11 @@ namespace Grpc.AspNetCore.Server.Internal
             public static void EncodingNotInAcceptEncoding(ILogger logger, string grpcEncoding)
             {
                 _encodingNotInAcceptEncoding(logger, grpcEncoding, null);
+            }
+
+            public static void DeadlineCancellationError(ILogger logger, Exception ex)
+            {
+                _deadlineCancellationError(logger, ex);
             }
         }
     }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -263,8 +263,15 @@ namespace Grpc.AspNetCore.Server.Internal
 
             _status = new Status(StatusCode.DeadlineExceeded, "Deadline Exceeded");
 
-            // TODO(JamesNK): I believe this sends a RST_STREAM with INTERNAL_ERROR. Grpc.Core sends NO_ERROR
-            HttpContext.Abort();
+            try
+            {
+                // TODO(JamesNK): I believe this sends a RST_STREAM with INTERNAL_ERROR. Grpc.Core sends NO_ERROR
+                HttpContext.Abort();
+            }
+            catch (Exception ex)
+            {
+                Log.DeadlineCancellationError(_logger, ex);
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
We don't want to throw an unhandled exception from the deadline timer, it will kill the process.

https://github.com/grpc/grpc-dotnet/issues/206
https://github.com/aspnet/AspNetCore/issues/9239