### PR TITLE
Special status message

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -127,8 +127,7 @@ namespace Grpc.AspNetCore.Server.Internal
         public static Task SendHttpError(HttpResponse response, int httpStatusCode, StatusCode grpcStatusCode, string message)
         {
             response.StatusCode = httpStatusCode;
-            response.AppendTrailer(GrpcProtocolConstants.StatusTrailer, grpcStatusCode.ToTrailerString());
-            response.AppendTrailer(GrpcProtocolConstants.MessageTrailer, message);
+            SetStatusTrailers(response, new Status(grpcStatusCode, message));
             return response.WriteAsync(message);
         }
 
@@ -205,7 +204,17 @@ namespace Grpc.AspNetCore.Server.Internal
         {
             // Use SetTrailer here because we want to overwrite any that was set earlier
             SetTrailer(response, GrpcProtocolConstants.StatusTrailer, status.StatusCode.ToTrailerString());
-            SetTrailer(response, GrpcProtocolConstants.MessageTrailer, status.Detail);
+
+            var escapedDetail = status.Detail;
+            if (!string.IsNullOrEmpty(status.Detail))
+            {
+                // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
+                // The value portion of Status-Message is conceptually a Unicode string description of the error,
+                // physically encoded as UTF-8 followed by percent-encoding.
+                escapedDetail = Uri.EscapeDataString(status.Detail);
+            }
+
+            SetTrailer(response, GrpcProtocolConstants.MessageTrailer, escapedDetail);
         }
 
         private static void SetTrailer(HttpResponse response, string trailerName, StringValues trailerValues)

--- a/test/FunctionalTests/AuthorizationTests.cs
+++ b/test/FunctionalTests/AuthorizationTests.cs
@@ -78,7 +78,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]

--- a/test/FunctionalTests/AuthorizationTests.cs
+++ b/test/FunctionalTests/AuthorizationTests.cs
@@ -78,8 +78,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]

--- a/test/FunctionalTests/ClientStreamingMethodTests.cs
+++ b/test/FunctionalTests/ClientStreamingMethodTests.cs
@@ -65,7 +65,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var reply = await response.GetSuccessfulGrpcMessageAsync<CounterReply>();
             Assert.AreEqual(2, reply.Count);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var response = await responseTask.DefaultTimeout();
             var reply = await response.GetSuccessfulGrpcMessageAsync<CounterReply>();
             Assert.AreEqual(3, reply.Count);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/ClientStreamingMethodTests.cs
+++ b/test/FunctionalTests/ClientStreamingMethodTests.cs
@@ -65,8 +65,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var reply = await response.GetSuccessfulGrpcMessageAsync<CounterReply>();
             Assert.AreEqual(2, reply.Count);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -107,8 +106,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             await responseTask.DefaultTimeout();
 
-            Assert.AreEqual(StatusCode.Internal.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
-            Assert.AreEqual("Incomplete message.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
+            Fixture.AssertTrailerStatus(StatusCode.Internal, "Incomplete message.");
         }
 
         [Test]
@@ -140,9 +138,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
-
-            Assert.AreEqual(StatusCode.Cancelled.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("No message returned from method.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.Cancelled, "No message returned from method.");
         }
 
         [Test]
@@ -211,8 +207,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var response = await responseTask.DefaultTimeout();
             var reply = await response.GetSuccessfulGrpcMessageAsync<CounterReply>();
             Assert.AreEqual(3, reply.Count);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/CompressionTests.cs
+++ b/test/FunctionalTests/CompressionTests.cs
@@ -62,7 +62,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -234,8 +234,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -263,7 +262,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout(), "gzip");
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -292,7 +291,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/CompressionTests.cs
+++ b/test/FunctionalTests/CompressionTests.cs
@@ -62,8 +62,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -95,8 +94,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
-            Assert.AreEqual(StatusCode.Internal.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
-            Assert.AreEqual("Request sent 'identity' grpc-encoding value with compressed message.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
+            Fixture.AssertTrailerStatus(StatusCode.Internal, "Request sent 'identity' grpc-encoding value with compressed message.");
         }
 
         [Test]
@@ -120,8 +118,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -161,8 +158,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.AreEqual("gzip", response.Headers.GetValues(GrpcProtocolConstants.MessageAcceptEncodingHeader).Single());
 
-            Assert.AreEqual(StatusCode.Unimplemented.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
-            Assert.AreEqual("Unsupported grpc-encoding value 'DOES_NOT_EXIST'. Supported encodings: gzip", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
+            Fixture.AssertTrailerStatus(StatusCode.Unimplemented, "Unsupported grpc-encoding value 'DOES_NOT_EXIST'. Supported encodings: gzip");
         }
 
         private class DoesNotExistCompressionProvider : ICompressionProvider
@@ -207,9 +203,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-
-            Assert.AreEqual(StatusCode.Internal.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
-            Assert.AreEqual("Request did not include grpc-encoding value with compressed message.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
+            Fixture.AssertTrailerStatus(StatusCode.Internal, "Request did not include grpc-encoding value with compressed message.");
         }
 
         [Test]
@@ -240,8 +234,8 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -269,8 +263,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout(), "gzip");
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -299,8 +292,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Fixture.AssertSuccessTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/DeadlineTests.cs
+++ b/test/FunctionalTests/DeadlineTests.cs
@@ -122,8 +122,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             Assert.AreNotEqual(0, messageCount);
 
-            Assert.AreEqual(StatusCode.DeadlineExceeded.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("Deadline Exceeded", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.DeadlineExceeded, "Deadline Exceeded");
         }
 
         [Test]
@@ -198,9 +197,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             await readTask.DefaultTimeout();
 
             Assert.AreNotEqual(0, messageCount);
-
-            Assert.AreEqual(StatusCode.Unknown.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("Exception was thrown by handler. InvalidOperationException: Cannot write message after request is complete.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.Unknown, "Exception was thrown by handler. InvalidOperationException: Cannot write message after request is complete.");
         }
     }
 }

--- a/test/FunctionalTests/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/DuplexStreamingMethodTests.cs
@@ -91,7 +91,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             requestStream.AddData(Array.Empty<byte>());
             await finishedTask.DefaultTimeout();
 
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -156,7 +156,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             Assert.IsNull(await MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader).DefaultTimeout());
 
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/DuplexStreamingMethodTests.cs
@@ -91,7 +91,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             requestStream.AddData(Array.Empty<byte>());
             await finishedTask.DefaultTimeout();
 
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -156,7 +156,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             Assert.IsNull(await MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader).DefaultTimeout());
 
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/HttpContextTests.cs
+++ b/test/FunctionalTests/HttpContextTests.cs
@@ -51,7 +51,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
             Assert.AreEqual("/Greet.Greeter/SayHelloWithHttpContextAccessor?query=extra", Fixture.TrailersContainer.Trailers["Test-HttpContext-PathAndQueryString"].ToString());
         }
 
@@ -83,7 +83,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
             Assert.AreEqual($"{url}?query=extra", Fixture.TrailersContainer.Trailers["Test-HttpContext-PathAndQueryString"].ToString());
         }
     }

--- a/test/FunctionalTests/HttpContextTests.cs
+++ b/test/FunctionalTests/HttpContextTests.cs
@@ -51,8 +51,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Fixture.AssertSuccessTrailerStatus();
             Assert.AreEqual("/Greet.Greeter/SayHelloWithHttpContextAccessor?query=extra", Fixture.TrailersContainer.Trailers["Test-HttpContext-PathAndQueryString"].ToString());
         }
 
@@ -84,8 +83,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Fixture.AssertSuccessTrailerStatus();
             Assert.AreEqual($"{url}?query=extra", Fixture.TrailersContainer.Trailers["Test-HttpContext-PathAndQueryString"].ToString());
         }
     }

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -19,11 +19,14 @@
 using System;
 using System.Net.Http;
 using FunctionalTestsWebsite.Infrastructure;
+using Grpc.AspNetCore.Server.Internal;
+using Grpc.Core;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
 
 namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 {
@@ -73,6 +76,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         {
             Client.Dispose();
             _server.Dispose();
+        }
+
+        public void AssertTrailerStatus(StatusCode statusCode, string details)
+        {
+            Assert.AreEqual(statusCode.ToTrailerString(), TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Assert.AreEqual(Uri.EscapeDataString(details), TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
+        }
+
+        public void AssertSuccessTrailerStatus()
+        {
+            Assert.AreEqual(StatusCode.OK.ToTrailerString(), TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            Assert.AreEqual(StringValues.Empty, TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer]);
         }
     }
 }

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -78,16 +78,13 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
             _server.Dispose();
         }
 
+        public void AssertTrailerStatus() => AssertTrailerStatus(StatusCode.OK, string.Empty);
+
         public void AssertTrailerStatus(StatusCode statusCode, string details)
         {
-            Assert.AreEqual(statusCode.ToTrailerString(), TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
+            var trailerValueString = TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString();
+            Assert.AreEqual(statusCode.ToTrailerString(), trailerValueString, $"Expected grpc-status {statusCode} but got {(StatusCode)Convert.ToInt32(trailerValueString)}");
             Assert.AreEqual(Uri.EscapeDataString(details), TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
-        }
-
-        public void AssertSuccessTrailerStatus()
-        {
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
-            Assert.AreEqual(StringValues.Empty, TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer]);
         }
     }
 }

--- a/test/FunctionalTests/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/MaxMessageSizeTests.cs
@@ -58,8 +58,7 @@ namespace Grpc.AspNetCore.FunctionalTests
                 new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(StatusCode.ResourceExhausted.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("Received message exceeds the maximum configured message size.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.ResourceExhausted, "Received message exceeds the maximum configured message size.");
         }
 
         [Test]
@@ -88,8 +87,7 @@ namespace Grpc.AspNetCore.FunctionalTests
                 new GrpcStreamContent(ms)).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(StatusCode.ResourceExhausted.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("Sending message exceeds the maximum configured message size.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.ResourceExhausted, "Sending message exceeds the maximum configured message size.");
         }
     }
 }

--- a/test/FunctionalTests/NestedTests.cs
+++ b/test/FunctionalTests/NestedTests.cs
@@ -56,7 +56,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello Nested: World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/NestedTests.cs
+++ b/test/FunctionalTests/NestedTests.cs
@@ -56,8 +56,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello Nested: World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/ServerStreamingMethodTests.cs
@@ -169,7 +169,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             Assert.IsNull(await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader).DefaultTimeout());
 
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/ServerStreamingMethodTests.cs
@@ -169,7 +169,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             Assert.IsNull(await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader).DefaultTimeout());
 
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -57,8 +57,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -128,8 +127,7 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             await responseTask.DefaultTimeout();
 
-            Assert.AreEqual(StatusCode.Internal.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("Additional data after the message received.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.Internal, "Additional data after the message received.");
         }
 
         [Test]
@@ -173,8 +171,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
 
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [Test]
@@ -216,8 +213,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
 
-            Assert.AreEqual(StatusCode.Unknown.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("Exception was thrown by handler. InvalidOperationException: Response headers can only be sent once per call.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.Unknown, "Exception was thrown by handler. InvalidOperationException: Response headers can only be sent once per call.");
         }
 
         [Test]
@@ -251,8 +247,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
 
-            Assert.AreEqual(StatusCode.Cancelled.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("No message returned from method.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.Cancelled, "No message returned from method.");
         }
 
         [Test]
@@ -291,8 +286,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
 
-            Assert.AreEqual(StatusCode.Unknown.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual("User error", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.Unknown, "User error");
             Assert.AreEqual("A value!", Fixture.TrailersContainer.Trailers["test-trailer"].Single());
         }
 
@@ -351,7 +345,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert 1
             var total = await response.GetSuccessfulGrpcMessageAsync<SingletonCount.CounterReply>();
             Assert.AreEqual(1, total.Count);
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
 
             // Act 2
             response = await Fixture.Client.PostAsync(
@@ -361,7 +355,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert 2
             total = await response.GetSuccessfulGrpcMessageAsync<SingletonCount.CounterReply>();
             Assert.AreEqual(2, total.Count);
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
 
         [TestCase(null, "Content-Type is missing from the request.")]
@@ -392,8 +386,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var content = await response.Content.ReadAsStringAsync().DefaultTimeout();
             Assert.AreEqual(responseMessage, content);
 
-            Assert.AreEqual(StatusCode.Internal.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
-            Assert.AreEqual(responseMessage, Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].Single());
+            Fixture.AssertTrailerStatus(StatusCode.Internal, responseMessage);
         }
 
         [TestCase("application/grpc")]
@@ -423,8 +416,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
             Assert.AreEqual("Hello World", responseMessage.Message);
-
-            Assert.AreEqual(StatusCode.OK.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].Single());
+            Fixture.AssertSuccessTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -27,7 +27,6 @@ using FunctionalTestsWebsite. Services;
 using Google.Protobuf.WellKnownTypes;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
-using Grpc.AspNetCore.Server.Internal;
 using Grpc.AspNetCore.Server.Tests;
 using Grpc.Core;
 using NUnit.Framework;
@@ -57,7 +56,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -171,7 +170,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
 
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [Test]
@@ -345,7 +344,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert 1
             var total = await response.GetSuccessfulGrpcMessageAsync<SingletonCount.CounterReply>();
             Assert.AreEqual(1, total.Count);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
 
             // Act 2
             response = await Fixture.Client.PostAsync(
@@ -355,7 +354,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert 2
             total = await response.GetSuccessfulGrpcMessageAsync<SingletonCount.CounterReply>();
             Assert.AreEqual(2, total.Count);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
 
         [TestCase(null, "Content-Type is missing from the request.")]
@@ -416,7 +415,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             var responseMessage = await response.GetSuccessfulGrpcMessageAsync<HelloReply>();
             Assert.AreEqual("Hello World", responseMessage.Message);
-            Fixture.AssertSuccessTrailerStatus();
+            Fixture.AssertTrailerStatus();
         }
     }
 }

--- a/test/FunctionalTests/UnimplementedTests.cs
+++ b/test/FunctionalTests/UnimplementedTests.cs
@@ -53,8 +53,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
 
-            Assert.AreEqual(StatusCode.Unimplemented.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
-            Assert.AreEqual("Method is unimplemented.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
+            Fixture.AssertTrailerStatus(StatusCode.Unimplemented, "Method is unimplemented.");
         }
 
         [Test]
@@ -78,8 +77,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
 
-            Assert.AreEqual(StatusCode.Unimplemented.ToTrailerString(), Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
-            Assert.AreEqual("Service is unimplemented.", Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.MessageTrailer].ToString());
+            Fixture.AssertTrailerStatus(StatusCode.Unimplemented, "Service is unimplemented.");
         }
 
         [TestCase("application/grpc", HttpStatusCode.OK, StatusCode.Unimplemented)]
@@ -104,7 +102,6 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             // Assert
             Assert.AreEqual(httpStatusCode, response.StatusCode);
-
             Assert.AreEqual(grpcStatusCode?.ToTrailerString() ?? string.Empty, Fixture.TrailersContainer.Trailers[GrpcProtocolConstants.StatusTrailer].ToString());
         }
     }

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -200,13 +200,14 @@ namespace Grpc.AspNetCore.Server.Tests
         }
 
         [Test]
-        public void ConsolidateTrailers_AppendsStatus()
+        public void ConsolidateTrailers_AppendsStatus_PercentEncodesMessage()
         {
             // Arrange
+            var errorMessage = "\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n";
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseTrailersFeature>(new TestHttpResponseTrailersFeature());
             var serverCallContext = CreateServerCallContext(httpContext);
-            serverCallContext.Status = new Status(StatusCode.Internal, "Error message");
+            serverCallContext.Status = new Status(StatusCode.Internal, errorMessage);
 
             // Act
             httpContext.Response.ConsolidateTrailers(serverCallContext);
@@ -216,19 +217,20 @@ namespace Grpc.AspNetCore.Server.Tests
 
             Assert.AreEqual(2, responseTrailers.Count);
             Assert.AreEqual(StatusCode.Internal.ToString("D"), responseTrailers[GrpcProtocolConstants.StatusTrailer]);
-            Assert.AreEqual("Error message", responseTrailers[GrpcProtocolConstants.MessageTrailer]);
+            Assert.AreEqual(Uri.EscapeDataString(errorMessage), responseTrailers[GrpcProtocolConstants.MessageTrailer]);
         }
 
         [Test]
-        public void ConsolidateTrailers_StatusOverwritesTrailers()
+        public void ConsolidateTrailers_StatusOverwritesTrailers_PercentEncodesMessage()
         {
             // Arrange
+            var errorMessage = "\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n";
             var httpContext = new DefaultHttpContext();
             httpContext.Features.Set<IHttpResponseTrailersFeature>(new TestHttpResponseTrailersFeature());
             var serverCallContext = CreateServerCallContext(httpContext);
             serverCallContext.ResponseTrailers.Add(GrpcProtocolConstants.StatusTrailer, StatusCode.OK.ToString("D"));
             serverCallContext.ResponseTrailers.Add(GrpcProtocolConstants.MessageTrailer, "All is good");
-            serverCallContext.Status = new Status(StatusCode.Internal, "Error message");
+            serverCallContext.Status = new Status(StatusCode.Internal, errorMessage);
 
             // Act
             httpContext.Response.ConsolidateTrailers(serverCallContext);
@@ -238,7 +240,7 @@ namespace Grpc.AspNetCore.Server.Tests
 
             Assert.AreEqual(2, responseTrailers.Count);
             Assert.AreEqual(StatusCode.Internal.ToString("D"), responseTrailers[GrpcProtocolConstants.StatusTrailer]);
-            Assert.AreEqual("Error message", responseTrailers[GrpcProtocolConstants.MessageTrailer]);
+            Assert.AreEqual(Uri.EscapeDataString(errorMessage), responseTrailers[GrpcProtocolConstants.MessageTrailer]);
         }
 
         [TestCase("trailer-bin")]


### PR DESCRIPTION
Percent encode the status message. Addresses https://github.com/grpc/grpc-dotnet/issues/161.

I have tested locally with a custom client but I'll see if I can run the interop tests as well.