### PR TITLE
Remove usage of endpoint builder extension methods

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServiceBinder.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServiceBinder.cs
@@ -98,10 +98,16 @@ namespace Grpc.AspNetCore.Server.Internal
 
             var pattern = method.FullName;
 
-            var endpointBuilder = _builder
-                .MapPost(pattern, requestDelegate)
-                .WithDisplayName($"gRPC - {method.FullName}")
-                .WithMetadata(resolvedMetadata.ToArray());
+            var endpointBuilder = _builder.MapPost(pattern, requestDelegate);
+
+            endpointBuilder.Add(ep =>
+            {
+                ep.DisplayName = $"gRPC - {method.FullName}";
+                foreach (var item in resolvedMetadata)
+                {
+                    ep.Metadata.Add(item);
+                }
+            });
 
             EndpointConventionBuilders.Add(endpointBuilder);
 


### PR DESCRIPTION
Removes usage of some extension methods that will likely change in the next preview of ASP.NET Core. As you can see from the file changes, the logic in these methods is very simple.

See https://github.com/aspnet/AspNetCore/pull/8906#issuecomment-486025764 for more details