### PR TITLE
Publish nightly build of grpc-dotnet nugets to dev feed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="build\sources.props" />
   <Import Project="build\dependencies.props" />
+  <Import Project="build\version.props" />
 
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)keys\Grpc.snk</AssemblyOriginatorKeyFile>

--- a/build/expand_dev_version.sh
+++ b/build/expand_dev_version.sh
@@ -13,23 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+# Updates the GrpcSharpVersion property so that we can build
+# dev nuget packages differentiated by timestamp.
 
-# change to grpc repo root
-cd $(dirname $0)/..
+set -e
 
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+cd "$(dirname "$0")"
 
-# Install dotnet SDK
-sudo apt-get install -y jq
-./build/get-dotnet.sh
-source ./activate.sh
-
-# Required when using nightly builds of gRPC packages
-# ./build/get-grpc.sh
-
-mkdir -p artifacts
-
-build/expand_dev_version.sh
-
-(cd src/Grpc.AspNetCore.Server && dotnet pack --configuration Release --output ../../artifacts)
+DEV_DATETIME_SUFFIX=$(date -u "+%Y%m%d%H%M")
+# expand the -dev suffix to contain current timestamp
+sed -ibak "s/-dev<\/GrpcDotnetVersion>/-dev${DEV_DATETIME_SUFFIX}<\/GrpcDotnetVersion>/" version.props

--- a/build/version.props
+++ b/build/version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- version of all grpc-dotnet packages -->
+    <GrpcDotnetVersion>0.1.21-dev</GrpcDotnetVersion>
+  </PropertyGroup>
+</Project>

--- a/kokoro/publish_nuget.cfg
+++ b/kokoro/publish_nuget.cfg
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright 2019 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,23 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+# Config file for the internal CI (in protobuf text format)
 
-# change to grpc repo root
-cd $(dirname $0)/..
+# Location of the continuous shell script in repository.
+build_file: "grpc-dotnet/kokoro/publish_nuget.sh"
+timeout_mins: 30
 
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc-dotnet/artifacts/**"
+  }
+}
 
-# Install dotnet SDK
-sudo apt-get install -y jq
-./build/get-dotnet.sh
-source ./activate.sh
-
-# Required when using nightly builds of gRPC packages
-# ./build/get-grpc.sh
-
-mkdir -p artifacts
-
-build/expand_dev_version.sh
-
-(cd src/Grpc.AspNetCore.Server && dotnet pack --configuration Release --output ../../artifacts)
+gfile_resources: "/bigstore/grpc-testing-secrets/nuget_credentials/artifactory_grpc_nuget_dev_api_key"

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
-    <VersionPrefix>0.1.20-pre1</VersionPrefix>
+    <VersionPrefix>$(GrpcDotnetVersion)</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Grpc.NetCore.HttpClient/Grpc.NetCore.HttpClient.csproj
+++ b/src/Grpc.NetCore.HttpClient/Grpc.NetCore.HttpClient.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
-    <VersionPrefix>0.1.20-pre1</VersionPrefix>
+    <VersionPrefix>$(GrpcDotnetVersion)</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/179 

- doesn't push dev packages to packages.grpc.io (which is meant for packages coming from grpc/grpc repository), but pushes them to the artifactory nuget dev feed.

- introduce version.props that has the version of all nugets from grpc/grpc-dotnet repository. If the package has a -dev suffix, the package version is expanded to contain current timestamp.

Dev nuget feed: https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev

