### PR TITLE
Fix potential deadlock when writing to client stream after response finishes

### DIFF
--- a/test/Grpc.NetCore.HttpClient.Tests/DeadlineTests.cs
+++ b/test/Grpc.NetCore.HttpClient.Tests/DeadlineTests.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -150,12 +151,15 @@ namespace Grpc.NetCore.HttpClient.Tests
             // Arrange
             var httpClient = TestHelpers.CreateTestClient(request =>
             {
-                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK));
+                var stream = new SyncPointMemoryStream();
+                var content = new StreamContent(stream);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, content));
             });
             var invoker = new HttpClientCallInvoker(httpClient);
 
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(TestHelpers.ServiceMethod, null, new CallOptions(deadline: DateTime.UtcNow));
+
 
             // Assert
             var ex = Assert.ThrowsAsync<RpcException>(async () => await call.RequestStream.WriteAsync(new HelloRequest()).DefaultTimeout());

--- a/test/Grpc.NetCore.HttpClient.Tests/DeadlineTests.cs
+++ b/test/Grpc.NetCore.HttpClient.Tests/DeadlineTests.cs
@@ -17,12 +17,9 @@
 #endregion
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Greet;
@@ -159,7 +156,6 @@ namespace Grpc.NetCore.HttpClient.Tests
 
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(TestHelpers.ServiceMethod, null, new CallOptions(deadline: DateTime.UtcNow));
-
 
             // Assert
             var ex = Assert.ThrowsAsync<RpcException>(async () => await call.RequestStream.WriteAsync(new HelloRequest()).DefaultTimeout());


### PR DESCRIPTION
Fixes a build failure I noticed, and makes things simpler.

https://travis-ci.org/grpc/grpc-dotnet/builds/527508838