### PR TITLE
Move workaround from Grpc.Tools to Grpc.AspNetCore.Server

### DIFF
--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -34,4 +34,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="build\**\*.targets" PackagePath="%(Identity)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Grpc.AspNetCore.Server/build/netcoreapp3.0/Grpc.AspNetCore.Server.targets
+++ b/src/Grpc.AspNetCore.Server/build/netcoreapp3.0/Grpc.AspNetCore.Server.targets
@@ -1,0 +1,9 @@
+<Project>
+  <!-- Workaround for VS Project System bug: -->
+  <!-- Duplicated items in None itemgroup without Generator attribute prevents the items -->
+  <!-- in Protobuf itemgroup with Generator attribute from triggering design time build. -->
+  <!-- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/849161?src=WorkItemMention&src-action=artifact_link -->
+  <ItemGroup Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >
+    <None Remove="@(Protobuf)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Moving the workaround from https://github.com/grpc/grpc/pull/18678 to Grpc.AspNetCore.Server instead.
