### PR TITLE
Add TE header to gRPC client requests

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview6-011694"
+    "version": "3.0.100-preview6-011799"
   }
 }

--- a/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
+++ b/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
@@ -371,7 +371,11 @@ namespace Grpc.NetCore.HttpClient.Internal
         {
             var message = new HttpRequestMessage(HttpMethod.Post, Method.FullName);
             message.Version = new Version(2, 0);
+            // User agent is optional but recommended
             message.Headers.UserAgent.Add(GrpcProtocolConstants.UserAgentHeader);
+            // TE is required by some servers, e.g. C Core
+            // A missing TE header results in servers aborting the gRPC call
+            message.Headers.TE.Add(GrpcProtocolConstants.TEHeader);
 
             if (Options.Headers != null && Options.Headers.Count > 0)
             {

--- a/src/Grpc.NetCore.HttpClient/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.NetCore.HttpClient/Internal/GrpcProtocolConstants.cs
@@ -37,6 +37,7 @@ namespace Grpc.NetCore.HttpClient.Internal
         internal const string MessageAcceptEncodingHeader = "grpc-accept-encoding";
 
         internal static readonly ProductInfoHeaderValue UserAgentHeader;
+        internal static readonly TransferCodingWithQualityHeaderValue TEHeader;
 
         static GrpcProtocolConstants()
         {
@@ -57,6 +58,8 @@ namespace Grpc.NetCore.HttpClient.Internal
             }
 
             UserAgentHeader = ProductInfoHeaderValue.Parse(userAgent);
+
+            TEHeader = new TransferCodingWithQualityHeaderValue("trailers");
         }
     }
 }

--- a/test/Grpc.NetCore.HttpClient.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.NetCore.HttpClient.Tests/AsyncUnaryCallTests.cs
@@ -67,7 +67,7 @@ namespace Grpc.NetCore.HttpClient.Tests
             Assert.AreEqual(HttpMethod.Post, httpRequestMessage.Method);
             Assert.AreEqual(new Uri("https://localhost/ServiceName/MethodName"), httpRequestMessage.RequestUri);
             Assert.AreEqual(new MediaTypeHeaderValue("application/grpc"), httpRequestMessage.Content.Headers.ContentType);
-            Assert.AreEqual(GrpcProtocolConstants.TEHeader, httpRequestMessage.Headers.TE);
+            Assert.AreEqual(GrpcProtocolConstants.TEHeader, httpRequestMessage.Headers.TE.Single());
 
             var userAgent = httpRequestMessage.Headers.UserAgent.Single();
             Assert.AreEqual(GrpcProtocolConstants.UserAgentHeader, userAgent);

--- a/test/Grpc.NetCore.HttpClient.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.NetCore.HttpClient.Tests/AsyncUnaryCallTests.cs
@@ -67,6 +67,7 @@ namespace Grpc.NetCore.HttpClient.Tests
             Assert.AreEqual(HttpMethod.Post, httpRequestMessage.Method);
             Assert.AreEqual(new Uri("https://localhost/ServiceName/MethodName"), httpRequestMessage.RequestUri);
             Assert.AreEqual(new MediaTypeHeaderValue("application/grpc"), httpRequestMessage.Content.Headers.ContentType);
+            Assert.AreEqual(GrpcProtocolConstants.TEHeader, httpRequestMessage.Headers.TE);
 
             var userAgent = httpRequestMessage.Headers.UserAgent.Single();
             Assert.AreEqual(GrpcProtocolConstants.UserAgentHeader, userAgent);

--- a/test/Grpc.NetCore.HttpClient.Tests/HeadersTests.cs
+++ b/test/Grpc.NetCore.HttpClient.Tests/HeadersTests.cs
@@ -104,7 +104,20 @@ namespace Grpc.NetCore.HttpClient.Tests
             Assert.IsNotNull(httpRequestMessage);
 
             // User-Agent is always sent
-            Assert.AreEqual(0, httpRequestMessage.Headers.Count(h => !string.Equals(h.Key, HeaderNames.UserAgent, StringComparison.OrdinalIgnoreCase)));
+            Assert.AreEqual(0, httpRequestMessage.Headers.Count(h =>
+            {
+                if (string.Equals(h.Key, HeaderNames.UserAgent, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                if (string.Equals(h.Key, HeaderNames.TE, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                return true;
+            }));
         }
     }
 }


### PR DESCRIPTION
Fixes many interop tests in https://github.com/grpc/grpc/pull/18897

Related https://github.com/dotnet/corefx/issues/37446#issuecomment-490332045