### PR TITLE
Fallback to reading status from headers

### DIFF
--- a/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
+++ b/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
@@ -493,15 +493,28 @@ namespace Grpc.NetCore.HttpClient.Internal
 
         private static Status GetStatusCore(HttpResponseMessage httpResponseMessage)
         {
-            // A gRPC server may return trailers in the headers when the response stream is empty
+            // A gRPC server may return gRPC status in the headers when the response stream is empty
             // For example, C Core server returns them together in the empty_stream interop test
-            var grpcStatus = GetHeaderValue(httpResponseMessage.TrailingHeaders, GrpcProtocolConstants.StatusTrailer)
-                ?? GetHeaderValue(httpResponseMessage.Headers, GrpcProtocolConstants.StatusTrailer);
+            HttpResponseHeaders statusHeaders;
 
-            // grpc-status is a required trailer
-            if (grpcStatus == null)
+            var grpcStatus = GetHeaderValue(httpResponseMessage.TrailingHeaders, GrpcProtocolConstants.StatusTrailer);
+            if (grpcStatus != null)
             {
-                throw new InvalidOperationException("Response did not have a grpc-status trailer.");
+                statusHeaders = httpResponseMessage.TrailingHeaders;
+            }
+            else
+            {
+                grpcStatus = GetHeaderValue(httpResponseMessage.Headers, GrpcProtocolConstants.StatusTrailer);
+
+                // grpc-status is a required trailer
+                if (grpcStatus != null)
+                {
+                    statusHeaders = httpResponseMessage.Headers;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Response did not have a grpc-status trailer.");
+                }
             }
 
             int statusValue;
@@ -511,8 +524,7 @@ namespace Grpc.NetCore.HttpClient.Internal
             }
 
             // grpc-message is optional
-            var grpcMessage = GetHeaderValue(httpResponseMessage.TrailingHeaders, GrpcProtocolConstants.MessageTrailer)
-                ?? GetHeaderValue(httpResponseMessage.Headers, GrpcProtocolConstants.MessageTrailer);
+            var grpcMessage = GetHeaderValue(statusHeaders, GrpcProtocolConstants.MessageTrailer);
 
             if (!string.IsNullOrEmpty(grpcMessage))
             {

--- a/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
+++ b/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
@@ -493,7 +493,11 @@ namespace Grpc.NetCore.HttpClient.Internal
 
         private static Status GetStatusCore(HttpResponseMessage httpResponseMessage)
         {
-            string grpcStatus = GetHeaderValue(httpResponseMessage.TrailingHeaders, GrpcProtocolConstants.StatusTrailer);
+            // A gRPC server may return trailers in the headers when the response stream is empty
+            // For example, C Core server returns them together in the empty_stream interop test
+            var grpcStatus = GetHeaderValue(httpResponseMessage.TrailingHeaders, GrpcProtocolConstants.StatusTrailer)
+                ?? GetHeaderValue(httpResponseMessage.Headers, GrpcProtocolConstants.StatusTrailer);
+
             // grpc-status is a required trailer
             if (grpcStatus == null)
             {
@@ -507,7 +511,9 @@ namespace Grpc.NetCore.HttpClient.Internal
             }
 
             // grpc-message is optional
-            string grpcMessage = GetHeaderValue(httpResponseMessage.TrailingHeaders, GrpcProtocolConstants.MessageTrailer);
+            var grpcMessage = GetHeaderValue(httpResponseMessage.TrailingHeaders, GrpcProtocolConstants.MessageTrailer)
+                ?? GetHeaderValue(httpResponseMessage.Headers, GrpcProtocolConstants.MessageTrailer);
+
             if (!string.IsNullOrEmpty(grpcMessage))
             {
                 // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses

--- a/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
+++ b/src/Grpc.NetCore.HttpClient/Internal/GrpcCall.cs
@@ -524,6 +524,7 @@ namespace Grpc.NetCore.HttpClient.Internal
             }
 
             // grpc-message is optional
+            // Always read the gRPC message from the same headers collection as the status
             var grpcMessage = GetHeaderValue(statusHeaders, GrpcProtocolConstants.MessageTrailer);
 
             if (!string.IsNullOrEmpty(grpcMessage))

--- a/src/Grpc.NetCore.HttpClient/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.NetCore.HttpClient/Internal/GrpcProtocolHelpers.cs
@@ -91,7 +91,12 @@ namespace Grpc.NetCore.HttpClient.Internal
                 // ASP.NET Core includes pseudo headers in the set of request headers
                 // whereas, they are not in gRPC implementations. We will filter them
                 // out when we construct the list of headers on the context.
-                if (header.Key.StartsWith(":", StringComparison.Ordinal))
+                if (header.Key.StartsWith(':'))
+                {
+                    continue;
+                }
+                // Exclude grpc related headers
+                if (header.Key.StartsWith("grpc-", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/test/Grpc.NetCore.HttpClient.Tests/AsyncServerStreamingCallTests.cs
+++ b/test/Grpc.NetCore.HttpClient.Tests/AsyncServerStreamingCallTests.cs
@@ -17,12 +17,14 @@
 #endregion
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Greet;
 using Grpc.Core;
+using Grpc.NetCore.HttpClient.Internal;
 using Grpc.NetCore.HttpClient.Tests.Infrastructure;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
@@ -36,17 +38,8 @@ namespace Grpc.NetCore.HttpClient.Tests
         public async Task AsyncServerStreamingCall_NoContent_NoMessagesReturned()
         {
             // Arrange
-            HttpRequestMessage httpRequestMessage = null;
-
             var httpClient = TestHelpers.CreateTestClient(request =>
             {
-                httpRequestMessage = request;
-
-                HelloReply reply = new HelloReply
-                {
-                    Message = "Hello world"
-                };
-
                 return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, new ByteArrayContent(Array.Empty<byte>())));
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);
@@ -175,6 +168,35 @@ namespace Grpc.NetCore.HttpClient.Tests
             var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await call.ResponseStream.MoveNext(CancellationToken.None).DefaultTimeout());
 
             Assert.AreEqual("Bad gRPC response. Expected HTTP status code 200. Got status code: 404", ex.Message);
+        }
+
+        [Test]
+        public async Task AsyncServerStreamingCall_NoContent_TrailersReturnedWithHeaders()
+        {
+            // Arrange
+            HttpResponseMessage responseMessage = null;
+            var httpClient = TestHelpers.CreateTestClient(request =>
+            {
+                responseMessage = ResponseUtils.CreateResponse(HttpStatusCode.OK, new ByteArrayContent(Array.Empty<byte>()), grpcStatusCode: null);
+                responseMessage.Headers.Add(GrpcProtocolConstants.StatusTrailer, StatusCode.OK.ToString("D"));
+                responseMessage.Headers.Add(GrpcProtocolConstants.MessageTrailer, "Detail!");
+                return Task.FromResult(responseMessage);
+            });
+            var invoker = new HttpClientCallInvoker(httpClient);
+
+            // Act
+            var call = invoker.AsyncServerStreamingCall<HelloRequest, HelloReply>(TestHelpers.ServiceMethod, null, new CallOptions(), new HelloRequest());
+            var headers = await call.ResponseHeadersAsync;
+            await call.ResponseStream.MoveNext(CancellationToken.None);
+
+            // Assert
+            Assert.IsFalse(responseMessage.TrailingHeaders.Any()); // sanity check that there are no trailers
+
+            Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
+            Assert.AreEqual("Detail!", call.GetStatus().Detail);
+
+            Assert.AreEqual(0, headers.Count);
+            Assert.AreEqual(0, call.GetTrailers().Count);
         }
     }
 }

--- a/test/Grpc.NetCore.HttpClient.Tests/AsyncServerStreamingCallTests.cs
+++ b/test/Grpc.NetCore.HttpClient.Tests/AsyncServerStreamingCallTests.cs
@@ -200,7 +200,7 @@ namespace Grpc.NetCore.HttpClient.Tests
         }
 
         [Test]
-        public async Task AsyncServerStreamingCall_TrailerInFooterAndStatusMessageInHeader_IgnoreStatusMessage()
+        public async Task AsyncServerStreamingCall_StatusInFooterAndMessageInHeader_IgnoreMessage()
         {
             // Arrange
             HttpResponseMessage responseMessage = null;

--- a/testassets/FunctionalTestsWebsite/Services/AuthorizedGreeter.cs
+++ b/testassets/FunctionalTestsWebsite/Services/AuthorizedGreeter.cs
@@ -22,7 +22,6 @@ using Authorize;
 using Grpc.Core;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http.Endpoints;
 
 namespace FunctionalTestsWebsite.Services
 {


### PR DESCRIPTION
Fix more interop test scenarios.

Double check that this is expected - https://github.com/grpc/grpc/issues/19003