### PR TITLE
Run C Core on .NET Core server tests with managed client

### DIFF
--- a/kokoro/interop.sh
+++ b/kokoro/interop.sh
@@ -27,4 +27,4 @@ cd ../grpc
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/run_tests/run_interop_tests.py -l aspnetcore csharp -s aspnetcore csharpcoreclr --use_docker --internal_ci -t -j 8
+tools/run_tests/run_interop_tests.py -l aspnetcore csharpcoreclr -s aspnetcore csharpcoreclr --use_docker --internal_ci -t -j 8

--- a/kokoro/interop.sh
+++ b/kokoro/interop.sh
@@ -27,4 +27,4 @@ cd ../grpc
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/run_tests/run_interop_tests.py -l csharp aspnetcore -s aspnetcore --use_docker --internal_ci -t -j 8
+tools/run_tests/run_interop_tests.py -l aspnetcore csharp -s aspnetcore csharpcoreclr --use_docker --internal_ci -t -j 8


### PR DESCRIPTION
Include C Core server so we have tests of the managed client will running against it in local CI.