### PR TITLE
Build interceptor pipeline once

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
@@ -32,28 +32,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
         where TService : class
     {
         private readonly DuplexStreamingServerMethod<TService, TRequest, TResponse> _invoker;
-        private static readonly Func<InterceptorRegistration, DuplexStreamingServerMethod<TRequest, TResponse>, DuplexStreamingServerMethod<TRequest, TResponse>> BuildInvoker = (interceptorRegistration, next) =>
-        {
-            return async (requestStream, responseStream, context) =>
-            {
-                var interceptorActivator = (IGrpcInterceptorActivator)context.GetHttpContext().RequestServices.GetRequiredService(interceptorRegistration.ActivatorType);
-                var interceptorInstance = interceptorActivator.Create(interceptorRegistration.Args);
-
-                if (interceptorInstance == null)
-                {
-                    throw new InvalidOperationException($"Could not construct Interceptor instance for type {interceptorRegistration.Type.FullName}");
-                }
-
-                try
-                {
-                    await interceptorInstance.DuplexStreamingServerHandler(requestStream, responseStream, context, next);
-                }
-                finally
-                {
-                    interceptorActivator.Release(interceptorInstance);
-                }
-            };
-        };
+        private readonly DuplexStreamingServerMethod<TRequest, TResponse>? _pipelineInvoker;
 
         public DuplexStreamingServerCallHandler(
             Method<TRequest, TResponse> method, 
@@ -63,6 +42,34 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             : base(method, serviceOptions, loggerFactory)
         {
             _invoker = invoker;
+
+            if (!ServiceOptions.Interceptors.IsEmpty)
+            {
+                DuplexStreamingServerMethod<TRequest, TResponse> resolvedInvoker = async (requestStream, responseStream, resolvedContext) =>
+                {
+                    var activator = resolvedContext.GetHttpContext().RequestServices.GetRequiredService<IGrpcServiceActivator<TService>>();
+                    TService? service = null;
+                    try
+                    {
+                        service = activator.Create();
+                        await _invoker(
+                            service,
+                            requestStream,
+                            responseStream,
+                            resolvedContext);
+                    }
+                    finally
+                    {
+                        if (service != null)
+                        {
+                            activator.Release(service);
+                        }
+                    }
+                };
+
+                var interceptorPipeline = new InterceptorPipelineBuilder<TRequest, TResponse>(ServiceOptions.Interceptors);
+                _pipelineInvoker = interceptorPipeline.DuplexStreamingPipeline(resolvedInvoker);
+            }
         }
 
         protected override async Task HandleCallAsyncCore(HttpContext httpContext)
@@ -71,15 +78,14 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
 
             GrpcProtocolHelpers.AddProtocolHeaders(httpContext.Response);
 
-            var activator = httpContext.RequestServices.GetRequiredService<IGrpcServiceActivator<TService>>();
-            TService? service = null;
-
             try
             {
                 serverCallContext.Initialize();
 
-                if (ServiceOptions.Interceptors.IsEmpty)
+                if (_pipelineInvoker == null)
                 {
+                    var activator = httpContext.RequestServices.GetRequiredService<IGrpcServiceActivator<TService>>();
+                    TService? service = null;
                     try
                     {
                         service = activator.Create();
@@ -99,33 +105,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
                 }
                 else
                 {
-                    DuplexStreamingServerMethod<TRequest, TResponse> resolvedInvoker = async (requestStream, responseStream, resolvedContext) =>
-                    {
-                        try
-                        {
-                            service = activator.Create();
-                            await _invoker(
-                                service,
-                                requestStream,
-                                responseStream,
-                                resolvedContext);
-                        }
-                        finally
-                        {
-                            if (service != null)
-                            {
-                                activator.Release(service);
-                            }
-                        }
-                    };
-
-                    // The list is reversed during construction so the first interceptor is built last and invoked first
-                    for (var i = ServiceOptions.Interceptors.Count - 1; i >= 0; i--)
-                    {
-                        resolvedInvoker = BuildInvoker(ServiceOptions.Interceptors[i], resolvedInvoker);
-                    }
-
-                    await resolvedInvoker(
+                    await _pipelineInvoker(
                         new HttpContextStreamReader<TRequest>(serverCallContext, Method.RequestMarshaller.Deserializer),
                         new HttpContextStreamWriter<TResponse>(serverCallContext, Method.ResponseMarshaller.Serializer),
                         serverCallContext);

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/InterceptorPipelineBuilder.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/InterceptorPipelineBuilder.cs
@@ -1,0 +1,160 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Grpc.AspNetCore.Server.Internal.CallHandlers
+{
+    internal class InterceptorPipelineBuilder<TRequest, TResponse>
+        where TRequest : class
+        where TResponse : class
+    {
+        private readonly InterceptorCollection _interceptors;
+
+        public InterceptorPipelineBuilder(InterceptorCollection interceptors)
+        {
+            _interceptors = interceptors;
+        }
+
+        public ClientStreamingServerMethod<TRequest, TResponse> ClientStreamingPipeline(ClientStreamingServerMethod<TRequest, TResponse> innerInvoker)
+        {
+            return BuildPipeline(innerInvoker, BuildInvoker);
+
+            static ClientStreamingServerMethod<TRequest, TResponse> BuildInvoker(InterceptorRegistration interceptorRegistration, ClientStreamingServerMethod<TRequest, TResponse> next)
+            {
+                return async (requestStream, context) =>
+                {
+                    var interceptorActivator = (IGrpcInterceptorActivator)context.GetHttpContext().RequestServices.GetRequiredService(interceptorRegistration.ActivatorType);
+                    var interceptorInstance = CreateInterceptor(interceptorRegistration, interceptorActivator);
+
+                    try
+                    {
+                        return await interceptorInstance.ClientStreamingServerHandler(requestStream, context, next);
+                    }
+                    finally
+                    {
+                        interceptorActivator.Release(interceptorInstance);
+                    }
+                };
+            }
+        }
+
+        internal DuplexStreamingServerMethod<TRequest, TResponse> DuplexStreamingPipeline(DuplexStreamingServerMethod<TRequest, TResponse> innerInvoker)
+        {
+            return BuildPipeline(innerInvoker, BuildInvoker);
+
+            static DuplexStreamingServerMethod<TRequest, TResponse> BuildInvoker(InterceptorRegistration interceptorRegistration, DuplexStreamingServerMethod<TRequest, TResponse> next)
+            {
+                return async (requestStream, responseStream, context) =>
+                {
+                    var interceptorActivator = (IGrpcInterceptorActivator)context.GetHttpContext().RequestServices.GetRequiredService(interceptorRegistration.ActivatorType);
+                    var interceptorInstance = CreateInterceptor(interceptorRegistration, interceptorActivator);
+
+                    try
+                    {
+                        await interceptorInstance.DuplexStreamingServerHandler(requestStream, responseStream, context, next);
+                    }
+                    finally
+                    {
+                        interceptorActivator.Release(interceptorInstance);
+                    }
+                };
+            }
+        }
+
+        internal ServerStreamingServerMethod<TRequest, TResponse> ServerStreamingPipeline(ServerStreamingServerMethod<TRequest, TResponse> innerInvoker)
+        {
+            return BuildPipeline(innerInvoker, BuildInvoker);
+
+            static ServerStreamingServerMethod<TRequest, TResponse> BuildInvoker(InterceptorRegistration interceptorRegistration, ServerStreamingServerMethod<TRequest, TResponse> next)
+            {
+                return async (request, responseStream, context) =>
+                {
+                    var interceptorActivator = (IGrpcInterceptorActivator)context.GetHttpContext().RequestServices.GetRequiredService(interceptorRegistration.ActivatorType);
+                    var interceptorInstance = interceptorActivator.Create(interceptorRegistration.Args);
+
+                    if (interceptorInstance == null)
+                    {
+                        throw new InvalidOperationException($"Could not construct Interceptor instance for type {interceptorRegistration.Type.FullName}");
+                    }
+
+                    try
+                    {
+                        await interceptorInstance.ServerStreamingServerHandler(request, responseStream, context, next);
+                    }
+                    finally
+                    {
+                        interceptorActivator.Release(interceptorInstance);
+                    }
+                };
+            }
+        }
+
+        internal UnaryServerMethod<TRequest, TResponse> UnaryPipeline(UnaryServerMethod<TRequest, TResponse> innerInvoker)
+        {
+            return BuildPipeline(innerInvoker, BuildInvoker);
+
+            static UnaryServerMethod<TRequest, TResponse> BuildInvoker(InterceptorRegistration interceptorRegistration, UnaryServerMethod<TRequest, TResponse> next)
+            {
+                return async (request, context) =>
+                {
+                    var interceptorActivator = (IGrpcInterceptorActivator)context.GetHttpContext().RequestServices.GetRequiredService(interceptorRegistration.ActivatorType);
+                    var interceptorInstance = CreateInterceptor(interceptorRegistration, interceptorActivator);
+
+                    try
+                    {
+                        return await interceptorInstance.UnaryServerHandler(request, context, next);
+                    }
+                    finally
+                    {
+                        interceptorActivator.Release(interceptorInstance);
+                    }
+                };
+            }
+        }
+
+        private T BuildPipeline<T>(T innerInvoker, Func<InterceptorRegistration, T, T> wrapInvoker)
+        {
+            // The inner invoker will create the service instance and invoke the method
+            var resolvedInvoker = innerInvoker;
+
+            // The list is reversed during construction so the first interceptor is built last and invoked first
+            for (var i = _interceptors.Count - 1; i >= 0; i--)
+            {
+                resolvedInvoker = wrapInvoker(_interceptors[i], resolvedInvoker);
+            }
+
+            return resolvedInvoker;
+        }
+
+        private static Interceptor CreateInterceptor(InterceptorRegistration interceptorRegistration, IGrpcInterceptorActivator interceptorActivator)
+        {
+            var interceptorInstance = interceptorActivator.Create(interceptorRegistration.Args);
+
+            if (interceptorInstance == null)
+            {
+                throw new InvalidOperationException($"Could not construct Interceptor instance for type {interceptorRegistration.Type.FullName}");
+            }
+
+            return interceptorInstance;
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcInterceptorActivatorTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcInterceptorActivatorTests.cs
@@ -126,6 +126,22 @@ namespace Grpc.AspNetCore.Server.Tests
         }
 
         [Test]
+        public void DisposeCalledForMultipleDisposableServicesCreatedByActivator()
+        {
+            var interceptorActivator = new DefaultGrpcInterceptorActivator<DisposableGrpcInterceptor>(Mock.Of<IServiceProvider>());
+            var interceptor1 = (DisposableGrpcInterceptor)interceptorActivator.Create();
+            var interceptor2 = (DisposableGrpcInterceptor)interceptorActivator.Create();
+            var interceptor3 = (DisposableGrpcInterceptor)interceptorActivator.Create();
+            interceptorActivator.Release(interceptor3);
+            interceptorActivator.Release(interceptor2);
+            interceptorActivator.Release(interceptor1);
+
+            Assert.True(interceptor1.Disposed);
+            Assert.True(interceptor2.Disposed);
+            Assert.True(interceptor3.Disposed);
+        }
+
+        [Test]
         public void DisposeNotCalledForUndisposableServicesCreatedByActivator()
         {
             var interceptorActivator = new DefaultGrpcInterceptorActivator<GrpcInterceptor>(Mock.Of<IServiceProvider>());


### PR DESCRIPTION
Interceptors don't change so we can build interceptor pipeline once for each method on startup.

Also optimize the activator to only create a hashset if needed.