### PR TITLE
Make IGrpcMethodModelFactory public to allow non-reflection based method binding.

### DIFF
--- a/src/Grpc.AspNetCore.Server/GrpcBindingOptions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcBindingOptions.cs
@@ -32,7 +32,9 @@ namespace Grpc.AspNetCore.Server
         /// </summary>
         public Action<ServiceBinderBase, TService?>? BindAction { get; set; }
 
-        // Currently internal. It is set in tests via InternalVisibleTo. Can be made public if there is demand for it
-        internal IGrpcMethodModelFactory<TService>? ModelFactory { get; set; }
+        /// <summary>
+        /// Gets or sets a factory for creating models that describe and invoke service methods on .NET types.
+        /// </summary>
+        public IGrpcMethodModelFactory<TService>? ModelFactory { get; set; }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/IGrpcMethodModelFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/IGrpcMethodModelFactory.cs
@@ -26,23 +26,71 @@ namespace Grpc.AspNetCore.Server.Internal
     /// An interface for creating models that describe and invoke service methods on .NET types.
     /// </summary>
     /// <typeparam name="TService">The service type.</typeparam>
-    internal interface IGrpcMethodModelFactory<TService>
+    public interface IGrpcMethodModelFactory<TService>
     {
+        /// <summary>
+        /// Creates a model that describe and invoke a unary operation.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="method">Unary remote method description.</param>
+        /// <returns>A model that describe and invoke a unary operation.</returns>
         GrpcEndpointModel<UnaryServerMethod<TService, TRequest, TResponse>> CreateUnaryModel<TRequest, TResponse>(Method<TRequest, TResponse> method);
+
+
+        /// <summary>
+        /// Creates a model that describe and invoke a client streaming operation.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="method">Client streaming remote method description.</param>
+        /// <returns>A model that describe and invoke a client streaming operation.</returns>
         GrpcEndpointModel<ClientStreamingServerMethod<TService, TRequest, TResponse>> CreateClientStreamingModel<TRequest, TResponse>(Method<TRequest, TResponse> method);
+
+        /// <summary>
+        /// Creates a model that describe and invoke a server streaming operation.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="method">Server streaming remote method description.</param>
+        /// <returns>A model that describe and invoke a server streaming operation.</returns>
         GrpcEndpointModel<ServerStreamingServerMethod<TService, TRequest, TResponse>> CreateServerStreamingModel<TRequest, TResponse>(Method<TRequest, TResponse> method);
+
+        /// <summary>
+        /// Creates a model that describe and invoke a duplex streaming operation.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="method">Duplex streaming remote method description.</param>
+        /// <returns>A model that describe and invoke a duplex streaming operation.</returns>
         GrpcEndpointModel<DuplexStreamingServerMethod<TService, TRequest, TResponse>> CreateDuplexStreamingModel<TRequest, TResponse>(Method<TRequest, TResponse> method);
     }
 
-    internal class GrpcEndpointModel<TInvoker> where TInvoker : Delegate
+    /// <summary>
+    /// Describes a service method on a .NET type and provides a method invoker.
+    /// </summary>
+    /// <typeparam name="TInvoker">The method invoker delegate.</typeparam>
+    public class GrpcEndpointModel<TInvoker> where TInvoker : Delegate
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="invoker"></param>
+        /// <param name="metadata"></param>
         public GrpcEndpointModel(TInvoker invoker, List<object> metadata)
         {
             Invoker = invoker;
             Metadata = metadata;
         }
 
+        /// <summary>
+        /// Gets a delegate that invokes the .NET method. 
+        /// </summary>
         public TInvoker Invoker { get; }
+        
+        /// <summary>
+        /// Gets metadata related to the service method.
+        /// </summary>
         public List<object> Metadata { get; }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/ServerMethods.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerMethods.cs
@@ -24,11 +24,53 @@ namespace Grpc.AspNetCore.Server.Internal
     // Open delegate (the first argument is the TService instance) versions of the service call types.
     // Needed because methods are executed with a new service instance each request.
 
-    internal delegate Task<TResponse> UnaryServerMethod<TService, TRequest, TResponse>(TService service, TRequest request, ServerCallContext serverCallContext);
+    /// <summary>
+    /// Defines a delegate that can be used to invoke a unary operation on a .NET method.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <typeparam name="TRequest">The request type.</typeparam>
+    /// <typeparam name="TResponse">The response type.</typeparam>
+    /// <param name="service">Target service instance.</param>
+    /// <param name="request">Request data</param>
+    /// <param name="serverCallContext">Context for the server side call.</param>
+    /// <returns>The operation response.</returns>
+    public delegate Task<TResponse> UnaryServerMethod<TService, TRequest, TResponse>(TService service, TRequest request, ServerCallContext serverCallContext);
 
-    internal delegate Task<TResponse> ClientStreamingServerMethod<TService, TRequest, TResponse>(TService service, IAsyncStreamReader<TRequest> stream, ServerCallContext serverCallContext);
+    /// <summary>
+    /// Defines a delegate that can be used to invoke a client streaming operation on a .NET method.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <typeparam name="TRequest">The request type.</typeparam>
+    /// <typeparam name="TResponse">The response type.</typeparam>
+    /// <param name="service">Target service instance.</param>
+    /// <param name="stream">Request stream.</param>
+    /// <param name="serverCallContext">Context for the server side call.</param>
+    /// <returns>The operation response.</returns>
+    public delegate Task<TResponse> ClientStreamingServerMethod<TService, TRequest, TResponse>(TService service, IAsyncStreamReader<TRequest> stream, ServerCallContext serverCallContext);
 
-    internal delegate Task ServerStreamingServerMethod<TService, TRequest, TResponse>(TService service, TRequest request, IServerStreamWriter<TResponse> stream, ServerCallContext serverCallContext);
+    /// <summary>
+    /// Defines a delegate that can be used to invoke a server streaming operation on a .NET method.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <typeparam name="TRequest">The request type.</typeparam>
+    /// <typeparam name="TResponse">The response type.</typeparam>
+    /// <param name="service">Target service instance.</param>
+    /// <param name="request">Request data</param>
+    /// <param name="stream">Response stream</param>
+    /// <param name="serverCallContext">Context for the server side call.</param>
+    /// <returns>The operation response.</returns>
+    public delegate Task ServerStreamingServerMethod<TService, TRequest, TResponse>(TService service, TRequest request, IServerStreamWriter<TResponse> stream, ServerCallContext serverCallContext);
 
-    internal delegate Task DuplexStreamingServerMethod<TService, TRequest, TResponse>(TService service, IAsyncStreamReader<TRequest> input, IServerStreamWriter<TResponse> output, ServerCallContext serverCallContext);
+    /// <summary>
+    /// Defines a delegate that can be used to invoke a duplex streaming operation on a .NET method.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <typeparam name="TRequest">The request type.</typeparam>
+    /// <typeparam name="TResponse">The response type.</typeparam>
+    /// <param name="service">Target service instance.</param>
+    /// <param name="input">Request stream.</param>
+    /// <param name="output">Response stream.</param>
+    /// <param name="serverCallContext">Context for the server side call.</param>
+    /// <returns>The operation response.</returns>
+    public delegate Task DuplexStreamingServerMethod<TService, TRequest, TResponse>(TService service, IAsyncStreamReader<TRequest> input, IServerStreamWriter<TResponse> output, ServerCallContext serverCallContext);
 }


### PR DESCRIPTION
We have just published a preview of a code first implementation of gRPC at [SciTechSoftware/SciTech.Rpc](/SciTechSoftware/SciTech.Rpc). It is based on grpc-dotnet for the ASP.NET Core server side implementation. To allow gRPC HTTP/2 calls to be forwarded to our implementation methods we need to provide our own GrpcEndpointModels. Unfortunately, GrpcEndpointModel and IGrpcMethodModelFactory are internal in grpc-dotnet.

This pull request changes the accessibility from internal to public for IGrpcMethodModelFactory and related types and properties. Considering the comment on GrpcBindingOptions.ModelFactory ("Currently internal. It is set in tests via InternalVisibleTo. Can be made public if there is demand for it"), you may be willing to make it public.

You can see how SciTech.Rpc implements IGrpcMethodModelFactory in [NetGrpcEndpointRouteBuilderExtensions.cs](/SciTechSoftware/SciTech.Rpc/blob/master/src/SciTech.Rpc.NetGrpc/NetGrpc/Server/NetGrpcEndpointRouteBuilderExtensions.cs)

The IGrpcMethodModelFactory and GrpcEndpointModel  types are still in the "Internal" namespace. If you believe they should be moved out of "Internal" due to this request, I can modify the pull request to do that.

Best regards,

Andreas Suurkuusk
SciTech Software AB

