### PR TITLE
Remove NUnit dependency from InteropClient

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <BenchmarkDotNetPackageVersion>0.11.3</BenchmarkDotNetPackageVersion>
+    <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
     <ConfigureAwaitCheckerAnalyzerPackageVersion>3.0.0</ConfigureAwaitCheckerAnalyzerPackageVersion>
     <GoogleProtobufPackageVersion>3.7.0</GoogleProtobufPackageVersion>
     <GrpcPackageVersion>1.21.0-pre1</GrpcPackageVersion>

--- a/test/Grpc.AspNetCore.Server.Tests/PercentEncodingHelpersTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/PercentEncodingHelpersTests.cs
@@ -46,6 +46,31 @@ namespace Grpc.AspNetCore.Server.Tests
             Assert.AreEqual(expectedDecodedValue, decodedValue);
         }
 
+        [Test]
+        public void StartOfHeaderChar_Roundtrip_Success()
+        {
+            // Arrange & Act
+            var encodedValue = PercentEncodingHelpers.PercentEncode("\x01");
+            var decodedValue = Uri.UnescapeDataString("%01");
+
+            // Assert
+            Assert.AreEqual("%01", encodedValue);
+            Assert.AreEqual("\x01", decodedValue);
+
+        }
+
+        [Test]
+        public void ShiftInChar_Roundtrip_Success()
+        {
+            // Arrange & Act
+            var encodedValue = PercentEncodingHelpers.PercentEncode("\x0f");
+            var decodedValue = Uri.UnescapeDataString("%0F");
+
+            // Assert
+            Assert.AreEqual("%0F", encodedValue);
+            Assert.AreEqual("\x0f", decodedValue);
+        }
+
         // This test double-checks that UnescapeDataString doesn't thrown when given odd data
         [TestCase("%", "%")]
         [TestCase("%A", "%A")]
@@ -126,10 +151,8 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             new TestCaseData("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~"),
             new TestCaseData("\x00", "%00"),
-            new TestCaseData("\x01", "%01"),
             new TestCaseData("a b", "a b"),
             new TestCaseData(" b", " b"),
-            new TestCaseData("\x0f", "%0F"),
             new TestCaseData("\xff", "%C3%BF"),
             new TestCaseData("\xee", "%C3%AE"),
             new TestCaseData("%2", "%252"),

--- a/testassets/InteropTestsClient/Assert.cs
+++ b/testassets/InteropTestsClient/Assert.cs
@@ -1,0 +1,119 @@
+﻿#region Copyright notice and license
+
+// Copyright 2015-2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InteropTestsClient
+{
+    internal static class Assert
+    {
+        public static void IsTrue(bool condition)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException("Expected true but got false.");
+            }
+        }
+
+        public static void IsFalse(bool condition)
+        {
+            if (condition)
+            {
+                throw new InvalidOperationException("Expected false but got true.");
+            }
+        }
+
+        public static void AreEqual(object expected, object actual)
+        {
+            if (!Equals(expected, actual))
+            {
+                throw new InvalidOperationException($"Expected {expected} but got {actual}.");
+            }
+        }
+
+        public static void IsNotNull(object value)
+        {
+            if (value == null)
+            {
+                throw new InvalidOperationException("Expected not null but got null.");
+            }
+        }
+
+        public static void Fail()
+        {
+            throw new InvalidOperationException("Failure assert.");
+        }
+
+        public static TException ThrowsAsync<TException>(Func<Task> action) where TException : Exception
+        {
+            return Throws<TException>(() => action().GetAwaiter().GetResult());
+        }
+
+        public static TException Throws<TException>(Action action) where TException : Exception
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                if (ex.GetType() == typeof(TException))
+                {
+                    return (TException)ex;
+                }
+
+                throw new InvalidOperationException($"Expected ${typeof(TException)} but got ${ex.GetType()}.");
+            }
+
+            throw new InvalidOperationException("No exception thrown.");
+        }
+
+        public static void Contains(object expected, ICollection actual)
+        {
+            foreach (var item in actual)
+            {
+                if (Equals(item, expected))
+                {
+                    return;
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find {expected} in the collection.");
+        }
+    }
+
+    internal static class CollectionAssert
+    {
+        public static void AreEqual(IList expected, IList actual)
+        {
+            if (expected.Count != actual.Count)
+            {
+                throw new InvalidOperationException($"Collection lengths differ. {expected.Count} but got {actual.Count}.");
+            }
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.AreEqual(expected[i], actual[i]);
+            }
+        }
+    }
+}

--- a/testassets/InteropTestsClient/InteropClient.cs
+++ b/testassets/InteropTestsClient/InteropClient.cs
@@ -37,7 +37,6 @@ using Grpc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
-using NUnit.Framework;
 
 namespace InteropTestsClient
 {
@@ -338,7 +337,7 @@ namespace InteropTestsClient
             using (var call = client.StreamingOutputCall(request))
             {
                 var responseList = await call.ResponseStream.ToListAsync();
-                CollectionAssert.AreEqual(bodySizes, responseList.Select((item) => item.Payload.Body.Length));
+                CollectionAssert.AreEqual(bodySizes, responseList.Select((item) => item.Payload.Body.Length).ToList());
             }
             Console.WriteLine("Passed!");
         }
@@ -421,8 +420,8 @@ namespace InteropTestsClient
             var response = client.UnaryCall(request);
 
             Assert.AreEqual(314159, response.Payload.Body.Length);
-            Assert.False(string.IsNullOrEmpty(response.OauthScope));
-            Assert.True(oauthScope.Contains(response.OauthScope));
+            Assert.IsFalse(string.IsNullOrEmpty(response.OauthScope));
+            Assert.IsTrue(oauthScope.Contains(response.OauthScope));
             Assert.AreEqual(defaultServiceAccount, response.Username);
             Console.WriteLine("Passed!");
         }
@@ -461,8 +460,8 @@ namespace InteropTestsClient
 
             var response = client.UnaryCall(request, new CallOptions(credentials: credentials));
 
-            Assert.False(string.IsNullOrEmpty(response.OauthScope));
-            Assert.True(oauthScope.Contains(response.OauthScope));
+            Assert.IsFalse(string.IsNullOrEmpty(response.OauthScope));
+            Assert.IsTrue(oauthScope.Contains(response.OauthScope));
             Assert.AreEqual(GetEmailFromServiceAccountFile(), response.Username);
             Console.WriteLine("Passed!");
         }

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -15,15 +15,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <PackageReference Include="CommandLineParser" Version="2.3.0" />
+    <PackageReference Include="CommandLineParser" Version="$(CommandLineParserPackageVersion)" />
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Grpc.Auth" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="nunit" Version="$(NunitPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
 
     <ProjectReference Include="..\..\src\Grpc.NetCore.HttpClient\Grpc.NetCore.HttpClient.csproj" />
   </ItemGroup>


### PR DESCRIPTION
An NUnit dependency in a non-test project was causing an error in the VS2019 test discovery.

Replace NUnit with some basic custom asserts.