### PR TITLE
Update runtime and use stackalloc again

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview6-012025"
+    "version": "3.0.100-preview6-012105"
   }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -42,7 +42,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
         {
             if (GrpcProtocolHelpers.IsInvalidContentType(httpContext, out var error))
             {
-                GrpcProtocolHelpers.SendHttpError(httpContext.Response, StatusCodes.Status415UnsupportedMediaType, StatusCode.Internal, error);
+                GrpcProtocolHelpers.SendHttpError(httpContext.Response, StatusCodes.Status415UnsupportedMediaType, StatusCode.Internal, error!);
                 return Task.CompletedTask;
             }
 

--- a/src/Grpc.AspNetCore.Server/Internal/PercentEncodingHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PercentEncodingHelpers.cs
@@ -78,7 +78,7 @@ namespace Grpc.AspNetCore.Server.Internal
 
             static void Encode(Span<char> span, string s)
             {
-                Span<byte> unicodeBytesBuffer = new byte[MaxUnicodeCharsReallocate * MaxUtf8BytesPerUnicodeChar];
+                Span<byte> unicodeBytesBuffer = stackalloc byte[MaxUnicodeCharsReallocate * MaxUtf8BytesPerUnicodeChar];
 
                 var writePosition = 0;
                 for (var i = 0; i < s.Length; i++)

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -171,7 +171,7 @@ namespace Grpc.AspNetCore.Server.Internal
             }
             else
             {
-                Span<byte> headerData = new byte[HeaderSize];
+                Span<byte> headerData = stackalloc byte[HeaderSize];
                 buffer.Slice(0, HeaderSize).CopyTo(headerData);
 
                 compressed = ReadCompressedFlag(headerData[0]);


### PR DESCRIPTION
Revert the stackalloc workaround now that we have a new Roslyn compiler with the latest SDK. 

Addresses the removal of the workaround in https://github.com/grpc/grpc-dotnet/issues/15.