### PR TITLE
Update roslyn compiler for VS workloads

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,4 +16,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- TODO (johluo): Remove this workaround when VS updates -->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,6 +7,7 @@
     <GrpcPackageVersion>1.21.0-pre1</GrpcPackageVersion>
     <MicrosoftAspNetCorePackageVersion>3.0.0-preview6-19265-03</MicrosoftAspNetCorePackageVersion>
     <MicrosoftExtensionsPackageVersion>3.0.0-preview6.19260.1</MicrosoftExtensionsPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>3.2.0-beta3-19280-02</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>16.0.0</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkGitHubPackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -6,6 +6,7 @@
       https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)feed')">
       $(RestoreSources);


### PR DESCRIPTION
Turns out my VS installation had some custom modifications to use the latest Roslyn compiler. This change should ensure VS uses an updated compiler and can therefore build and test.