### PR TITLE
React to new .NET Core SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview6-012155"
+    "version": "3.0.100-preview6-012162"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview6-012105"
+    "version": "3.0.100-preview6-012155"
   }
 }

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
@@ -11,9 +11,11 @@
 
   <ItemGroup>
     <Protobuf Include=".\Proto\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-
     <None Remove="@(Protobuf)" />
     <Content Include="@(Protobuf)" LinkBase="" />
+    
+    <Compile Include="..\..\test\Shared\TestRequestBodyPipeFeature.cs" Link="Internal\TestRequestBodyPipeFeature.cs" />
+    <Compile Include="..\..\test\Shared\TestResponseBodyPipeFeature.cs" Link="Internal\TestResponseBodyPipeFeature.cs" />
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Internal/MessageHelpers.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Internal/MessageHelpers.cs
@@ -39,7 +39,7 @@ namespace Grpc.AspNetCore.Microbenchmarks.Internal
         {
             var messageData = message.ToByteArray();
 
-            var pipeWriter = new StreamPipeWriter(stream);
+            var pipeWriter = PipeWriter.Create(stream);
 
             PipeExtensions.WriteMessageAsync(pipeWriter, messageData, TestServerCallContext, flush: true).GetAwaiter().GetResult();
         }

--- a/perf/Grpc.AspNetCore.Microbenchmarks/UnaryServerCallHandlerBenchmarkBase.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/UnaryServerCallHandlerBenchmarkBase.cs
@@ -28,6 +28,7 @@ using Grpc.AspNetCore.Server;
 using Grpc.AspNetCore.Server.Internal;
 using Grpc.AspNetCore.Server.Internal.CallHandlers;
 using Grpc.Core;
+using Grpc.Tests.Shared;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,10 +80,10 @@ namespace Grpc.AspNetCore.Microbenchmarks
 
             _httpContext = new DefaultHttpContext();
             _httpContext.RequestServices = _requestServices;
-            _httpContext.Request.BodyReader = _requestPipe;
             _httpContext.Request.ContentType = GrpcProtocolConstants.GrpcContentType;
-            _httpContext.Response.BodyWriter = new TestPipeWriter();
 
+            _httpContext.Features.Set<IRequestBodyPipeFeature>(new TestRequestBodyPipeFeature(_requestPipe));
+            _httpContext.Features.Set<IResponseBodyPipeFeature>(new TestResponseBodyPipeFeature(new TestPipeWriter()));
             _httpContext.Features.Set<IHttpResponseTrailersFeature>(new TestHttpResponseTrailersFeature
             {
                 Trailers = _trailers

--- a/test/FunctionalTests/DeadlineTests.cs
+++ b/test/FunctionalTests/DeadlineTests.cs
@@ -95,7 +95,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             var messageCount = 0;
 
@@ -171,7 +171,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             var messageCount = 0;
 

--- a/test/FunctionalTests/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/DuplexStreamingMethodTests.cs
@@ -60,7 +60,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             var message1Task = MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader);
             var message1 = await message1Task.DefaultTimeout();
@@ -141,7 +141,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             var message1 = await MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader).DefaultTimeout();
             Assert.AreEqual("John", message1.Name);

--- a/test/FunctionalTests/Infrastructure/HttpResponseMessageExtensions.cs
+++ b/test/FunctionalTests/Infrastructure/HttpResponseMessageExtensions.cs
@@ -41,7 +41,10 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         public static async Task<T> GetSuccessfulGrpcMessageAsync<T>(this HttpResponseMessage response) where T : IMessage, new()
         {
             response.AssertIsSuccessfulGrpcRequest();
-            return MessageHelpers.AssertReadMessage<T>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
+            var data = await response.Content.ReadAsByteArrayAsync().DefaultTimeout();
+            response.AssertTrailerStatus();
+
+            return MessageHelpers.AssertReadMessage<T>(data);
         }
 
         public static void AssertTrailerStatus(this HttpResponseMessage response) => response.AssertTrailerStatus(StatusCode.OK, string.Empty);

--- a/test/FunctionalTests/InterceptorOrderTests.cs
+++ b/test/FunctionalTests/InterceptorOrderTests.cs
@@ -111,7 +111,7 @@ namespace Grpc.AspNetCore.FunctionalTests
                 url,
                 new GrpcStreamContent(ms)).DefaultTimeout();
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             // Assert
             await MessageHelpers.AssertReadStreamMessageAsync<Empty>(pipeReader);
@@ -134,7 +134,7 @@ namespace Grpc.AspNetCore.FunctionalTests
                 url,
                 new GrpcStreamContent(new MemoryStream())).DefaultTimeout();
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             // Assert
             await MessageHelpers.AssertReadStreamMessageAsync<Empty>(pipeReader);

--- a/test/FunctionalTests/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/ServerStreamingMethodTests.cs
@@ -54,7 +54,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             for (var i = 0; i < 3; i++)
             {
@@ -97,7 +97,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             for (var i = 0; i < 3; i++)
             {
@@ -154,7 +154,7 @@ namespace Grpc.AspNetCore.FunctionalTests
             response.AssertIsSuccessfulGrpcRequest();
 
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
-            var pipeReader = new StreamPipeReader(responseStream);
+            var pipeReader = PipeReader.Create(responseStream);
 
             for (var i = 0; i < 3; i++)
             {

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -337,10 +337,9 @@ namespace Grpc.AspNetCore.FunctionalTests
         }
 
         [Test]
-        [Ignore("Regression in TestServer - https://github.com/aspnet/AspNetCore/issues/10737")]
         public async Task SingletonService_PrivateFieldsPreservedBetweenCalls()
         {
-            // Arrange
+            // Arrange 1
             var ms = new MemoryStream();
             MessageHelpers.WriteMessage(ms, new Empty());
 
@@ -353,6 +352,10 @@ namespace Grpc.AspNetCore.FunctionalTests
             var total = await response.GetSuccessfulGrpcMessageAsync<SingletonCount.CounterReply>();
             Assert.AreEqual(1, total.Count);
             response.AssertTrailerStatus();
+
+            // Arrange 2
+            ms = new MemoryStream();
+            MessageHelpers.WriteMessage(ms, new Empty());
 
             // Act 2
             response = await Fixture.Client.PostAsync(

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -337,6 +337,7 @@ namespace Grpc.AspNetCore.FunctionalTests
         }
 
         [Test]
+        [Ignore("Regression in TestServer")]
         public async Task SingletonService_PrivateFieldsPreservedBetweenCalls()
         {
             // Arrange

--- a/test/FunctionalTests/UnaryMethodTests.cs
+++ b/test/FunctionalTests/UnaryMethodTests.cs
@@ -337,7 +337,7 @@ namespace Grpc.AspNetCore.FunctionalTests
         }
 
         [Test]
-        [Ignore("Regression in TestServer")]
+        [Ignore("Regression in TestServer - https://github.com/aspnet/AspNetCore/issues/10737")]
         public async Task SingletonService_PrivateFieldsPreservedBetweenCalls()
         {
             // Arrange

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -15,6 +15,8 @@
     <Compile Include="..\Shared\SyncPoint.cs" Link="Infrastructure\SyncPoint.cs" />
     <Compile Include="..\Shared\SyncPointMemoryStream.cs" Link="Infrastructure\SyncPointMemoryStream.cs" />
     <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
+    <Compile Include="..\Shared\TestRequestBodyPipeFeature.cs" Link="Infrastructure\TestRequestBodyPipeFeature.cs" />
+    <Compile Include="..\Shared\TestResponseBodyPipeFeature.cs" Link="Infrastructure\TestResponseBodyPipeFeature.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextStreamReaderTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextStreamReaderTests.cs
@@ -22,8 +22,10 @@ using System.Threading.Tasks;
 using Google.Protobuf;
 using Greet;
 using Grpc.AspNetCore.Server.Internal;
+using Grpc.AspNetCore.Server.Tests.Infrastructure;
 using Grpc.Tests.Shared;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using NUnit.Framework;
 
 namespace Grpc.AspNetCore.Server.Tests
@@ -61,7 +63,7 @@ namespace Grpc.AspNetCore.Server.Tests
             var ms = new SyncPointMemoryStream();
 
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.BodyReader = new StreamPipeReader(ms);
+            httpContext.Features.Set<IRequestBodyPipeFeature>(new TestRequestBodyPipeFeature(PipeReader.Create(ms)));
             var serverCallContext = HttpContextServerCallContextHelper.CreateServerCallContext(httpContext);
             var reader = new HttpContextStreamReader<HelloReply>(serverCallContext, (data) =>
             {

--- a/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
@@ -49,7 +49,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x00 // length = 0
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var messageData = await pipeReader.ReadSingleMessageAsync(TestServerCallContext);
@@ -72,7 +72,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x10
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var messageData = await pipeReader.ReadSingleMessageAsync(TestServerCallContext);
@@ -97,7 +97,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x10
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var messageData = await pipeReader.ReadSingleMessageAsync(context);
@@ -123,7 +123,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x10
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var ex = Assert.ThrowsAsync<RpcException>(() => pipeReader.ReadSingleMessageAsync(context).AsTask());
@@ -151,7 +151,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0xC1 // length = 449
                 }.Concat(content).ToArray());
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var messageData = await pipeReader.ReadSingleMessageAsync(TestServerCallContext);
@@ -179,7 +179,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0xC1 // length = 449
                 }.Concat(content).ToArray());
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var messageData = await pipeReader.ReadStreamMessageAsync(TestServerCallContext);
@@ -203,7 +203,7 @@ namespace Grpc.AspNetCore.Server.Tests
                 };
             var ms = new MemoryStream(emptyMessage.Concat(emptyMessage).ToArray());
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act 1
             var messageData1 = await pipeReader.ReadStreamMessageAsync(TestServerCallContext);
@@ -235,7 +235,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x00
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var ex = Assert.ThrowsAsync<RpcException>(
@@ -260,7 +260,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x10
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var ex = Assert.ThrowsAsync<RpcException>(
@@ -286,7 +286,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x10 // additional data
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var ex = Assert.ThrowsAsync<RpcException>(
@@ -308,7 +308,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x00
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var ex = Assert.ThrowsAsync<RpcException>(
@@ -333,7 +333,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x10
                 });
 
-            var pipeReader = new StreamPipeReader(ms);
+            var pipeReader = PipeReader.Create(ms);
 
             // Act
             var ex = Assert.ThrowsAsync<RpcException>(
@@ -349,7 +349,7 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             // Arrange
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
 
             // Act
             await pipeWriter.WriteMessageAsync(Encoding.UTF8.GetBytes("Hello world"), TestServerCallContext);
@@ -364,7 +364,7 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             // Arrange
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
 
             // Act
             await pipeWriter.WriteMessageAsync(Array.Empty<byte>(), TestServerCallContext, flush: true);
@@ -389,7 +389,7 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             // Arrange
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
 
             // Act
             await pipeWriter.WriteMessageAsync(new byte[] { 0x10 }, TestServerCallContext, flush: true);
@@ -415,7 +415,7 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             // Arrange
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
             var content = Encoding.UTF8.GetBytes("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam varius nibh a blandit mollis. "
                 + "In hac habitasse platea dictumst. Proin non quam nec neque convallis commodo. Orci varius natoque penatibus et magnis dis "
                 + "parturient montes, nascetur ridiculus mus. Mauris commodo est vehicula, semper arcu eu, ornare urna. Mauris malesuada nisl "
@@ -445,7 +445,7 @@ namespace Grpc.AspNetCore.Server.Tests
             // Arrange
             var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { SendMaxMessageSize = 1 });
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
 
             // Act
             await pipeWriter.WriteMessageAsync(new byte[] { 0x10 }, context, flush: true);
@@ -472,7 +472,7 @@ namespace Grpc.AspNetCore.Server.Tests
             // Arrange
             var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { SendMaxMessageSize = 1 });
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
 
             // Act
             var ex = Assert.ThrowsAsync<RpcException>(() => pipeWriter.WriteMessageAsync(new byte[] { 0x10, 0x10 }, context, flush: true));
@@ -502,7 +502,7 @@ namespace Grpc.AspNetCore.Server.Tests
             context.Initialize();
 
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
 
             // Act
             await pipeWriter.WriteMessageAsync(new byte[] { 0x10 }, context, flush: true);
@@ -536,7 +536,7 @@ namespace Grpc.AspNetCore.Server.Tests
             context.Initialize();
 
             var ms = new MemoryStream();
-            var pipeWriter = new StreamPipeWriter(ms);
+            var pipeWriter = PipeWriter.Create(ms);
 
             // Act
             await pipeWriter.WriteMessageAsync(new byte[] { 0x10 }, context, flush: true);

--- a/test/Shared/MessageHelpers.cs
+++ b/test/Shared/MessageHelpers.cs
@@ -47,7 +47,7 @@ namespace Grpc.Tests.Shared
                 new GzipCompressionProvider(CompressionLevel.Fastest)
             };
 
-            var pipeReader = new StreamPipeReader(stream);
+            var pipeReader = PipeReader.Create(stream);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers[GrpcProtocolConstants.MessageEncodingHeader] = compressionEncoding;
@@ -70,7 +70,7 @@ namespace Grpc.Tests.Shared
 
         public static Task<T?> AssertReadStreamMessageAsync<T>(Stream stream, string? compressionEncoding = null, List<ICompressionProvider>? compressionProviders = null) where T : class, IMessage, new()
         {
-            var pipeReader = new StreamPipeReader(stream);
+            var pipeReader = PipeReader.Create(stream);
 
             return AssertReadStreamMessageAsync<T>(pipeReader, compressionEncoding, compressionProviders);
         }
@@ -110,7 +110,7 @@ namespace Grpc.Tests.Shared
 
             var messageData = message.ToByteArray();
 
-            var pipeWriter = new StreamPipeWriter(stream);
+            var pipeWriter = PipeWriter.Create(stream);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers[GrpcProtocolConstants.MessageAcceptEncodingHeader] = compressionEncoding;

--- a/test/Shared/TestRequestBodyPipeFeature.cs
+++ b/test/Shared/TestRequestBodyPipeFeature.cs
@@ -1,0 +1,33 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Grpc.Tests.Shared
+{
+    public class TestRequestBodyPipeFeature : IRequestBodyPipeFeature
+    {
+        public TestRequestBodyPipeFeature(PipeReader reader)
+        {
+            Reader = reader;
+        }
+
+        public PipeReader Reader { get; }
+    }
+}

--- a/test/Shared/TestResponseBodyPipeFeature.cs
+++ b/test/Shared/TestResponseBodyPipeFeature.cs
@@ -1,0 +1,33 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Grpc.Tests.Shared
+{
+    public class TestResponseBodyPipeFeature : IResponseBodyPipeFeature
+    {
+        public TestResponseBodyPipeFeature(PipeWriter writer)
+        {
+            Writer = writer;
+        }
+
+        public PipeWriter Writer { get; }
+    }
+}


### PR DESCRIPTION
Lots of compile errors to fix because of https://github.com/aspnet/AspNetCore/pull/10154

A functional test is broken because of a regression in TestServer. Test is ignored until TestServer is fixed.