### PR TITLE
Remove workarounds for DesignTimeBuild

### DIFF
--- a/examples/Clients/Counter/Counter.csproj
+++ b/examples/Clients/Counter/Counter.csproj
@@ -6,14 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\..\Proto\count.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="..\..\Proto\count.proto" GrpcServices="Client" />
 
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Shared\*.cs" />
 

--- a/examples/Clients/Greeter/Greeter.csproj
+++ b/examples/Clients/Greeter/Greeter.csproj
@@ -6,14 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\..\Proto\greet.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="..\..\Proto\greet.proto" GrpcServices="Client" />
 
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Shared\*.cs" />
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />

--- a/examples/Clients/Mailer/Mailer.csproj
+++ b/examples/Clients/Mailer/Mailer.csproj
@@ -6,14 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\..\Proto\mail.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="..\..\Proto\mail.proto" GrpcServices="Client" />
 
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Shared\*.cs" />
 

--- a/examples/Clients/Ticketer/Ticketer.csproj
+++ b/examples/Clients/Ticketer/Ticketer.csproj
@@ -6,14 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\..\Proto\ticket.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="..\..\Proto\ticket.proto" GrpcServices="Client" />
 
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Shared\*.cs" />
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />

--- a/examples/Server/Server.csproj
+++ b/examples/Server/Server.csproj
@@ -7,15 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\Proto\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="Protos" />
+    <Protobuf Include="..\Proto\*.proto" GrpcServices="Server" />
 
     <Compile Include="$(MSBuildThisFileDirectory)..\Shared\Resources.cs" />
 

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
@@ -10,9 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include=".\Proto\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include=".\Proto\*.proto" GrpcServices="Server" />
     
     <Compile Include="..\..\test\Shared\TestRequestBodyPipeFeature.cs" Link="Internal\TestRequestBodyPipeFeature.cs" />
     <Compile Include="..\..\test\Shared\TestResponseBodyPipeFeature.cs" Link="Internal\TestResponseBodyPipeFeature.cs" />

--- a/perf/benchmarkapps/BenchmarkClient/BenchmarkClient.csproj
+++ b/perf/benchmarkapps/BenchmarkClient/BenchmarkClient.csproj
@@ -6,14 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Client" />
 
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Shared\*.cs" />
 

--- a/perf/benchmarkapps/BenchmarkServer/BenchmarkServer.csproj
+++ b/perf/benchmarkapps/BenchmarkServer/BenchmarkServer.csproj
@@ -12,18 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" />
+
     <Compile Include="..\Shared\BenchmarkConfigurationHelpers.cs" Link="BenchmarkConfigurationHelpers.cs" />
-
     <Compile Include="..\Shared\Greeter.cs" Link="Greeter.cs" />
-
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\examples\Shared\Resources.cs" />
 
     <Content Update="hosting.json">

--- a/perf/benchmarkapps/NativeServer/NativeServer.csproj
+++ b/perf/benchmarkapps/NativeServer/NativeServer.csproj
@@ -6,21 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
+    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" />
+
     <None Remove="hosting.json" />
-    <Content Include="@(Protobuf)" LinkBase="" />
     <Content Include="hosting.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Compile Include="..\Shared\BenchmarkConfigurationHelpers.cs" Link="BenchmarkConfigurationHelpers.cs" />
 
+    <Compile Include="..\Shared\BenchmarkConfigurationHelpers.cs" Link="BenchmarkConfigurationHelpers.cs" />
     <Compile Include="..\Shared\Greeter.cs" Link="Greeter.cs" />
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -33,8 +33,4 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="build\**\*.targets" PackagePath="%(Identity)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Grpc.AspNetCore.Server/build/netcoreapp3.0/Grpc.AspNetCore.Server.targets
+++ b/src/Grpc.AspNetCore.Server/build/netcoreapp3.0/Grpc.AspNetCore.Server.targets
@@ -1,9 +1,0 @@
-<Project>
-  <!-- Workaround for VS Project System bug: -->
-  <!-- Duplicated items in None itemgroup without Generator attribute prevents the items -->
-  <!-- in Protobuf itemgroup with Generator attribute from triggering design time build. -->
-  <!-- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/849161?src=WorkItemMention&src-action=artifact_link -->
-  <ItemGroup Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >
-    <None Remove="@(Protobuf)" />
-  </ItemGroup>
-</Project>

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\*.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="Proto\*.proto" GrpcServices="Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -6,11 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\*.proto" GrpcServices="Server,Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
-    <Compile Include="..\Shared\HttpContextHelpers.cs" Link="Infrastructure\HttpContextHelpers.cs" />
+    <Protobuf Include="Proto\*.proto" GrpcServices="Server,Client" />
 
+    <Compile Include="..\Shared\HttpContextHelpers.cs" Link="Infrastructure\HttpContextHelpers.cs" />
     <Compile Include="..\Shared\HttpContextServerCallContextHelpers.cs" Link="Infrastructure\HttpContextServerCallContextHelpers.cs" />
     <Compile Include="..\Shared\MessageHelpers.cs" Link="Infrastructure\MessageHelpers.cs" />
     <Compile Include="..\Shared\ResponseUtils.cs" Link="Infrastructure\ResponseUtils.cs" />

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -6,11 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\*.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
-    <Compile Include="..\Shared\CallbackInterceptor.cs" Link="Infrastructure\CallbackInterceptor.cs" />
+    <Protobuf Include="Proto\*.proto" GrpcServices="Client" />
 
+    <Compile Include="..\Shared\CallbackInterceptor.cs" Link="Infrastructure\CallbackInterceptor.cs" />
     <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
     <Compile Include="..\Shared\SyncPoint.cs" Link="Infrastructure\SyncPoint.cs" />
     <Compile Include="..\Shared\SyncPointMemoryStream.cs" Link="Infrastructure\SyncPointMemoryStream.cs" />

--- a/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
+++ b/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\*.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
+    <Protobuf Include="Proto\*.proto" GrpcServices="Client" />
   </ItemGroup>
 
   <ItemGroup>
@@ -16,7 +14,7 @@
     <Compile Include="..\Shared\ResponseUtils.cs" Link="Infrastructure\ResponseUtils.cs" />
     <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
     <Compile Include="..\Shared\TestHelpers.cs" Link="Infrastructure\TestHelpers.cs" />
-    
+
     <ProjectReference Include="..\..\src\Grpc.Net.ClientFactory\Grpc.Net.ClientFactory.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
@@ -8,13 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="grpc\core\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-    <Protobuf Include="grpc\testing\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
+    <Protobuf Include="grpc\core\*.proto" GrpcServices="Server" />
+    <Protobuf Include="grpc\testing\*.proto" GrpcServices="Server" />
 
     <None Remove="@(Protobuf)" />
     <Content Include="@(Protobuf)" LinkBase="" />

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -7,15 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\Proto\*.proto" GrpcServices="Server,Client" Generator="MSBuild:Compile" />
-
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="Proto" />
+    <Protobuf Include="..\Proto\*.proto" GrpcServices="Both" />
 
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -6,10 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Client" Generator="MSBuild:Compile" />
-
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="Proto" />
+    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Client" />
 
     <None Include="..\Certs\InteropTests\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/testassets/InteropTestsNativeServer/InteropTestsNativeServer.csproj
+++ b/testassets/InteropTestsNativeServer/InteropTestsNativeServer.csproj
@@ -6,15 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="Proto" />
+    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Server" />
 
     <None Include="..\Certs\InteropTests\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -7,15 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requirements (Note that most of these changes will be made to the msbuild targets in Grpc.Tools) -->
-    <!-- 1. Grpc.Tools msbuild files: the Google.Protobuf.Tools.targets file needs to be updated to remove Condition=" '$(DesignTimeBuild)' != 'true' "  -->
-    <!-- 2. Generator metadata: this is the target that's run during the design time build to generate the *.cs files -->
-    <!-- 3. None ItemGroup: Remove the *.proto files from None since the generator metadata for those files are ignored -->
-    <!-- 4. Content ItemGroup: Include the *.proto files in the Content ItemGroup. This isn't required if the file is included in the project directory. I'm not sure about what's going on with this requirement. -->
-    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
-
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="Proto" />
+    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Server" />
 
     <None Include="..\Certs\InteropTests\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
We can remove these workarounds now that VS 16.2 Preview1 is released.

Addresses: https://github.com/grpc/grpc-dotnet/issues/237