### PR TITLE
Improve method discovery logging

### DIFF
--- a/examples/Clients/Certifier/Program.cs
+++ b/examples/Clients/Certifier/Program.cs
@@ -74,7 +74,7 @@ namespace Sample.Clients
             {
                 // Load client certificate
                 var basePath = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-                var certPath = Path.Combine(basePath, "Certs", "client.pfx");
+                var certPath = Path.Combine(basePath!, "Certs", "client.pfx");
                 var clientCertificate = new X509Certificate2(certPath, "1111");
                 handler.ClientCertificates.Add(clientCertificate);
             }

--- a/examples/Server/Program.cs
+++ b/examples/Server/Program.cs
@@ -42,7 +42,7 @@ namespace GRPCServer
                         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                         {
                             var basePath = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-                            var certPath = Path.Combine(basePath, "Certs", "server.pfx");
+                            var certPath = Path.Combine(basePath!, "Certs", "server.pfx");
 
                             listenOptions.UseHttps(certPath, "1111", o =>
                             {

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview7-012341"
+    "version": "3.0.100-preview7-012414"
   }
 }

--- a/perf/benchmarkapps/BenchmarkClient/Workers/GrpcCoreUnaryWorker.cs
+++ b/perf/benchmarkapps/BenchmarkClient/Workers/GrpcCoreUnaryWorker.cs
@@ -65,7 +65,7 @@ namespace BenchmarkClient.Workers
 
         private static ChannelCredentials GetCertificateCredentials()
         {
-            var currentPath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            var currentPath = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location)!;
 
             return new SslCredentials(
               File.ReadAllText(Path.Combine(currentPath, "Certs", "ca.crt")),

--- a/perf/benchmarkapps/BenchmarkServer/Program.cs
+++ b/perf/benchmarkapps/BenchmarkServer/Program.cs
@@ -86,7 +86,7 @@ namespace BenchmarkServer
                             Console.WriteLine($"Require client certificate: {requireClientCertificate}");
 
                             var basePath = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-                            var certPath = Path.Combine(basePath, "Certs/server.pfx");
+                            var certPath = Path.Combine(basePath!, "Certs/server.pfx");
 
                             listenOptions.UseHttps(certPath, "1111", httpsOptions =>
                             {

--- a/src/Grpc.AspNetCore.Server.Reflection/Internal/ReflectionGrpcServiceActivator.cs
+++ b/src/Grpc.AspNetCore.Server.Reflection/Internal/ReflectionGrpcServiceActivator.cs
@@ -103,7 +103,7 @@ namespace Grpc.AspNetCore.Server.Reflection.Internal
 
             public static void ServiceDescriptorNotResolved(ILogger logger, Type serviceType)
             {
-                _serviceDescriptorNotResolved(logger, serviceType.FullName, null);
+                _serviceDescriptorNotResolved(logger, serviceType.FullName ?? string.Empty, null);
             }
         }
     }

--- a/src/Grpc.AspNetCore.Server/Model/Internal/BinderServiceModelProvider.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/BinderServiceModelProvider.cs
@@ -57,7 +57,7 @@ namespace Grpc.AspNetCore.Server.Model.Internal
         private static class Log
         {
             private static readonly Action<ILogger, Type, Exception?> _bindMethodNotFound =
-                LoggerMessage.Define<Type>(LogLevel.Warning, new EventId(1, "BindMethodNotFound"), "Could not find bind method for service '{ServiceType}'.");
+                LoggerMessage.Define<Type>(LogLevel.Debug, new EventId(1, "BindMethodNotFound"), "Could not find bind method for {ServiceType}.");
 
             public static void BindMethodNotFound(ILogger logger, Type serviceType)
             {

--- a/test/Grpc.Net.Client.Tests/GetTrailersTests.cs
+++ b/test/Grpc.Net.Client.Tests/GetTrailersTests.cs
@@ -122,7 +122,7 @@ namespace Grpc.Net.Client.Tests
 
             // Assert
             Assert.AreEqual("Can't get the call trailers because an error occured when making the request.", ex.Message);
-            Assert.AreEqual("An error!", ex.InnerException.InnerException.Message);
+            Assert.AreEqual("An error!", ex.InnerException?.InnerException?.Message);
         }
 
         [Test]

--- a/test/Shared/TestHelpers.cs
+++ b/test/Shared/TestHelpers.cs
@@ -29,7 +29,7 @@ namespace Grpc.Tests.Shared
     {
         public static string ResolvePath(string relativePath)
         {
-            var resolvedPath = Path.Combine(Path.GetDirectoryName(typeof(TestHelpers).Assembly.Location), relativePath);
+            var resolvedPath = Path.Combine(Path.GetDirectoryName(typeof(TestHelpers).Assembly.Location)!, relativePath);
 
             return resolvedPath;
         }

--- a/testassets/InteropTestsClient/Assert.cs
+++ b/testassets/InteropTestsClient/Assert.cs
@@ -110,7 +110,7 @@ namespace InteropTestsClient
 
             for (var i = 0; i < expected.Count; i++)
             {
-                Assert.AreEqual(expected[i], actual[i]);
+                Assert.AreEqual(expected[i]!, actual[i]!);
             }
         }
     }

--- a/testassets/InteropTestsClient/InteropClient.cs
+++ b/testassets/InteropTestsClient/InteropClient.cs
@@ -205,7 +205,7 @@ namespace InteropTestsClient
         {
             if (channel is CoreChannel coreChannel)
             {
-                return (TClient)Activator.CreateInstance(typeof(TClient), coreChannel.Channel);
+                return (TClient)Activator.CreateInstance(typeof(TClient), coreChannel.Channel)!;
             }
             else if (channel is HttpClientChannel httpClientChannel)
             {
@@ -813,7 +813,7 @@ namespace InteropTestsClient
         // extracts the client_email field from service account file used for auth test cases
         private static string GetEmailFromServiceAccountFile()
         {
-            string keyFile = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
+            string keyFile = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS")!;
             Assert.IsNotNull(keyFile);
             var jobject = JObject.Parse(File.ReadAllText(keyFile));
             string email = jobject.GetValue("client_email").Value<string>();

--- a/testassets/InteropTestsClient/TestCredentials.cs
+++ b/testassets/InteropTestsClient/TestCredentials.cs
@@ -69,7 +69,7 @@ namespace InteropTestsClient
         private static string GetPath(string relativePath)
         {
             var assemblyDir = Path.GetDirectoryName(typeof(TestCredentials).GetTypeInfo().Assembly.Location);
-            return Path.Combine(assemblyDir, relativePath);
+            return Path.Combine(assemblyDir!, relativePath);
         }
     }
 }

--- a/testassets/InteropTestsNativeServer/TestCredentials.cs
+++ b/testassets/InteropTestsNativeServer/TestCredentials.cs
@@ -69,7 +69,7 @@ namespace InteropTestsNativeWebsite
         private static string GetPath(string relativePath)
         {
             var assemblyDir = Path.GetDirectoryName(typeof(TestCredentials).GetTypeInfo().Assembly.Location);
-            return Path.Combine(assemblyDir, relativePath);
+            return Path.Combine(assemblyDir!, relativePath);
         }
     }
 }

--- a/testassets/InteropTestsWebsite/Program.cs
+++ b/testassets/InteropTestsWebsite/Program.cs
@@ -49,7 +49,7 @@ namespace InteropTestsWebsite
                         if (useTls)
                         {
                             var basePath = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-                            var certPath = Path.Combine(basePath, "Certs", "server1.pfx");
+                            var certPath = Path.Combine(basePath!, "Certs", "server1.pfx");
 
                             listenOptions.UseHttps(certPath, "1111");
                         }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/331

Also fixes a bunch of nullable warnings. These are showing up because BCL is adding nullable metadata.