### PR TITLE
Add Grpc.AspNetCore metapackage

### DIFF
--- a/Grpc.DotNet.sln
+++ b/Grpc.DotNet.sln
@@ -9,8 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8C62055F-8CD
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Proto", "Proto", "{AC41B2B2-62D9-454E-8521-F71E331B07F3}"
 	ProjectSection(SolutionItems) = preProject
-		examples\Proto\certify.proto = examples\Proto\certify.proto
 		examples\Proto\aggregate.proto = examples\Proto\aggregate.proto
+		examples\Proto\certify.proto = examples\Proto\certify.proto
 		examples\Proto\count.proto = examples\Proto\count.proto
 		examples\Proto\greet.proto = examples\Proto\greet.proto
 		examples\Proto\mail.proto = examples\Proto\mail.proto
@@ -159,6 +159,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Certifier", "examples\Clien
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aggregator", "examples\Clients\Aggregator\Aggregator.csproj", "{BEC5E994-7EE1-4429-B5A6-870B174D8830}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore", "src\Grpc.AspNetCore\Grpc.AspNetCore.csproj", "{F6CA82C9-85C6-4A5F-B892-4DF8A20B1C05}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -277,6 +279,10 @@ Global
 		{BEC5E994-7EE1-4429-B5A6-870B174D8830}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BEC5E994-7EE1-4429-B5A6-870B174D8830}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BEC5E994-7EE1-4429-B5A6-870B174D8830}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6CA82C9-85C6-4A5F-B892-4DF8A20B1C05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6CA82C9-85C6-4A5F-B892-4DF8A20B1C05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6CA82C9-85C6-4A5F-B892-4DF8A20B1C05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6CA82C9-85C6-4A5F-B892-4DF8A20B1C05}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -324,6 +330,7 @@ Global
 		{94F42386-DCB3-4500-87A2-75479957C881} = {F6E0F9D7-64E5-4C7B-A9BC-3C2AD687710B}
 		{F7A0064A-C648-46BD-A3E8-132D5E08A970} = {F6E0F9D7-64E5-4C7B-A9BC-3C2AD687710B}
 		{BEC5E994-7EE1-4429-B5A6-870B174D8830} = {F6E0F9D7-64E5-4C7B-A9BC-3C2AD687710B}
+		{F6CA82C9-85C6-4A5F-B892-4DF8A20B1C05} = {8C62055F-8CD7-4859-9001-634D544DF2AE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD5C2B19-49B4-480A-990C-36D98A719B07}

--- a/examples/Server/Server.csproj
+++ b/examples/Server/Server.csproj
@@ -13,12 +13,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.Reflection\Grpc.AspNetCore.Server.Reflection.csproj" />
 
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificatePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageVersion)" />
   </ItemGroup>

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
@@ -6,20 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Protobuf Include=".\Proto\*.proto" GrpcServices="Server" />
-    
+
     <Compile Include="..\..\test\Shared\TestRequestBodyPipeFeature.cs" Link="Internal\TestRequestBodyPipeFeature.cs" />
     <Compile Include="..\..\test\Shared\TestResponseBodyPipeFeature.cs" Link="Internal\TestResponseBodyPipeFeature.cs" />
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
+++ b/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Authors>The gRPC Authors</Authors>
+    <Copyright>Copyright 2019 The gRPC Authors</Copyright>
+    <Description>gRPC meta-package for ASP.NET Core</Description>
+    <PackageIconUrl>https://github.com/grpc/grpc.github.io/raw/master/img/grpc_square_reverse_4x.png</PackageIconUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/grpc/grpc-dotnet</PackageProjectUrl>
+    <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
+    <VersionPrefix>$(GrpcDotnetVersion)</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <ProjectReference Include="..\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />
+
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="None" />
+  </ItemGroup>
+
+</Project>

--- a/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
+++ b/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
@@ -17,8 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
     <ProjectReference Include="..\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />

--- a/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
+++ b/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <!-- PrivateAssets set to None to ensure the build targets/props are propagated to parent project -->
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="None" />
   </ItemGroup>
 

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\*.proto" GrpcServices="Server,Client" />
+    <Protobuf Include="Proto\*.proto" GrpcServices="Both" />
 
     <Compile Include="..\Shared\HttpContextHelpers.cs" Link="Infrastructure\HttpContextHelpers.cs" />
     <Compile Include="..\Shared\HttpContextServerCallContextHelpers.cs" Link="Infrastructure\HttpContextServerCallContextHelpers.cs" />
@@ -24,13 +24,9 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.Reflection\Grpc.AspNetCore.Server.Reflection.csproj" />
 
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
-    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcPackageVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
@@ -11,13 +11,7 @@
     <Protobuf Include="grpc\core\*.proto" GrpcServices="Server" />
     <Protobuf Include="grpc\testing\*.proto" GrpcServices="Server" />
 
-    <None Remove="@(Protobuf)" />
-    <Content Include="@(Protobuf)" LinkBase="" />
-
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
-
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -9,12 +9,8 @@
   <ItemGroup>
     <Protobuf Include="..\Proto\*.proto" GrpcServices="Both" />
 
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
 
-    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcPackageVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageVersion)" />
   </ItemGroup>
 

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -13,10 +13,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
-
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is the last package we intend to ship in 3.0 based on the diagram at https://github.com/grpc/grpc-dotnet/blob/master/doc/packages.md.

I've done some preliminary tests using a slightly modified grpc template, which ran correctly. I've also verified that the build and publish output contains only the dlls we expect so adding a dependency on Grpc.Tools with PrivateAssets=None is safe.

![image](https://user-images.githubusercontent.com/2030323/59792520-3a6e6900-9289-11e9-8d75-8128700985fb.png)

I think as another method of validation, I can convert our samples to now use the metapackage