### PR TITLE
 Change deadline timer to CTS, move deadline logic to its own class

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -125,7 +125,7 @@ namespace Grpc.AspNetCore.Server.Internal
         {
             Debug.Assert(DeadlineManager != null, "Deadline manager should have been created.");
 
-            await DeadlineManager.DeadlineLock.WaitAsync();
+            await DeadlineManager.Lock.WaitAsync();
 
             try
             {
@@ -133,7 +133,7 @@ namespace Grpc.AspNetCore.Server.Internal
             }
             finally
             {
-                DeadlineManager.DeadlineLock.Release();
+                DeadlineManager.Lock.Release();
                 await DeadlineManager.DisposeAsync();
             }
         }
@@ -205,7 +205,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 return Task.CompletedTask;
             }
 
-            var lockTask = DeadlineManager.DeadlineLock.WaitAsync();
+            var lockTask = DeadlineManager.Lock.WaitAsync();
             if (lockTask.IsCompletedSuccessfully)
             {
                 Task disposeTask;
@@ -215,7 +215,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 }
                 finally
                 {
-                    DeadlineManager.DeadlineLock.Release();
+                    DeadlineManager.Lock.Release();
 
                     // Can't return from a finally
                     disposeTask = DeadlineManager.DisposeAsync().AsTask();
@@ -241,7 +241,7 @@ namespace Grpc.AspNetCore.Server.Internal
             }
             finally
             {
-                DeadlineManager.DeadlineLock.Release();
+                DeadlineManager.Lock.Release();
                 await DeadlineManager.DisposeAsync();
             }
         }

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallDeadlineManager.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallDeadlineManager.cs
@@ -1,0 +1,140 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grpc.AspNetCore.Server.Internal
+{
+    internal class ServerCallDeadlineManager : IAsyncDisposable
+    {
+        private CancellationTokenSource _deadlineCts;
+        private Task? _deadlineExceededTask;
+        private CancellationTokenRegistration _deadlineExceededRegistration;
+        private CancellationTokenRegistration _requestAbortedRegistration;
+        private Func<Task> _deadlineExceededCallback;
+
+        internal DateTime Deadline { get; private set; }
+        // Lock is to ensure deadline doesn't execute as call is completing
+        internal SemaphoreSlim DeadlineLock { get; private set; }
+        // Internal for testing
+        internal bool _callComplete;
+
+        public CancellationToken CancellationToken => _deadlineCts.Token;
+
+        public ServerCallDeadlineManager(ISystemClock clock, TimeSpan timeout, Func<Task> deadlineExceededCallback, CancellationToken requestAborted)
+        {
+            Deadline = clock.UtcNow.Add(timeout);
+            _deadlineExceededCallback = deadlineExceededCallback;
+
+            // Create lock before setting up deadline event
+            DeadlineLock = new SemaphoreSlim(1, 1);
+
+            _deadlineCts = new CancellationTokenSource(timeout);
+            _deadlineExceededRegistration = _deadlineCts.Token.Register(DeadlineExceeded);
+            _requestAbortedRegistration = requestAborted.Register(() =>
+            {
+                // Call is complete if the request has aborted
+                _callComplete = true;
+                _deadlineCts?.Cancel();
+            });
+        }
+
+        public void SetCallComplete()
+        {
+            _callComplete = true;
+        }
+
+        private void DeadlineExceeded()
+        {
+            _deadlineExceededTask = DeadlineExceededAsync();
+        }
+
+        private async Task DeadlineExceededAsync()
+        {
+            if (!CanExceedDeadline())
+            {
+                return;
+            }
+
+            Debug.Assert(DeadlineLock != null, "Lock has not been created.");
+
+            await DeadlineLock.WaitAsync();
+
+            try
+            {
+                // Double check after lock is aquired
+                if (!CanExceedDeadline())
+                {
+                    return;
+                }
+
+                await _deadlineExceededCallback();
+            }
+            finally
+            {
+                DeadlineLock.Release();
+            }
+        }
+
+        private bool CanExceedDeadline()
+        {
+            // Deadline callback could be raised by the CTS after call has been completed (either successfully, with error, or aborted)
+            // but before deadline exceeded registration has been disposed
+            return !_callComplete;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            // Deadline registration needs to be disposed with DisposeAsync, and the task completed
+            // before the lock can be disposed.
+            // Awaiting deadline registration and deadline task ensures it has finished running, so there is
+            // no way for deadline logic to attempt to wait on a disposed lock.
+            var disposeTask = _deadlineExceededRegistration.DisposeAsync();
+
+            if (disposeTask.IsCompletedSuccessfully &&
+                (_deadlineExceededTask == null || _deadlineExceededTask.IsCompletedSuccessfully))
+            {
+                DisposeCore();
+                return default;
+            }
+
+            return DeadlineDisposeAsyncCore(disposeTask);
+        }
+
+        private async ValueTask DeadlineDisposeAsyncCore(ValueTask disposeTask)
+        {
+            await disposeTask;
+            if (_deadlineExceededTask != null)
+            {
+                await _deadlineExceededTask;
+            }
+
+            DisposeCore();
+        }
+
+        private void DisposeCore()
+        {
+            DeadlineLock!.Dispose();
+            _deadlineCts!.Dispose();
+            _requestAbortedRegistration.Dispose();
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -349,10 +349,9 @@ namespace Grpc.AspNetCore.Server.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers[GrpcProtocolConstants.TimeoutHeader] = header;
             var context = CreateServerCallContext(httpContext);
-            context.Clock = TestClock;
 
             // Act
-            context.Initialize();
+            context.Initialize(TestClock);
 
             // Assert
             Assert.AreEqual(TestClock.UtcNow.Add(TimeSpan.FromTicks(ticks)), context.Deadline);
@@ -593,7 +592,7 @@ namespace Grpc.AspNetCore.Server.Tests
                 Assert.Fail($"{methodName} did not wait on lock taken by deadline cancellation.");
             }
 
-            Assert.IsFalse(serverCallContext._callComplete);
+            Assert.IsFalse(serverCallContext.DeadlineManager!._callComplete);
 
             // Wait for dispose to finish
             syncPoint.Continue();
@@ -601,7 +600,7 @@ namespace Grpc.AspNetCore.Server.Tests
 
             Assert.AreEqual(GrpcProtocolConstants.ResetStreamNoError, httpResetFeature.ErrorCode);
 
-            Assert.IsTrue(serverCallContext._callComplete);
+            Assert.IsTrue(serverCallContext.DeadlineManager!._callComplete);
         }
 
         [Test]
@@ -627,7 +626,7 @@ namespace Grpc.AspNetCore.Server.Tests
             await syncPoint.WaitForSyncPoint();
 
             // Act
-            var disposeTask = serverCallContext.DeadlineDisposeAsync();
+            var disposeTask = serverCallContext.DeadlineManager!.DisposeAsync();
 
             // Assert
             Assert.IsFalse(disposeTask.IsCompletedSuccessfully);


### PR DESCRIPTION
Using a CTS instead of a timer is required because completing the request in the deadline will prevent RequestAborted being raised. The CTS acts as a replacement token.

Also moved the deadline logic to its own class. Encapsulates it somewhat, and shrinks the number of fields on server call context.