### PR TITLE
Validate HttpClient.BaseAddress has been set

### DIFF
--- a/src/Grpc.Net.Client/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/HttpClientCallInvoker.cs
@@ -158,6 +158,12 @@ namespace Grpc.Net.Client
             where TRequest : class
             where TResponse : class
         {
+            if (_client.BaseAddress == null)
+            {
+                throw new InvalidOperationException("Unable to send the gRPC call because no server address has been configured. " +
+                    "Set HttpClient.BaseAddress on the HttpClient used to created to gRPC client.");
+            }
+
             CancellationTokenSource? linkedCts = null;
 
             // Use propagated deadline if it is small than the specified deadline

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -128,5 +128,20 @@ namespace Grpc.Net.Client.Tests
             // Assert
             Assert.AreEqual(StatusCode.Unimplemented, ex.StatusCode);
         }
+
+        [Test]
+        public async Task AsyncUnaryCall_HttpClientBaseAddressNotSet_ThrowError()
+        {
+            // Arrange
+            var httpClient = new HttpClient();
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient);
+
+            // Act
+            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest()).ResponseAsync).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual("Unable to send the gRPC call because no server address has been configured. " +
+                "Set HttpClient.BaseAddress on the HttpClient used to created to gRPC client.", ex.Message);
+        }
     }
 }


### PR DESCRIPTION
URL paths from IMethod are always relative so no BaseAddress will always fail. This improves the error message.