### PR TITLE
Add tests for ClientBase type overrides

### DIFF
--- a/examples/Clients/Aggregator/Aggregator.csproj
+++ b/examples/Clients/Aggregator/Aggregator.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\Proto\*.proto" GrpcServices="Client" />
+    <Protobuf Include="..\..\Proto\aggregate.proto" GrpcServices="Client" Link="Protos\aggregate.proto"/>
+    <Protobuf Include="..\..\Proto\greet.proto" GrpcServices="None" Link="Protos\greet.proto"/>
+    <Protobuf Include="..\..\Proto\count.proto" GrpcServices="None" Link="Protos\count.proto"/>
 
     <Compile Include="..\..\Shared\ClientResources.cs" Link="ClientResources.cs" />
 

--- a/examples/Clients/Certifier/Certifier.csproj
+++ b/examples/Clients/Certifier/Certifier.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\Proto\certify.proto" GrpcServices="Client" />
+    <Protobuf Include="..\..\Proto\certify.proto" GrpcServices="Client" Link="Protos\certify.proto" />
 
     <None Include="..\..\Certs\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/examples/Clients/Counter/Counter.csproj
+++ b/examples/Clients/Counter/Counter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\Proto\count.proto" GrpcServices="Client" />
+    <Protobuf Include="..\..\Proto\count.proto" GrpcServices="Client" Link="Protos\count.proto" />
 
     <Compile Include="..\..\Shared\ClientResources.cs" Link="ClientResources.cs" />
 

--- a/examples/Clients/Greeter/Greeter.csproj
+++ b/examples/Clients/Greeter/Greeter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\Proto\greet.proto" GrpcServices="Client" />
+    <Protobuf Include="..\..\Proto\greet.proto" GrpcServices="Client" Link="Protos\greet.proto" />
 
     <Compile Include="..\..\Shared\ClientResources.cs" Link="ClientResources.cs" />
 

--- a/examples/Clients/Mailer/Mailer.csproj
+++ b/examples/Clients/Mailer/Mailer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\Proto\mail.proto" GrpcServices="Client" />
+    <Protobuf Include="..\..\Proto\mail.proto" GrpcServices="Client" Link="Protos\mail.proto" />
 
     <Compile Include="..\..\Shared\ClientResources.cs" Link="ClientResources.cs" />
 

--- a/examples/Clients/Ticketer/Ticketer.csproj
+++ b/examples/Clients/Ticketer/Ticketer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\Proto\ticket.proto" GrpcServices="Client" />
+    <Protobuf Include="..\..\Proto\ticket.proto" GrpcServices="Client" Link="Protos\ticket.proto" />
 
     <Compile Include="..\..\Shared\ClientResources.cs" Link="ClientResources.cs" />
 

--- a/examples/Clients/Worker/Worker.csproj
+++ b/examples/Clients/Worker/Worker.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\Proto\count.proto" GrpcServices="Client" />
+    <Protobuf Include="..\..\Proto\count.proto" GrpcServices="Client" Link="Protos\count.proto" />
 
     <ProjectReference Include="..\..\..\src\Grpc.Net.ClientFactory\Grpc.Net.ClientFactory.csproj" />
 

--- a/examples/Server/Server.csproj
+++ b/examples/Server/Server.csproj
@@ -1,23 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>
-
   <ItemGroup>
-    <Protobuf Include="..\Proto\*.proto" />
-
     <None Include="..\Certs\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.Reflection\Grpc.AspNetCore.Server.Reflection.csproj" />
-
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCorePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Protobuf Include="..\Proto\aggregate.proto" GrpcServices="Server" Link="Protos\aggregate.proto" />
+    <Protobuf Include="..\Proto\certify.proto" GrpcServices="Server" Link="Protos\certify.proto" />
+    <Protobuf Include="..\Proto\count.proto" GrpcServices="Both" Link="Protos\count.proto" />
+    <Protobuf Include="..\Proto\greet.proto" GrpcServices="Both" Link="Protos\greet.proto" />
+    <Protobuf Include="..\Proto\mail.proto" GrpcServices="Server" Link="Protos\mail.proto" />
+    <Protobuf Include="..\Proto\ticket.proto" GrpcServices="Server" Link="Protos\ticket.proto" />
+  </ItemGroup>
 </Project>

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include=".\Proto\*.proto" GrpcServices="Server" />
+    <Protobuf Include=".\Proto\chat.proto" GrpcServices="Server" />
 
     <Compile Include="..\..\test\Shared\TestRequestBodyPipeFeature.cs" Link="Internal\TestRequestBodyPipeFeature.cs" />
     <Compile Include="..\..\test\Shared\TestResponseBodyPipeFeature.cs" Link="Internal\TestResponseBodyPipeFeature.cs" />

--- a/perf/benchmarkapps/BenchmarkClient/BenchmarkClient.csproj
+++ b/perf/benchmarkapps/BenchmarkClient/BenchmarkClient.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Client" ClientType="LiteClientBase" />
-    <Protobuf Include="..\Shared\core-greet.proto" GrpcServices="Client" ClientType="ClientBase" />
+    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Client" ClientType="LiteClientBase" Link="Protos\greet.proto" />
+    <Protobuf Include="..\Shared\core-greet.proto" GrpcServices="Client" ClientType="ClientBase" Link="Protos\core-greet.proto" />
 
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Shared\*.cs" />
 

--- a/perf/benchmarkapps/BenchmarkServer/BenchmarkServer.csproj
+++ b/perf/benchmarkapps/BenchmarkServer/BenchmarkServer.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" />
+    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" Link="Protos\greet.proto" />
 
     <None Include="..\..\..\examples\Certs\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/perf/benchmarkapps/NativeServer/NativeServer.csproj
+++ b/perf/benchmarkapps/NativeServer/NativeServer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" />
+    <Protobuf Include="..\Shared\greet.proto" GrpcServices="Server" Link="Protos\greet.proto" />
 
     <None Remove="hosting.json" />
     <Content Include="hosting.json">

--- a/src/dotnet-grpc/Commands/CommandBase.cs
+++ b/src/dotnet-grpc/Commands/CommandBase.cs
@@ -161,7 +161,7 @@ namespace Grpc.Dotnet.Cli.Commands
                 // If file is outside of the project, display the file under Protos/ directory
                 if (!Path.GetFullPath(resolvedPath).StartsWith(Project.DirectoryPath, StringComparison.OrdinalIgnoreCase))
                 {
-                    newItem.Xml.AddMetadata(LinkElement, Path.Combine(ProtosFolder, Path.GetFileName(file)!));
+                    newItem.Xml.AddMetadata(LinkElement, Path.Combine(ProtosFolder, Path.GetFileName(file)!), expressAsAttribute: true);
                 }
             }
         }

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/ClientBaseTests.cs
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/ClientBaseTests.cs
@@ -25,6 +25,7 @@ namespace Grpc.Net.Client.Tests
     [TestFixture]
     public class ClientBaseTests
     {
+        [Test]
         public void ClientBaseClass_Implicit_UsesLiteClientBase()
         {
             // Assert

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/ClientBaseTests.cs
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/ClientBaseTests.cs
@@ -1,0 +1,34 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Greet;
+using Grpc.Core;
+using NUnit.Framework;
+
+namespace Grpc.Net.Client.Tests
+{
+    [TestFixture]
+    public class ClientBaseTests
+    {
+        public void ClientBaseClass_Implicit_UsesLiteClientBase()
+        {
+            // Assert
+            Assert.True(typeof(Greeter.GreeterClient).IsSubclassOf(typeof(LiteClientBase)));
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\*.proto" GrpcServices="Client" />
+    <Protobuf Include="Proto\greet.proto" GrpcServices="Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
     <Compile Include="..\Shared\ExceptionAssert.cs" Link="Infrastructure\ExceptionAssert.cs" />
 
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="Proto\*.proto" GrpcServices="Both" />
+    <Protobuf Include="Proto\greet.proto" GrpcServices="Both" />
 
     <Compile Include="..\Shared\ExceptionAssert.cs" Link="Infrastructure\ExceptionAssert.cs" />
     <Compile Include="..\Shared\HttpContextHelpers.cs" Link="Infrastructure\HttpContextHelpers.cs" />

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -11,6 +11,7 @@
     <Protobuf Include="Proto\core-greet.proto" GrpcServices="Client" ClientBaseType="ClientBase" />
 
     <Compile Include="..\Shared\CallbackInterceptor.cs" Link="Infrastructure\CallbackInterceptor.cs" />
+    <Compile Include="..\Shared\ClientBaseTests.cs" Link="ClientBaseTests.cs" />
     <Compile Include="..\Shared\ClientTestHelpers.cs" Link="Infrastructure\ClientTestHelpers.cs" />
     <Compile Include="..\Shared\ExceptionAssert.cs" Link="Infrastructure\ExceptionAssert.cs" />
     <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
@@ -29,12 +30,6 @@
     <PackageReference Include="Grpc.Core" Version="$(GrpcPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Protobuf Update="Proto\core-greet.proto">
-      <_GrpcOutputOptions>$(_GrpcOutputOptions);lite_client</_GrpcOutputOptions>
-    </Protobuf>
   </ItemGroup>
 
 </Project>

--- a/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
+++ b/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\CallbackInterceptor.cs" Link="Infrastructure\CallbackInterceptor.cs" />
+    <Compile Include="..\Shared\ClientBaseTests.cs" Link="ClientBaseTests.cs" />
     <Compile Include="..\Shared\ClientTestHelpers.cs" Link="Infrastructure\ClientTestHelpers.cs" />
     <Compile Include="..\Shared\ExceptionAssert.cs" Link="Infrastructure\ExceptionAssert.cs" />
     <Compile Include="..\Shared\ResponseUtils.cs" Link="Infrastructure\ResponseUtils.cs" />
@@ -23,7 +25,7 @@
     <ProjectReference Include="..\..\src\Grpc.Net.ClientFactory\Grpc.Net.ClientFactory.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
-    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcPackageVersion)" />
+    <PackageReference Include="Grpc.Core" Version="$(GrpcPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>

--- a/test/Shared/ClientBaseTests.cs
+++ b/test/Shared/ClientBaseTests.cs
@@ -1,0 +1,39 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.Core;
+using NUnit.Framework;
+
+namespace Grpc.Net.Client.Tests
+{
+    [TestFixture]
+    public class ClientBaseTests
+    {
+        public void ClientBaseClass_ExplicitSetting_UsesLiteClientBase()
+        {
+            // Assert
+            Assert.True(typeof(Greet.Greeter.GreeterClient).IsSubclassOf(typeof(LiteClientBase)));
+        }
+
+        public void ClientBaseClass_ExplicitSetting_UsesClientBase()
+        {
+            // Assert
+            Assert.True(typeof(CoreGreet.Greeter.GreeterClient).IsSubclassOf(typeof(ClientBase)));
+        }
+    }
+}

--- a/test/Shared/ClientBaseTests.cs
+++ b/test/Shared/ClientBaseTests.cs
@@ -24,12 +24,14 @@ namespace Grpc.Net.Client.Tests
     [TestFixture]
     public class ClientBaseTests
     {
+        [Test]
         public void ClientBaseClass_ExplicitSetting_UsesLiteClientBase()
         {
             // Assert
             Assert.True(typeof(Greet.Greeter.GreeterClient).IsSubclassOf(typeof(LiteClientBase)));
         }
 
+        [Test]
         public void ClientBaseClass_ExplicitSetting_UsesClientBase()
         {
             // Assert

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
-    <Protobuf Include="grpc\core\*.proto" GrpcServices="Server" />
-    <Protobuf Include="grpc\testing\*.proto" GrpcServices="Server" />
+    <Protobuf Include="grpc\core\grpc_core_stats.proto" GrpcServices="Server" />
+    <Protobuf Include="grpc\testing\benchmark_service.proto" GrpcServices="Server" />
+    <Protobuf Include="grpc\testing\worker_service.proto" GrpcServices="Server" />
+    <Protobuf Include="grpc\testing\messages.proto" GrpcServices="None" />
+    <Protobuf Include="grpc\testing\control.proto" GrpcServices="None" />
+    <Protobuf Include="grpc\testing\stats.proto" GrpcServices="None" />
+    <Protobuf Include="grpc\testing\payloads.proto" GrpcServices="None" />
 
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
   </ItemGroup>
-
 </Project>

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -1,17 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <Protobuf Include="..\Proto\*.proto" GrpcServices="Both" />
-
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
-
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    
+    <Protobuf Include="..\Proto\any.proto" Link="Protos\any.proto" />
+    <Protobuf Include="..\Proto\authorize.proto" Link="Protos\authorize.proto" />
+    <Protobuf Include="..\Proto\chat.proto" Link="Protos\chat.proto" />
+    <Protobuf Include="..\Proto\compression.proto" Link="Protos\compression.proto" />
+    <Protobuf Include="..\Proto\count.proto" Link="Protos\count.proto" />
+    <Protobuf Include="..\Proto\greet.proto" Link="Protos\greet.proto" />
+    <Protobuf Include="..\Proto\lifetime.proto" Link="Protos\lifetime.proto" />
+    <Protobuf Include="..\Proto\nested.proto" Link="Protos\nested.proto" />
+    <Protobuf Include="..\Proto\singleton.proto" Link="Protos\singleton.proto" />
   </ItemGroup>
-
 </Project>

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Client" />
+    <Protobuf Include="..\Proto\grpc\testing\test.proto" GrpcServices="Client" Link="Protos\test.proto" />
+    <Protobuf Include="..\Proto\grpc\testing\empty.proto" GrpcServices="None" Link="Protos\empty.proto" />
+    <Protobuf Include="..\Proto\grpc\testing\messages.proto" GrpcServices="None" Link="Protos\messages.proto" />
 
     <None Include="..\Certs\InteropTests\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\Proto\grpc\testing\*.proto" GrpcServices="Server" />
+    <Protobuf Include="..\Proto\grpc\testing\test.proto" GrpcServices="Server" Link="Protos\test.proto" />
+    <Protobuf Include="..\Proto\grpc\testing\empty.proto" GrpcServices="None" Link="Protos\empty.proto" />
+    <Protobuf Include="..\Proto\grpc\testing\messages.proto" GrpcServices="None" Link="Protos\messages.proto" />
 
     <None Include="..\Certs\InteropTests\*.*" LinkBase="Certs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/370.

In the meantime before decisions regarding ChannelBase are finalized, let's add tests for the override logic. The first commit is the one that adds tests. The second one is just clean up.