### PR TITLE
Verify AddInterceptor and EnableCallContextPropagation is used with AddGrpcClient

### DIFF
--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -224,7 +224,15 @@ namespace Microsoft.Extensions.DependencyInjection
                 httpClient.BaseAddress = clientOptions.BaseAddress;
             };
 
-            services.Configure<GrpcClientFactoryOptions>(name, options => options.ExplicitlySet = true);
+            // This configuration serves multiple purposes:
+            // 1. ExplicitlySet is tested at runtime to determin if AddGrpcClient was called for this name.
+            // 2. `IConfigureOptions<GrpcClientFactoryOptions>` presense is services collection is tested
+            //    in gRPC client extension methods that take IHttpClientBuilder that the builder is from
+            //    AddGrpcClient. ConfigureNamedOptions<GrpcClientFactoryOptions> needs to be the value.
+            //    We need to cast to the concrete type to get the name.
+            //
+            services.AddSingleton<IConfigureOptions<GrpcClientFactoryOptions>>(
+                new ConfigureNamedOptions<GrpcClientFactoryOptions>(name, options => options.ExplicitlySet = true));
 
             IHttpClientBuilder clientBuilder = services.AddGrpcHttpClient<TClient>(name, configureTypedClient);
 

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -225,11 +225,12 @@ namespace Microsoft.Extensions.DependencyInjection
             };
 
             // This configuration serves multiple purposes:
-            // 1. ExplicitlySet is tested at runtime to determin if AddGrpcClient was called for this name.
-            // 2. `IConfigureOptions<GrpcClientFactoryOptions>` presense is services collection is tested
-            //    in gRPC client extension methods that take IHttpClientBuilder that the builder is from
+            // 1. ExplicitlySet is tested at runtime to determine if AddGrpcClient was called for this name.
+            // 2. `IConfigureOptions<GrpcClientFactoryOptions>` presence in builder's ServicesCollection is tested
+            //    in gRPC client extension methods that take IHttpClientBuilder. Validation will throw an error if
+            //    if gRPC extension methods, e.g. AddInterceptor, are used with client builders that are not from
             //    AddGrpcClient. ConfigureNamedOptions<GrpcClientFactoryOptions> needs to be the value.
-            //    We need to cast to the concrete type to get the name.
+            //    We need to cast the service value to the concrete type to get the name.
             //
             services.AddSingleton<IConfigureOptions<GrpcClientFactoryOptions>>(
                 new ConfigureNamedOptions<GrpcClientFactoryOptions>(name, options => options.ExplicitlySet = true));

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -50,7 +50,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
         public void EnableCallContextPropagation_NotFromGrpcClientFactoryAndExistingGrpcClient_ThrowError()
         {
             var services = new ServiceCollection();
-            services.AddGrpcClient<TestGreeterClient>(o => { });
+            services.AddGrpcClient<Greeter.GreeterClient>(o => { });
             var clientBuilder = services.AddHttpClient("TestClient");
 
             var ex = Assert.Throws<InvalidOperationException>(() => clientBuilder.EnableCallContextPropagation());

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -37,6 +37,27 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
     public class DefaultGrpcClientFactoryTests
     {
         [Test]
+        public void EnableCallContextPropagation_NotFromGrpcClientFactory_ThrowError()
+        {
+            var services = new ServiceCollection();
+            var clientBuilder = services.AddHttpClient("TestClient");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => clientBuilder.EnableCallContextPropagation());
+            Assert.AreEqual("EnableCallContextPropagation must be used with a gRPC client.", ex.Message);
+        }
+
+        [Test]
+        public void EnableCallContextPropagation_NotFromGrpcClientFactoryAndExistingGrpcClient_ThrowError()
+        {
+            var services = new ServiceCollection();
+            services.AddGrpcClient<TestGreeterClient>(o => { });
+            var clientBuilder = services.AddHttpClient("TestClient");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => clientBuilder.EnableCallContextPropagation());
+            Assert.AreEqual("EnableCallContextPropagation must be used with a gRPC client.", ex.Message);
+        }
+
+        [Test]
         public async Task CreateClient_ServerCallContextHasValues_PropogatedDeadlineAndCancellation()
         {
             // Arrange

--- a/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
@@ -69,6 +69,35 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
         }
 
         [Test]
+        public void AddInterceptor_NotFromGrpcClientFactoryAndExistingGrpcClient_ThrowError()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddGrpcClient<Greeter.GreeterClient>(o => { });
+            var client = services.AddHttpClient("TestClient");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(() => new CallbackInterceptor(() => { })));
+            Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(s => new CallbackInterceptor(() => { })));
+            Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
+        }
+
+        [Test]
+        public void AddInterceptor_NotFromGrpcClientFactory_ThrowError()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var client = services.AddHttpClient("TestClient");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(() => new CallbackInterceptor(() => { })));
+            Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(s => new CallbackInterceptor(() => { })));
+            Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
+        }
+
+        [Test]
         public async Task AddInterceptorGeneric_MultipleInstances_ExecutedInOrder()
         {
             // Arrange
@@ -108,6 +137,17 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             Assert.AreEqual(2, list[0]);
             Assert.AreEqual(4, list[1]);
             Assert.AreEqual(6, list[2]);
+        }
+
+        [Test]
+        public void AddInterceptorGeneric_NotFromGrpcClientFactory_ThrowError()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var client = services.AddHttpClient("TestClient");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor<CallbackInterceptor>());
+            Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
         }
 
         private class TestHttpMessageHandler : HttpMessageHandler

--- a/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
@@ -76,10 +76,10 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             services.AddGrpcClient<Greeter.GreeterClient>(o => { });
             var client = services.AddHttpClient("TestClient");
 
-            var ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(() => new CallbackInterceptor(() => { })));
+            var ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(() => new CallbackInterceptor(o => { })));
             Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
 
-            ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(s => new CallbackInterceptor(() => { })));
+            ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(s => new CallbackInterceptor(o => { })));
             Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
         }
 
@@ -90,10 +90,10 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             var services = new ServiceCollection();
             var client = services.AddHttpClient("TestClient");
 
-            var ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(() => new CallbackInterceptor(() => { })));
+            var ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(() => new CallbackInterceptor(o => { })));
             Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
 
-            ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(s => new CallbackInterceptor(() => { })));
+            ex = Assert.Throws<InvalidOperationException>(() => client.AddInterceptor(s => new CallbackInterceptor(o => { })));
             Assert.AreEqual("AddInterceptor must be used with a gRPC client.", ex.Message);
         }
 


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/383

@rynowak I went with looking at the service collection instead of an internal wrapper type over IHttpClientBuilder. This works for EnableCallContextPropagation which is in another assembly and won't be able to check for the internal type.