### PR TITLE
Update grpc-dotnet commandline dependency

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -17,6 +17,6 @@
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
     <NunitPackageVersion>3.12.0</NunitPackageVersion>
     <Nunit3TestAdapterPackageVersion>3.13.0</Nunit3TestAdapterPackageVersion>
-    <SystemCommandLineExperimentalPackageVersion>0.2.0-alpha.19272.1</SystemCommandLineExperimentalPackageVersion>
+    <SystemCommandLineExperimentalPackageVersion>0.3.0-alpha.19317.1</SystemCommandLineExperimentalPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -35,12 +35,12 @@ namespace Grpc.Dotnet.Cli.Commands
         {
             var command = new Command(
                 name: "add-file",
-                description: CoreStrings.AddFileCommandDescription,
-                argument: new Argument<string[]>
-                {
-                    Name = "files",
-                    Description = CoreStrings.AddFileCommandArgumentDescription,
-                });
+                description: CoreStrings.AddFileCommandDescription);
+            command.AddArgument(new Argument<string[]>
+            {
+                Name = "files",
+                Description = CoreStrings.AddFileCommandArgumentDescription,
+            });
 
             command.AddOption(CommonOptions.ProjectOption());
             command.AddOption(CommonOptions.ServiceOption());

--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -40,6 +40,7 @@ namespace Grpc.Dotnet.Cli.Commands
             {
                 Name = "files",
                 Description = CoreStrings.AddFileCommandArgumentDescription,
+                Arity = ArgumentArity.OneOrMore
             });
 
             command.AddOption(CommonOptions.ProjectOption());

--- a/src/dotnet-grpc/Commands/AddUrlCommand.cs
+++ b/src/dotnet-grpc/Commands/AddUrlCommand.cs
@@ -40,18 +40,19 @@ namespace Grpc.Dotnet.Cli.Commands
         {
             var command = new Command(
                 name: "add-url",
-                description: CoreStrings.AddUrlCommandDescription,
-                argument: new Argument<string>
-                {
-                    Name = "url",
-                    Description = CoreStrings.AddUrlCommandArgumentDescription,
-                    Arity = ArgumentArity.ExactlyOne
-                });
+                description: CoreStrings.AddUrlCommandDescription);
+            command.AddArgument(new Argument<string>
+            {
+                Name = "url",
+                Description = CoreStrings.AddUrlCommandArgumentDescription,
+                Arity = ArgumentArity.ExactlyOne
+            });
 
-            command.AddOption(new Option(
+            var outputOption = new Option(
                 aliases: new[] { "-o", "--output" },
-                description: CoreStrings.OutputOptionDescription,
-                argument: new Argument<string> { Name = "path", Arity = ArgumentArity.ExactlyOne }));
+                description: CoreStrings.OutputOptionDescription);
+            outputOption.Argument = new Argument<string> { Name = "path", Arity = ArgumentArity.ExactlyOne };
+            command.AddOption(outputOption);
             command.AddOption(CommonOptions.ProjectOption());
             command.AddOption(CommonOptions.ServiceOption());
             command.AddOption(CommonOptions.AdditionalImportDirsOption());

--- a/src/dotnet-grpc/Commands/RefreshCommand.cs
+++ b/src/dotnet-grpc/Commands/RefreshCommand.cs
@@ -42,19 +42,18 @@ namespace Grpc.Dotnet.Cli.Commands
         {
             var command = new Command(
                 name: "refresh",
-                description: CoreStrings.RefreshCommandDescription,
-                argument: new Argument<string[]>
-                {
-                    Name = "references",
-                    Description = CoreStrings.RefreshCommandArgumentDescription,
-                    Arity = ArgumentArity.ZeroOrMore
-                });
+                description: CoreStrings.RefreshCommandDescription);
 
+            command.AddArgument(new Argument<string[]>
+            {
+                Name = "references",
+                Description = CoreStrings.RefreshCommandArgumentDescription,
+                Arity = ArgumentArity.ZeroOrMore
+            });
             command.AddOption(CommonOptions.ProjectOption());
             command.AddOption(new Option(
                 aliases: new[] { "--dry-run" },
-                description: CoreStrings.DryRunOptionDescription,
-                argument: Argument.None
+                description: CoreStrings.DryRunOptionDescription
                 ));
 
             command.Handler = CommandHandler.Create<IConsole, FileInfo, bool, string[]>(

--- a/src/dotnet-grpc/Commands/RemoveCommand.cs
+++ b/src/dotnet-grpc/Commands/RemoveCommand.cs
@@ -35,13 +35,13 @@ namespace Grpc.Dotnet.Cli.Commands
         {
             var command = new Command(
                 name: "remove",
-                description: CoreStrings.RemoveCommandDescription,
-                argument: new Argument<string[]>
-                {
-                    Name = "references",
-                    Description = CoreStrings.RemoveCommandArgumentDescription,
-                    Arity = ArgumentArity.OneOrMore
-                });
+                description: CoreStrings.RemoveCommandDescription);
+            command.AddArgument(new Argument<string[]>
+            {
+                Name = "references",
+                Description = CoreStrings.RemoveCommandArgumentDescription,
+                Arity = ArgumentArity.OneOrMore
+            });
 
             command.AddOption(CommonOptions.ProjectOption());
 

--- a/src/dotnet-grpc/Options/CommonOptions.cs
+++ b/src/dotnet-grpc/Options/CommonOptions.cs
@@ -24,28 +24,40 @@ namespace Grpc.Dotnet.Cli.Options
 {
     internal static class CommonOptions
     {
-        public static Option ProjectOption() =>
-            new Option(
+        public static Option ProjectOption()
+        {
+            var o = new Option(
                 aliases: new[] { "-p", "--project" },
-                description: CoreStrings.ProjectOptionDescription,
-                argument: new Argument<FileInfo> { Name = "project" });
+                description: CoreStrings.ProjectOptionDescription);
+            o.Argument = new Argument<FileInfo> { Name = "project" };
+            return o;
+        }
 
-        public static Option ServiceOption() =>
-            new Option(
+        public static Option ServiceOption()
+        {
+            var o = new Option(
                 aliases: new[] { "-s", "--services" },
-                description: CoreStrings.ServiceOptionDescription,
-                argument: new Argument<Services> { Name = "services" });
+                description: CoreStrings.ServiceOptionDescription);
+            o.Argument = new Argument<Services> { Name = "services" };
+            return o;
+        }
 
-        public static Option AccessOption() =>
-            new Option(
+        public static Option AccessOption()
+        {
+            var o = new Option(
                 aliases: new[] { "--access" },
-                description: CoreStrings.AccessOptionDescription,
-                argument: new Argument<Access> { Name = "access" });
+                description: CoreStrings.AccessOptionDescription);
+            o.Argument = new Argument<Access> { Name = "access" };
+            return o;
+        }
 
-        public static Option AdditionalImportDirsOption() =>
-            new Option(
+        public static Option AdditionalImportDirsOption()
+        {
+            var o = new Option(
                 aliases: new[] { "-i", "--additional-import-dirs" },
-                description: CoreStrings.AdditionalImportDirsOption,
-                argument: new Argument<string> { Name = "dirs" });
+                description: CoreStrings.AdditionalImportDirsOption);
+            o.Argument = new Argument<string> { Name = "dirs" };
+            return o;
+        }
     }
 }


### PR DESCRIPTION
@JunTaoLuo after I made this change I ran `dotnet run add-file` and got a null reference exception. Because there were no file arguments. Should the argument have prevented the handler being called? I'm not familiar enough to say one way or another.