### PR TITLE
Temporarily suppress conflict warning in dotnet-grpc

### DIFF
--- a/src/dotnet-grpc/dotnet-grpc.csproj
+++ b/src/dotnet-grpc/dotnet-grpc.csproj
@@ -15,7 +15,10 @@
     <PackAsTool>true</PackAsTool>
     <RootNamespace>Grpc.Dotnet.Cli</RootNamespace>
 
-    <!-- Workaround for MSBuild issue TODO (johluo): https://github.com/microsoft/msbuild/issues/4474 -->
+    <!-- Temporary workaround for dependency conflict TODO (JamesNK): https://github.com/grpc/grpc-dotnet/issues/360 -->
+    <MSBuildWarningsAsMessages>MSB3277</MSBuildWarningsAsMessages>
+
+    <!-- Temporary workaround for MSBuild issue TODO (johluo): https://github.com/microsoft/msbuild/issues/4474 -->
     <GenerateResourceUsePreserializedResources>false</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/360

See issue for more detail.