### PR TITLE
Fix contents of AuthInterceptorContext

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -502,8 +502,8 @@ namespace Grpc.Net.Client.Internal
 
         private static AuthInterceptorContext CreateAuthInterceptorContext(Uri baseAddress, IMethod method)
         {
-            string serviceUrl = baseAddress.OriginalString;
-            if (baseAddress.Scheme == Uri.UriSchemeHttps && serviceUrl.EndsWith(":443", StringComparison.InvariantCulture))
+            var serviceUrl = baseAddress.OriginalString;
+            if (baseAddress.Scheme == Uri.UriSchemeHttps && serviceUrl.EndsWith(":443", StringComparison.Ordinal))
             {
                 // The service URL can be used by auth libraries to construct the "aud" fields of the JWT token,
                 // so not producing serviceUrl compatible with other gRPC implementations can lead to auth failures.

--- a/test/Grpc.Net.Client.Tests/CallCredentialTests.cs
+++ b/test/Grpc.Net.Client.Tests/CallCredentialTests.cs
@@ -140,11 +140,13 @@ namespace Grpc.Net.Client.Tests
         }
 
         [Test]
+        [TestCase("https://somehost", "https://somehost/ServiceName")]
+        [TestCase("https://somehost/", "https://somehost/ServiceName")]
         [TestCase("https://somehost:443", "https://somehost/ServiceName")]
         [TestCase("https://somehost:443/", "https://somehost/ServiceName")]
         [TestCase("https://somehost:1234", "https://somehost:1234/ServiceName")]
         [TestCase("https://foo.bar:443", "https://foo.bar/ServiceName")]
-        [TestCase("https://foo.bar:443/abc/xyz", "https:/foo.bar/abc/xyz/ServiceName")]
+        [TestCase("https://foo.bar:443/abc/xyz", "https://foo.bar/abc/xyz/ServiceName")]
         public async Task CallCredentials_AuthContextPopulated(string target, string expectedServiceUrl)
         {
             // Arrange

--- a/test/Grpc.Net.Client.Tests/CallCredentialTests.cs
+++ b/test/Grpc.Net.Client.Tests/CallCredentialTests.cs
@@ -138,5 +138,39 @@ namespace Grpc.Net.Client.Tests
             Assert.AreEqual("SECOND_SECRET_TOKEN", requestHeaders!.GetValues("second_authorization").Single());
             Assert.AreEqual("THIRD_SECRET_TOKEN", requestHeaders!.GetValues("third_authorization").Single());
         }
+
+        [Test]
+        [TestCase("https://somehost:443", "https://somehost/ServiceName")]
+        [TestCase("https://somehost:443/", "https://somehost/ServiceName")]
+        [TestCase("https://somehost:1234", "https://somehost:1234/ServiceName")]
+        [TestCase("https://foo.bar:443", "https://foo.bar/ServiceName")]
+        [TestCase("https://foo.bar:443/abc/xyz", "https:/foo.bar/abc/xyz/ServiceName")]
+        public async Task CallCredentials_AuthContextPopulated(string target, string expectedServiceUrl)
+        {
+            // Arrange
+            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            {
+                var reply = new HelloReply { Message = "Hello world" };
+                var streamContent = await ClientTestHelpers.CreateResponseContent(reply).DefaultTimeout();
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent);
+            }, new Uri(target));
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient);
+
+            // Act
+            string? serviceUrl = null;
+            string? methodName = null;
+            var callCredentials = CallCredentials.FromInterceptor((context, metadata) =>
+            {
+                serviceUrl = context.ServiceUrl;
+                methodName = context.MethodName;
+                return Task.CompletedTask;
+            });
+            var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(credentials: callCredentials), new HelloRequest());
+            await call.ResponseAsync.DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual(expectedServiceUrl, serviceUrl);
+            Assert.AreEqual("MethodName", ClientTestHelpers.ServiceMethod.Name);
+        }
     }
 }


### PR DESCRIPTION
Use the same values that C-core would produce.
The serviceUrl is used as "aud" field when constructing a JWT auth token in the auth library,
so if it's malformed, authentication will fail.

This partially answers https://github.com/grpc/grpc/pull/19512#issuecomment-511380720 (one more fix coming to grpc/grpc)