### PR TITLE
Update proto files to have semicolon after methods

### DIFF
--- a/examples/Proto/aggregate.proto
+++ b/examples/Proto/aggregate.proto
@@ -20,6 +20,6 @@ import "greet.proto";
 package Aggregate;
 
 service Aggregator {
-  rpc AccumulateCount (stream Count.CounterRequest) returns (Count.CounterReply) {}
-  rpc SayHellos (Greet.HelloRequest) returns (stream Greet.HelloReply) {}
+  rpc AccumulateCount (stream Count.CounterRequest) returns (Count.CounterReply) {};
+  rpc SayHellos (Greet.HelloRequest) returns (stream Greet.HelloReply) {};
 }

--- a/examples/Proto/certify.proto
+++ b/examples/Proto/certify.proto
@@ -18,7 +18,7 @@ import "google/protobuf/empty.proto";
 package Certify;
 
 service Certifier {
-  rpc GetCertificateInfo (google.protobuf.Empty) returns (CertificateInfoResponse) {}
+  rpc GetCertificateInfo (google.protobuf.Empty) returns (CertificateInfoResponse) {};
 }
 
 message CertificateInfoResponse {

--- a/examples/Proto/count.proto
+++ b/examples/Proto/count.proto
@@ -20,9 +20,9 @@ package Count;
 // The counter service definition.
 service Counter {
   // Get current count
-  rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {}
+  rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {};
   // Increment count through multiple counts
-  rpc AccumulateCount (stream CounterRequest) returns (CounterReply) {}
+  rpc AccumulateCount (stream CounterRequest) returns (CounterReply) {};
 }
 
 // The request message containing the count to increment by

--- a/examples/Proto/greet.proto
+++ b/examples/Proto/greet.proto
@@ -19,8 +19,8 @@ package Greet;
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 // The request message containing the user's name.

--- a/examples/Proto/mail.proto
+++ b/examples/Proto/mail.proto
@@ -18,7 +18,7 @@ package Mail;
 
 // The mail service definition.
 service Mailer {
-  rpc Mailbox (stream ForwardMailMessage) returns (stream MailboxMessage) {}
+  rpc Mailbox (stream ForwardMailMessage) returns (stream MailboxMessage) {};
 }
 
 message ForwardMailMessage {

--- a/examples/Proto/ticket.proto
+++ b/examples/Proto/ticket.proto
@@ -20,9 +20,9 @@ package Ticket;
 // The banker service definition.
 service Ticketer {
   // Get available ticket count
-  rpc GetAvailableTickets (google.protobuf.Empty) returns (AvailableTicketsResponse) {}
+  rpc GetAvailableTickets (google.protobuf.Empty) returns (AvailableTicketsResponse) {};
   // Buy tickets
-  rpc BuyTickets (BuyTicketsRequest) returns (BuyTicketsResponse) {}
+  rpc BuyTickets (BuyTicketsRequest) returns (BuyTicketsResponse) {};
 }
 
 // The response message containing the available ticket count

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Proto/chat.proto
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Proto/chat.proto
@@ -19,7 +19,7 @@ package Chat;
 // The greeting service definition.
 service Chatter {
   // Sends a greeting
-  rpc Chat (stream ChatMessage) returns (stream ChatMessage) {}
+  rpc Chat (stream ChatMessage) returns (stream ChatMessage) {};
 }
 
 // The chat message.

--- a/perf/benchmarkapps/Shared/core-greet.proto
+++ b/perf/benchmarkapps/Shared/core-greet.proto
@@ -21,8 +21,8 @@ import "google/protobuf/timestamp.proto";
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 // The request message containing the user's name.

--- a/perf/benchmarkapps/Shared/greet.proto
+++ b/perf/benchmarkapps/Shared/greet.proto
@@ -21,8 +21,8 @@ import "google/protobuf/timestamp.proto";
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 // The request message containing the user's name.

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Proto/greet.proto
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Proto/greet.proto
@@ -17,13 +17,13 @@ syntax = "proto3";
 package Greet;
 
 service Greeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 service SecondGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 message HelloRequest {

--- a/test/Grpc.AspNetCore.Server.Tests/Proto/greet.proto
+++ b/test/Grpc.AspNetCore.Server.Tests/Proto/greet.proto
@@ -17,13 +17,13 @@ syntax = "proto3";
 package Greet;
 
 service Greeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 service SecondGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 message HelloRequest {

--- a/test/Grpc.Net.Client.Tests/Proto/core-greet.proto
+++ b/test/Grpc.Net.Client.Tests/Proto/core-greet.proto
@@ -17,13 +17,13 @@ syntax = "proto3";
 package CoreGreet;
 
 service Greeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 service SecondGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 message HelloRequest {

--- a/test/Grpc.Net.Client.Tests/Proto/greet.proto
+++ b/test/Grpc.Net.Client.Tests/Proto/greet.proto
@@ -17,13 +17,13 @@ syntax = "proto3";
 package Greet;
 
 service Greeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 service SecondGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 message HelloRequest {

--- a/test/Grpc.Net.ClientFactory.Tests/Proto/core-greet.proto
+++ b/test/Grpc.Net.ClientFactory.Tests/Proto/core-greet.proto
@@ -17,13 +17,13 @@ syntax = "proto3";
 package CoreGreet;
 
 service Greeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 service SecondGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 message HelloRequest {

--- a/test/Grpc.Net.ClientFactory.Tests/Proto/greet.proto
+++ b/test/Grpc.Net.ClientFactory.Tests/Proto/greet.proto
@@ -17,13 +17,13 @@ syntax = "proto3";
 package Greet;
 
 service Greeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 service SecondGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
 }
 
 message HelloRequest {

--- a/testassets/Proto/any.proto
+++ b/testassets/Proto/any.proto
@@ -19,7 +19,7 @@ import "google/protobuf/any.proto";
 package Any;
 
 service AnyService {
-  rpc DoAny (google.protobuf.Any) returns (AnyMessageResponse) {}
+  rpc DoAny (google.protobuf.Any) returns (AnyMessageResponse) {};
 }
 
 message AnyProductRequest {

--- a/testassets/Proto/authorize.proto
+++ b/testassets/Proto/authorize.proto
@@ -18,7 +18,7 @@ package Authorize;
 
 // The greeting service definition.
 service AuthorizedGreeter {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
 }
 
 message HelloRequest {

--- a/testassets/Proto/chat.proto
+++ b/testassets/Proto/chat.proto
@@ -19,7 +19,7 @@ package Chat;
 // The greeting service definition.
 service Chatter {
   // Sends a greeting
-  rpc Chat (stream ChatMessage) returns (stream ChatMessage) {}
+  rpc Chat (stream ChatMessage) returns (stream ChatMessage) {};
 }
 
 // The chat message.

--- a/testassets/Proto/compression.proto
+++ b/testassets/Proto/compression.proto
@@ -17,8 +17,8 @@ syntax = "proto3";
 package Compression;
 
 service CompressionService {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc WriteMessageWithoutCompression (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc WriteMessageWithoutCompression (HelloRequest) returns (HelloReply) {};
 }
 
 message HelloRequest {

--- a/testassets/Proto/count.proto
+++ b/testassets/Proto/count.proto
@@ -20,9 +20,9 @@ package Count;
 // The counter service definition.
 service Counter {
   // Get current count
-  rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {}
+  rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {};
   // Increment count through multiple counts
-  rpc AccumulateCount (stream CounterRequest) returns (CounterReply) {}
+  rpc AccumulateCount (stream CounterRequest) returns (CounterReply) {};
 }
 
 // The request message containing the count to increment by

--- a/testassets/Proto/greet.proto
+++ b/testassets/Proto/greet.proto
@@ -19,11 +19,11 @@ package Greet;
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
-  rpc SayHelloWithHttpContextAccessor (HelloRequest) returns (HelloReply) {}
-  rpc SayHelloSendLargeReply (HelloRequest) returns (HelloReply) {}
-  rpc SayHellos (HelloRequest) returns (stream HelloReply) {}
-  rpc SayHellosSendHeadersFirst (HelloRequest) returns (stream HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
+  rpc SayHelloWithHttpContextAccessor (HelloRequest) returns (HelloReply) {};
+  rpc SayHelloSendLargeReply (HelloRequest) returns (HelloReply) {};
+  rpc SayHellos (HelloRequest) returns (stream HelloReply) {};
+  rpc SayHellosSendHeadersFirst (HelloRequest) returns (stream HelloReply) {};
 }
 
 // Test multiple services in one package

--- a/testassets/Proto/lifetime.proto
+++ b/testassets/Proto/lifetime.proto
@@ -19,9 +19,9 @@ import "google/protobuf/empty.proto";
 package Lifetime;
 
 service LifetimeService {
-  rpc GetScopedValue (google.protobuf.Empty) returns (ValueResponse) {}
-  rpc GetSingletonValue (google.protobuf.Empty) returns (ValueResponse) {}
-  rpc GetTransientValue (google.protobuf.Empty) returns (ValueResponse) {}
+  rpc GetScopedValue (google.protobuf.Empty) returns (ValueResponse) {};
+  rpc GetSingletonValue (google.protobuf.Empty) returns (ValueResponse) {};
+  rpc GetTransientValue (google.protobuf.Empty) returns (ValueResponse) {};
 }
 
 message ValueResponse {

--- a/testassets/Proto/nested.proto
+++ b/testassets/Proto/nested.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 package Nested;
 
 service NestedService {
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHello (HelloRequest) returns (HelloReply) {};
 }
 
 message HelloRequest {

--- a/testassets/Proto/singleton.proto
+++ b/testassets/Proto/singleton.proto
@@ -20,7 +20,7 @@ package SingletonCount;
 // The counter service definition.
 service Counter {
   // Get current count
-  rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {}
+  rpc IncrementCount (google.protobuf.Empty) returns (CounterReply) {};
 }
 
 // The response message containing the current count


### PR DESCRIPTION
Semicolon is optional but its absence breaks some syntax highlighters. Lets use it everywhere.