### PR TITLE
Fix incorrectly setting examined when message is read

### DIFF
--- a/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
@@ -58,7 +58,7 @@ namespace Grpc.AspNetCore.Server.Tests
             // Assert
             Assert.AreEqual(0, messageData.Length);
             Assert.IsNotNull(pipeReader.Consumed); // Consume the data
-            Assert.IsNull(pipeReader.Examined); // Read data together so there is no need to examine
+            Assert.IsNull(pipeReader.Examined); // Read complete message so there is no need to request more
         }
 
         [Test]
@@ -355,7 +355,7 @@ namespace Grpc.AspNetCore.Server.Tests
                     0x10
                 };
 
-            // Run continuations without async so ReadSingleMessageAsync immediately consumes data
+            // Run continuations without async so ReadSingleMessageAsync immediately consumes added data
             var requestStream = new SyncPointMemoryStream(runContinuationsAsynchronously: false);
 
             var pipeReader = new TestPipeReader(PipeReader.Create(requestStream));
@@ -373,14 +373,13 @@ namespace Grpc.AspNetCore.Server.Tests
 
                 await requestStream.AddDataAndWait(new[] { b }).DefaultTimeout();
 
-                Assert.IsNotNull(pipeReader.Consumed); // Consume the data
                 if (!isLast)
                 {
                     Assert.IsNotNull(pipeReader.Examined); // Message is not complete, reporting need to read more
                 }
                 else
                 {
-                    Assert.IsNull(pipeReader.Examined); // Last segment so examined not set
+                    Assert.IsNull(pipeReader.Examined); // Last segment so no need to set examined to request more data
                 }
             }
 

--- a/test/Shared/SyncPointMemoryStream.cs
+++ b/test/Shared/SyncPointMemoryStream.cs
@@ -28,14 +28,17 @@ namespace Grpc.Tests.Shared
     /// </summary>
     public class SyncPointMemoryStream : Stream
     {
+        private readonly bool _runContinuationsAsynchronously;
+
         private SyncPoint _syncPoint;
         private Func<Task> _awaiter;
         private byte[] _currentData;
 
-        public SyncPointMemoryStream()
+        public SyncPointMemoryStream(bool runContinuationsAsynchronously = true)
         {
+            _runContinuationsAsynchronously = runContinuationsAsynchronously;
             _currentData = Array.Empty<byte>();
-            _awaiter = SyncPoint.Create(out _syncPoint);
+            _awaiter = SyncPoint.Create(out _syncPoint, _runContinuationsAsynchronously);
         }
 
         /// <summary>
@@ -111,7 +114,7 @@ namespace Grpc.Tests.Shared
 
         private void ResetSyncPoint()
         {
-            _awaiter = SyncPoint.Create(out _syncPoint);
+            _awaiter = SyncPoint.Create(out _syncPoint, _runContinuationsAsynchronously);
         }
 
         #region Stream implementation


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/401

When a complete message was parsed gRPC was incorrectly requesting more data. When given a constant stream of data from the client the server would eagerly grab it, creating a build up on data on the pipe.

Only request more data when a message is not finished.