### PR TITLE
Add functional tests for hangs in client

### DIFF
--- a/Grpc.DotNet.sln
+++ b/Grpc.DotNet.sln
@@ -68,6 +68,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Proto", "Proto", "{BF1393D4
 		testassets\Proto\nested.proto = testassets\Proto\nested.proto
 		testassets\Proto\singleton.proto = testassets\Proto\singleton.proto
 		testassets\Proto\streaming.proto = testassets\Proto\streaming.proto
+		testassets\Proto\unimplemented.proto = testassets\Proto\unimplemented.proto
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionalTestsWebsite", "testassets\FunctionalTestsWebsite\FunctionalTestsWebsite.csproj", "{7B95289B-4992-4C0D-B26F-8EC58F81FC96}"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview8-013421"
+    "version": "3.0.100-preview8-013442"
   }
 }

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -19,5 +19,6 @@
     <Protobuf Include="..\Proto\nested.proto" Link="Protos\nested.proto" />
     <Protobuf Include="..\Proto\singleton.proto" Link="Protos\singleton.proto" />
     <Protobuf Include="..\Proto\streaming.proto" Link="Protos\streaming.proto" />
+    <Protobuf Include="..\Proto\unimplemented.proto" Link="Protos\unimplemented.proto" />
   </ItemGroup>
 </Project>

--- a/testassets/Proto/unimplemented.proto
+++ b/testassets/Proto/unimplemented.proto
@@ -1,0 +1,27 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+package Unimplemented;
+
+// No service is registered on the server so methods will return unimplemented
+service UnimplementedService {
+  rpc DuplexData (stream UnimplementeDataMessage) returns (stream UnimplementeDataMessage);
+}
+
+message UnimplementeDataMessage {
+  bytes data = 1;
+}


### PR DESCRIPTION
WIP because the SDK containing the fix has a problem. Will update when the SDK with fix is fixed.