### PR TITLE
Fix hang in client writer when call is started canceled

### DIFF
--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -17,7 +17,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -232,9 +232,9 @@ namespace Grpc.Net.Client.Tests
         public async Task ClientStreamWriter_CancelledBeforeCallStarts_ThrowsError()
         {
             // Arrange
-            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            var httpClient = ClientTestHelpers.CreateTestClient(request =>
             {
-                return ResponseUtils.CreateResponse(HttpStatusCode.OK);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK));
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);
 


### PR DESCRIPTION
Race condition in client/duplex streaming when call is passed a canceled cancellation token.