### PR TITLE
Update SDK and enable fixed tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview9-013629"
+    "version": "3.0.100-preview9-013753"
   }
 }

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -166,6 +166,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         [Test]
         public async Task DuplexStream_SendToUnimplementedMethodAfterResponseReceived_MoveNextThrowsError()
         {
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                if (writeContext.LoggerName == "Grpc.Net.Client.Internal.GrpcCall" &&
+                    writeContext.EventId.Name == "GrpcStatusError" &&
+                    writeContext.State.ToString() == "Server returned gRPC error status. Status code: 'Unimplemented', Message: 'Service is unimplemented.'.")
+                {
+                    return true;
+                }
+
+                return false;
+            });
+
             // Arrange
             var client = new UnimplementedService.UnimplementedServiceClient(Channel);
 

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -126,7 +126,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         }
 
         [Test]
-        [Ignore("Waiting on fix from https://github.com/dotnet/corefx/issues/39586")]
+        //[Ignore("Waiting on fix from https://github.com/dotnet/corefx/issues/39586")]
         public async Task DuplexStream_SendToUnimplementedMethod_ThrowError()
         {
             SetExpectedErrorsFilter(writeContext =>
@@ -165,7 +165,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         }
 
         [Test]
-        [Ignore("Waiting on fix from https://github.com/dotnet/corefx/issues/39586")]
+        //[Ignore("Waiting on fix from https://github.com/dotnet/corefx/issues/39586")]
         public async Task DuplexStream_SendToUnimplementedMethodAfterResponseReceived_Hang()
         {
             // Arrange

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -126,7 +126,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         }
 
         [Test]
-        //[Ignore("Waiting on fix from https://github.com/dotnet/corefx/issues/39586")]
         public async Task DuplexStream_SendToUnimplementedMethod_ThrowError()
         {
             SetExpectedErrorsFilter(writeContext =>
@@ -165,7 +164,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         }
 
         [Test]
-        //[Ignore("Waiting on fix from https://github.com/dotnet/corefx/issues/39586")]
         public async Task DuplexStream_SendToUnimplementedMethodAfterResponseReceived_Hang()
         {
             // Arrange

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -193,9 +193,11 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 await call.RequestStream.CompleteAsync();
 
                 var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext());
+                var status = call.GetStatus();
 
                 // Assert
                 Assert.AreEqual(StatusCode.Unimplemented, ex.StatusCode);
+                Assert.AreEqual(StatusCode.Unimplemented, status.StatusCode);
             }
         }
     }

--- a/test/FunctionalTests/Server/ClientStreamingMethodTests.cs
+++ b/test/FunctionalTests/Server/ClientStreamingMethodTests.cs
@@ -275,8 +275,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             var responseTask = Fixture.Client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
 
             // Assert
-            Assert.IsFalse(responseTask.IsCompleted, "Server should wait for client to finish streaming");
-
             var response = await responseTask.DefaultTimeout();
 
             response.AssertIsSuccessfulGrpcRequest();


### PR DESCRIPTION
SDK contains HTTP/2 fix for some disabled tests.