### PR TITLE
Rename max message size properties

### DIFF
--- a/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
@@ -37,12 +37,12 @@ namespace Grpc.AspNetCore.Server
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be sent from the server.
         /// </summary>
-        public int? SendMaxMessageSize { get; set; }
+        public int? MaxSendMessageSize { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be received by the server.
         /// </summary>
-        public int? ReceiveMaxMessageSize { get; set; }
+        public int? MaxReceiveMessageSize { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether detailed error messages are sent to the peer.

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
@@ -31,9 +31,9 @@ namespace Grpc.AspNetCore.Server.Internal
 
         public void Configure(GrpcServiceOptions options)
         {
-            if (options.ReceiveMaxMessageSize == null)
+            if (options.MaxReceiveMessageSize == null)
             {
-                options.ReceiveMaxMessageSize = DefaultReceiveMaxMessageSize;
+                options.MaxReceiveMessageSize = DefaultReceiveMaxMessageSize;
             }
             if (options._compressionProviders == null || options._compressionProviders.Count == 0)
             {
@@ -54,8 +54,8 @@ namespace Grpc.AspNetCore.Server.Internal
 
         public void Configure(GrpcServiceOptions<TService> options)
         {
-            options.ReceiveMaxMessageSize = _options.ReceiveMaxMessageSize;
-            options.SendMaxMessageSize = _options.SendMaxMessageSize;
+            options.MaxReceiveMessageSize = _options.MaxReceiveMessageSize;
+            options.MaxSendMessageSize = _options.MaxSendMessageSize;
             options.EnableDetailedErrors = _options.EnableDetailedErrors;
             options.ResponseCompressionAlgorithm = _options.ResponseCompressionAlgorithm;
             options.ResponseCompressionLevel = _options.ResponseCompressionLevel;

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -95,7 +95,7 @@ namespace Grpc.AspNetCore.Server.Internal
                         responsePayload);
                 }
 
-                if (responsePayload.Length > serverCallContext.ServiceOptions.SendMaxMessageSize)
+                if (responsePayload.Length > serverCallContext.ServiceOptions.MaxSendMessageSize)
                 {
                     throw new RpcException(SendingMessageExceedsLimitStatus);
                 }
@@ -395,7 +395,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 return false;
             }
 
-            if (messageLength > context.ServiceOptions.ReceiveMaxMessageSize)
+            if (messageLength > context.ServiceOptions.MaxReceiveMessageSize)
             {
                 throw new RpcException(ReceivedMessageExceedsLimitStatus);
             }

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -60,8 +60,8 @@ namespace Grpc.AspNetCore.Server.Internal
             _resolvedOptions = new GrpcServiceOptions
             {
                 EnableDetailedErrors = so.EnableDetailedErrors ?? go.EnableDetailedErrors,
-                ReceiveMaxMessageSize = so.ReceiveMaxMessageSize ?? go.ReceiveMaxMessageSize,
-                SendMaxMessageSize = so.SendMaxMessageSize ?? go.SendMaxMessageSize,
+                MaxReceiveMessageSize = so.MaxReceiveMessageSize ?? go.MaxReceiveMessageSize,
+                MaxSendMessageSize = so.MaxSendMessageSize ?? go.MaxSendMessageSize,
                 ResponseCompressionAlgorithm = so.ResponseCompressionAlgorithm ?? go.ResponseCompressionAlgorithm,
                 ResponseCompressionLevel = so.ResponseCompressionLevel ?? go.ResponseCompressionLevel
             };

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -38,7 +38,7 @@ namespace Grpc.Net.Client
     /// </summary>
     public sealed class GrpcChannel : ChannelBase
     {
-        internal const int DefaultReceiveMaxMessageSize = 1024 * 1024 * 4; // 4 MB
+        internal const int DefaultMaxReceiveMessageSize = 1024 * 1024 * 4; // 4 MB
 
         internal Uri Address { get; }
         internal HttpClient HttpClient { get; }
@@ -58,8 +58,8 @@ namespace Grpc.Net.Client
         {
             Address = address;
             HttpClient = channelOptions.HttpClient ?? new HttpClient();
-            SendMaxMessageSize = channelOptions.SendMaxMessageSize;
-            ReceiveMaxMessageSize = channelOptions.ReceiveMaxMessageSize;
+            SendMaxMessageSize = channelOptions.MaxSendMessageSize;
+            ReceiveMaxMessageSize = channelOptions.MaxReceiveMessageSize;
             CompressionProviders = ResolveCompressionProviders(channelOptions.CompressionProviders);
             MessageAcceptEncoding = GrpcProtocolHelpers.GetMessageAcceptEncoding(CompressionProviders);
             LoggerFactory = channelOptions.LoggerFactory ?? NullLoggerFactory.Instance;

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -38,12 +38,12 @@ namespace Grpc.Net.Client
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be sent from the client.
         /// </summary>
-        public int? SendMaxMessageSize { get; set; }
+        public int? MaxSendMessageSize { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be received by the client.
         /// </summary>
-        public int? ReceiveMaxMessageSize { get; set; }
+        public int? MaxReceiveMessageSize { get; set; }
 
         /// <summary>
         /// Gets or sets a collection of compression providers.
@@ -65,7 +65,7 @@ namespace Grpc.Net.Client
         /// </summary>
         public GrpcChannelOptions()
         {
-            ReceiveMaxMessageSize = GrpcChannel.DefaultReceiveMaxMessageSize;
+            MaxReceiveMessageSize = GrpcChannel.DefaultMaxReceiveMessageSize;
         }
     }
 }

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcServicesExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcServicesExtensionsTests.cs
@@ -34,8 +34,8 @@ namespace Grpc.AspNetCore.Server.Tests
                 .AddGrpc(o =>
                 {
                     o.EnableDetailedErrors = true;
-                    o.ReceiveMaxMessageSize = 1;
-                    o.SendMaxMessageSize = 1;
+                    o.MaxReceiveMessageSize = 1;
+                    o.MaxSendMessageSize = 1;
                 });
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
@@ -45,8 +45,8 @@ namespace Grpc.AspNetCore.Server.Tests
 
             // Assert
             Assert.AreEqual(true, options.EnableDetailedErrors);
-            Assert.AreEqual(1, options.ReceiveMaxMessageSize);
-            Assert.AreEqual(1, options.SendMaxMessageSize);
+            Assert.AreEqual(1, options.MaxReceiveMessageSize);
+            Assert.AreEqual(1, options.MaxSendMessageSize);
         }
 
         [Test]
@@ -58,12 +58,12 @@ namespace Grpc.AspNetCore.Server.Tests
                 .AddGrpc(o =>
                 {
                     o.EnableDetailedErrors = true;
-                    o.ReceiveMaxMessageSize = 1;
-                    o.SendMaxMessageSize = 1;
+                    o.MaxReceiveMessageSize = 1;
+                    o.MaxSendMessageSize = 1;
                 })
                 .AddServiceOptions<object>(o =>
                 {
-                    o.SendMaxMessageSize = 2;
+                    o.MaxSendMessageSize = 2;
                 });
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
@@ -73,8 +73,8 @@ namespace Grpc.AspNetCore.Server.Tests
 
             // Assert
             Assert.AreEqual(true, options.EnableDetailedErrors);
-            Assert.AreEqual(1, options.ReceiveMaxMessageSize);
-            Assert.AreEqual(2, options.SendMaxMessageSize);
+            Assert.AreEqual(1, options.MaxReceiveMessageSize);
+            Assert.AreEqual(2, options.MaxSendMessageSize);
         }
     }
 }

--- a/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTests.cs
@@ -91,7 +91,7 @@ namespace Grpc.AspNetCore.Server.Tests
         public async Task ReadSingleMessageAsync_UnderReceiveSize_ReturnData()
         {
             // Arrange
-            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { SendMaxMessageSize = 1 });
+            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { MaxSendMessageSize = 1 });
             var ms = new MemoryStream(new byte[]
                 {
                     0x00, // compression = 0
@@ -116,7 +116,7 @@ namespace Grpc.AspNetCore.Server.Tests
         public async Task ReadSingleMessageAsync_ExceedReceiveSize_ReturnData()
         {
             // Arrange
-            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { ReceiveMaxMessageSize = 1 });
+            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { MaxReceiveMessageSize = 1 });
             var ms = new MemoryStream(new byte[]
                 {
                     0x00, // compression = 0
@@ -593,7 +593,7 @@ namespace Grpc.AspNetCore.Server.Tests
         public async Task WriteMessageAsync_UnderSendSize_WriteData()
         {
             // Arrange
-            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { SendMaxMessageSize = 1 });
+            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { MaxSendMessageSize = 1 });
             var ms = new MemoryStream();
             var pipeWriter = PipeWriter.Create(ms);
 
@@ -620,7 +620,7 @@ namespace Grpc.AspNetCore.Server.Tests
         public async Task WriteMessageAsync_ExceedSendSize_ThrowError()
         {
             // Arrange
-            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { SendMaxMessageSize = 1 });
+            var context = HttpContextServerCallContextHelper.CreateServerCallContext(serviceOptions: new GrpcServiceOptions { MaxSendMessageSize = 1 });
             var ms = new MemoryStream();
             var pipeWriter = PipeWriter.Create(ms);
 

--- a/test/Grpc.Net.Client.Tests/MaximumMessageSizeTests.cs
+++ b/test/Grpc.Net.Client.Tests/MaximumMessageSizeTests.cs
@@ -61,7 +61,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.SendMaxMessageSize = 100);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxSendMessageSize = 100);
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest
@@ -79,7 +79,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.SendMaxMessageSize = 1);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxSendMessageSize = 1);
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest
@@ -103,7 +103,7 @@ namespace Grpc.Net.Client.Tests
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest
             {
-                Name = new string('!', GrpcChannel.DefaultReceiveMaxMessageSize + 1) // max size + 1 B
+                Name = new string('!', GrpcChannel.DefaultMaxReceiveMessageSize + 1) // max size + 1 B
             });
 
             // Assert
@@ -117,8 +117,8 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ReceiveMaxMessageSize = null);
-            var largeName = new string('!', GrpcChannel.DefaultReceiveMaxMessageSize + 1); // max size + 1 B
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxReceiveMessageSize = null);
+            var largeName = new string('!', GrpcChannel.DefaultMaxReceiveMessageSize + 1); // max size + 1 B
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest
@@ -136,7 +136,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ReceiveMaxMessageSize = 100);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxReceiveMessageSize = 100);
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest
@@ -154,7 +154,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ReceiveMaxMessageSize = 1);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxReceiveMessageSize = 1);
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest
@@ -173,7 +173,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.SendMaxMessageSize = 100);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxSendMessageSize = 100);
 
             // Act
             var call = invoker.AsyncDuplexStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions());
@@ -193,7 +193,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.SendMaxMessageSize = 1);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxSendMessageSize = 1);
 
             // Act
             var call = invoker.AsyncDuplexStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions());
@@ -212,7 +212,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ReceiveMaxMessageSize = 100);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxReceiveMessageSize = 100);
 
             // Act
             var call = invoker.AsyncDuplexStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions());
@@ -232,7 +232,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(HandleRequest);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ReceiveMaxMessageSize = 1);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.MaxReceiveMessageSize = 1);
 
             // Act
             var call = invoker.AsyncDuplexStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions());

--- a/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
@@ -55,7 +55,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
                 })
                 .ConfigureChannel(options =>
                 {
-                    options.SendMaxMessageSize = 100;
+                    options.MaxSendMessageSize = 100;
                 })
                 .ConfigurePrimaryHttpMessageHandler(() =>
                 {

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -46,8 +46,8 @@ namespace FunctionalTestsWebsite
                 })
                 .AddServiceOptions<GreeterService>(options =>
                 {
-                    options.SendMaxMessageSize = 64 * 1024;
-                    options.ReceiveMaxMessageSize = 64 * 1024;
+                    options.MaxSendMessageSize = 64 * 1024;
+                    options.MaxReceiveMessageSize = 64 * 1024;
                 })
                 .AddServiceOptions<CompressionService>(options =>
                 {


### PR DESCRIPTION
Makes max size configuration consistent with Kestrel and other gRPC implementation naming.