### PR TITLE
Major client performance refactor

### DIFF
--- a/perf/Grpc.AspNetCore.Microbenchmarks/Program.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Program.cs
@@ -33,7 +33,7 @@ namespace Grpc.AspNetCore.Microbenchmarks
         {
             var benchmark = new Client.UnaryClientBenchmark();
             benchmark.GlobalSetup();
-            for (var i = 0; i < 100; i++)
+            for (var i = 0; i < 1000; i++)
             {
                 await benchmark.HandleCallAsync();
             }

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -17,12 +17,9 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Net.Http;
-using System.Net.Mail;
-using System.Threading;
 using Grpc.Core;
 using Grpc.Net.Client.Internal;
 using Grpc.Net.Compression;
@@ -40,6 +37,9 @@ namespace Grpc.Net.Client
     {
         internal const int DefaultMaxReceiveMessageSize = 1024 * 1024 * 4; // 4 MB
 
+        private readonly ConcurrentDictionary<IMethod, GrpcMethodInfo> _methodInfoCache;
+        private readonly Func<IMethod, GrpcMethodInfo> _createMethodInfoFunc;
+
         internal Uri Address { get; }
         internal HttpClient HttpClient { get; }
         internal int? SendMaxMessageSize { get; }
@@ -51,7 +51,6 @@ namespace Grpc.Net.Client
         internal Dictionary<string, ICompressionProvider> CompressionProviders { get; }
         internal string MessageAcceptEncoding { get; }
         internal bool Disposed { get; private set; }
-
         // Timing related options that are set in unit tests
         internal ISystemClock Clock = SystemClock.Instance;
         internal bool DisableClientDeadlineTimer { get; set; }
@@ -60,6 +59,8 @@ namespace Grpc.Net.Client
 
         internal GrpcChannel(Uri address, GrpcChannelOptions channelOptions) : base(address.Authority)
         {
+            _methodInfoCache = new ConcurrentDictionary<IMethod, GrpcMethodInfo>();
+
             // Dispose the HttpClient if...
             //   1. No client was specified and so the channel created the HttpClient itself
             //   2. User has specified a client and set DisposeHttpClient to true
@@ -73,6 +74,7 @@ namespace Grpc.Net.Client
             MessageAcceptEncoding = GrpcProtocolHelpers.GetMessageAcceptEncoding(CompressionProviders);
             LoggerFactory = channelOptions.LoggerFactory ?? NullLoggerFactory.Instance;
             ThrowOperationCanceledOnCancellation = channelOptions.ThrowOperationCanceledOnCancellation;
+            _createMethodInfoFunc = CreateMethodInfo;
 
             if (channelOptions.Credentials != null)
             {
@@ -84,6 +86,19 @@ namespace Grpc.Net.Client
 
                 ValidateChannelCredentials();
             }
+        }
+
+        internal GrpcMethodInfo GrpcMethodInfo(IMethod method)
+        {
+            return _methodInfoCache.GetOrAdd(method, _createMethodInfoFunc);
+        }
+
+        private GrpcMethodInfo CreateMethodInfo(IMethod method)
+        {
+            var uri = new Uri(method.FullName, UriKind.Relative);
+            var scope = new GrpcCallScope(method.Type, uri);
+
+            return new GrpcMethodInfo(scope, new Uri(Address, uri));
         }
 
         private static Dictionary<string, ICompressionProvider> ResolveCompressionProviders(IList<ICompressionProvider>? compressionProviders)

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -88,7 +88,7 @@ namespace Grpc.Net.Client
             }
         }
 
-        internal GrpcMethodInfo GrpcMethodInfo(IMethod method)
+        internal GrpcMethodInfo GetCachedGrpcMethodInfo(IMethod method)
         {
             return _methodInfoCache.GetOrAdd(method, _createMethodInfoFunc);
         }

--- a/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
+++ b/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
@@ -1,0 +1,45 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Collections.Generic;
+using Grpc.Core;
+
+namespace Grpc.Net.Client.Internal
+{
+    internal class DefaultCallCredentialsConfigurator : CallCredentialsConfiguratorBase
+    {
+        public AsyncAuthInterceptor? Interceptor { get; private set; }
+        public IReadOnlyList<CallCredentials>? Credentials { get; private set; }
+
+        public void Reset()
+        {
+            Interceptor = null;
+            Credentials = null;
+        }
+
+        public override void SetAsyncAuthInterceptorCredentials(object state, AsyncAuthInterceptor interceptor)
+        {
+            Interceptor = interceptor;
+        }
+
+        public override void SetCompositeCredentials(object state, IReadOnlyList<CallCredentials> credentials)
+        {
+            Credentials = credentials;
+        }
+    }
+}

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -17,14 +17,10 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -36,8 +32,12 @@ namespace Grpc.Net.Client.Internal
         where TRequest : class
         where TResponse : class
     {
+        // Getting logger name from generic type is slow
+        private const string LoggerName = "Grpc.Net.Client.Internal.GrpcCall";
+
         private readonly CancellationTokenSource _callCts;
         private readonly TaskCompletionSource<Status> _callTcs;
+        private readonly TaskCompletionSource<Metadata> _metadataTcs;
         private readonly TimeSpan? _timeout;
         private readonly Uri _uri;
         private readonly GrpcCallScope _logScope;
@@ -45,8 +45,6 @@ namespace Grpc.Net.Client.Internal
         private Timer? _deadlineTimer;
         private Metadata? _trailers;
         private CancellationTokenRegistration? _ctsRegistration;
-        private TaskCompletionSource<Stream>? _writeStreamTcs;
-        private TaskCompletionSource<bool>? _writeCompleteTcs;
 
         public bool Disposed { get; private set; }
         public bool ResponseFinished { get; private set; }
@@ -54,25 +52,28 @@ namespace Grpc.Net.Client.Internal
         public CallOptions Options { get; }
         public Method<TRequest, TResponse> Method { get; }
         public GrpcChannel Channel { get; }
-
         public ILogger Logger { get; }
-        public Task? SendTask { get; private set; }
+
+        // These are set depending on the type of gRPC call
+        private TaskCompletionSource<TResponse>? _responseTcs;
         public HttpContentClientStreamWriter<TRequest, TResponse>? ClientStreamWriter { get; private set; }
         public HttpContentClientStreamReader<TRequest, TResponse>? ClientStreamReader { get; private set; }
 
-        public GrpcCall(Method<TRequest, TResponse> method, CallOptions options, GrpcChannel channel)
+        public GrpcCall(Method<TRequest, TResponse> method, Uri uri, GrpcCallScope logScope, CallOptions options, GrpcChannel channel)
         {
             // Validate deadline before creating any objects that require cleanup
             ValidateDeadline(options.Deadline);
 
             _callCts = new CancellationTokenSource();
-            _callTcs = new TaskCompletionSource<Status>(TaskContinuationOptions.RunContinuationsAsynchronously);
+            // Run the callTcs continuation immediately to keep the same context. Required for Activity.
+            _callTcs = new TaskCompletionSource<Status>();
+            _metadataTcs = new TaskCompletionSource<Metadata>(TaskCreationOptions.RunContinuationsAsynchronously);
             Method = method;
-            _uri = new Uri(method.FullName, UriKind.Relative);
-            _logScope = new GrpcCallScope(method.Type, _uri);
+            _uri = uri;
+            _logScope = logScope;
             Options = options;
             Channel = channel;
-            Logger = channel.LoggerFactory.CreateLogger<GrpcCall<TRequest, TResponse>>();
+            Logger = channel.LoggerFactory.CreateLogger(LoggerName);
 
             if (options.Deadline != null && options.Deadline != DateTime.MaxValue)
             {
@@ -98,32 +99,36 @@ namespace Grpc.Net.Client.Internal
 
         public void StartUnary(TRequest request)
         {
+            _responseTcs = new TaskCompletionSource<TResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             var message = CreateHttpRequestMessage();
             SetMessageContent(request, message);
-            _ = StartAsync(message);
+            _ = RunCall(message);
         }
 
         public void StartClientStreaming()
         {
+            _responseTcs = new TaskCompletionSource<TResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             var message = CreateHttpRequestMessage();
-            ClientStreamWriter = CreateWriter(message);
-            _ = StartAsync(message);
+            CreateWriter(message);
+            _ = RunCall(message);
         }
 
         public void StartServerStreaming(TRequest request)
         {
             var message = CreateHttpRequestMessage();
             SetMessageContent(request, message);
-            _ = StartAsync(message);
             ClientStreamReader = new HttpContentClientStreamReader<TRequest, TResponse>(this);
+            _ = RunCall(message);
         }
 
         public void StartDuplexStreaming()
         {
             var message = CreateHttpRequestMessage();
-            ClientStreamWriter = CreateWriter(message);
-            _ = StartAsync(message);
+            CreateWriter(message);
             ClientStreamReader = new HttpContentClientStreamReader<TRequest, TResponse>(this);
+            _ = RunCall(message);
         }
 
         public void Dispose()
@@ -157,12 +162,11 @@ namespace Grpc.Net.Client.Internal
             }
             else
             {
-                _writeStreamTcs?.TrySetCanceled();
-                _writeCompleteTcs?.TrySetCanceled();
-
-                // If response has successfully finished then the status will come from the trailers
-                // If it didn't finish then complete with a status
                 _callTcs.TrySetResult(status);
+
+                ClientStreamWriter?.WriteStreamTcs.TrySetCanceled();
+                ClientStreamWriter?.CompleteTcs.TrySetCanceled();
+                ClientStreamReader?.HttpResponseTcs.TrySetCanceled();
             }
 
             _ctsRegistration?.Dispose();
@@ -171,10 +175,10 @@ namespace Grpc.Net.Client.Internal
             ClientStreamReader?.Dispose();
             ClientStreamWriter?.Dispose();
 
-            // To avoid racing with Dispose, skip disposing the call CTS
-            // This avoid Dispose potentially calling cancel on a disposed CTS
+            // To avoid racing with Dispose, skip disposing the call CTS.
+            // This avoid Dispose potentially calling cancel on a disposed CTS.
             // The call CTS is not exposed externally and all dependent registrations
-            // are cleaned up
+            // are cleaned up.
         }
 
         public void EnsureNotDisposed()
@@ -190,74 +194,26 @@ namespace Grpc.Net.Client.Internal
             var status = (CallTask.IsCompletedSuccessfully) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
             return new RpcException(status);
         }
-
+        
         /// <summary>
         /// Marks the response as finished, i.e. all response content has been read and trailers are available.
         /// Can be called by <see cref="GetResponseAsync"/> for unary and client streaming calls, or
         /// <see cref="HttpContentClientStreamReader{TRequest,TResponse}.MoveNextCore(CancellationToken)"/>
         /// for server streaming and duplex streaming calls.
         /// </summary>
-        public void FinishResponse(bool throwOnFail, Status? status = null)
+        public void FinishResponse(Status status)
         {
             ResponseFinished = true;
-            Debug.Assert(HttpResponse != null);
-
-            if (status == null)
-            {
-                try
-                {
-                    if (!TryGetStatusCore(HttpResponse, out status))
-                    {
-                        status = new Status(StatusCode.Cancelled, "No grpc-status found on response.");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // Handle error from parsing badly formed status
-                    status = new Status(StatusCode.Cancelled, ex.Message);
-                }
-            }
 
             // Clean up call resources once this call is finished
             // Call may not be explicitly disposed when used with unary methods
             // e.g. var reply = await client.SayHelloAsync(new HelloRequest());
-            Cleanup(status.Value);
-
-            if (throwOnFail)
-            {
-                // Get status from response before dispose
-                // This may throw an error if the grpc-status is missing or malformed
-                if (status.Value.StatusCode == StatusCode.DeadlineExceeded &&
-                    Channel.ThrowOperationCanceledOnCancellation)
-                {
-                    throw new OperationCanceledException("Call returned a deadline exceeded status.");
-                }
-                else if (status.Value.StatusCode != StatusCode.OK)
-                {
-                    throw new RpcException(status.Value);
-                }
-            }
+            Cleanup(status);
         }
 
-        public async Task<Metadata> GetResponseHeadersAsync()
+        public Task<Metadata> GetResponseHeadersAsync()
         {
-            Debug.Assert(SendTask != null);
-
-            try
-            {
-                using (StartScope())
-                {
-                    await SendTask.ConfigureAwait(false);
-                    Debug.Assert(HttpResponse != null);
-
-                    // The task of this method is cached so there is no need to cache the headers here
-                    return GrpcProtocolHelpers.BuildMetadata(HttpResponse.Headers);
-                }
-            }
-            catch (OperationCanceledException) when (!Channel.ThrowOperationCanceledOnCancellation)
-            {
-                throw CreateCanceledStatusException();
-            }
+            return _metadataTcs.Task;
         }
 
         public Status GetStatus()
@@ -273,104 +229,42 @@ namespace Grpc.Net.Client.Internal
             }
         }
 
-        public async Task<TResponse> GetResponseAsync()
+        public Task<TResponse> GetResponseAsync()
         {
-            Debug.Assert(SendTask != null);
-
-            try
-            {
-                using (StartScope())
-                {
-                    // Wait for send to finish so the HttpResponse is available
-                    await SendTask.ConfigureAwait(false);
-
-                    // Verify the call is not complete. The call should be complete once the grpc-status
-                    // has been read from trailers, which happens AFTER the message has been read.
-                    if (CallTask.IsCompletedSuccessfully)
-                    {
-                        var status = CallTask.Result;
-                        if (status.StatusCode != StatusCode.OK)
-                        {
-                            throw new RpcException(status);
-                        }
-                        else
-                        {
-                            // The server should never return StatusCode.OK in the header for a unary call.
-                            // If it does then throw an error that no message was returned from the server.
-                            Log.MessageNotReturned(Logger);
-                            throw new InvalidOperationException("Call did not return a response message");
-                        }
-                    }
-
-                    Debug.Assert(HttpResponse != null);
-
-                    // Trailers are only available once the response body had been read
-                    var responseStream = await HttpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    var message = await responseStream.ReadSingleMessageAsync(
-                        Logger,
-                        Method.ResponseMarshaller.ContextualDeserializer,
-                        GrpcProtocolHelpers.GetGrpcEncoding(HttpResponse),
-                        Channel.ReceiveMaxMessageSize,
-                        Channel.CompressionProviders,
-                        _callCts.Token).ConfigureAwait(false);
-                    FinishResponse(throwOnFail: true);
-
-                    if (message == null)
-                    {
-                        Log.MessageNotReturned(Logger);
-                        throw new InvalidOperationException("Call did not return a response message");
-                    }
-
-                    GrpcEventSource.Log.MessageReceived();
-
-                    // The task of this method is cached so there is no need to cache the message here
-                    return message;
-                }
-            }
-            catch (OperationCanceledException) when (!Channel.ThrowOperationCanceledOnCancellation)
-            {
-                throw CreateCanceledStatusException();
-            }
+            Debug.Assert(_responseTcs != null);
+            return _responseTcs.Task;
         }
 
-        private void ValidateHeaders()
+        private Status? ValidateHeaders(HttpResponseMessage httpResponse)
         {
-            // We don't want to throw in this method, even for non-success situations.
-            // Response is still needed to return headers in GetResponseHeadersAsync.
-
             Log.ResponseHeadersReceived(Logger);
 
-            Debug.Assert(HttpResponse != null);
-            if (HttpResponse.StatusCode != HttpStatusCode.OK)
+            if (httpResponse.StatusCode != HttpStatusCode.OK)
             {
-                FinishResponse(throwOnFail: false, new Status(StatusCode.Cancelled, "Bad gRPC response. Expected HTTP status code 200. Got status code: " + (int)HttpResponse.StatusCode));
-                return;
+                return new Status(StatusCode.Cancelled, "Bad gRPC response. Expected HTTP status code 200. Got status code: " + (int)httpResponse.StatusCode);
             }
             
-            if (HttpResponse.Content?.Headers.ContentType == null)
+            if (httpResponse.Content?.Headers.ContentType == null)
             {
-                FinishResponse(throwOnFail: false, new Status(StatusCode.Cancelled, "Bad gRPC response. Response did not have a content-type header."));
-                return;
+                return new Status(StatusCode.Cancelled, "Bad gRPC response. Response did not have a content-type header.");
             }
 
-            var grpcEncoding = HttpResponse.Content.Headers.ContentType.ToString();
+            var grpcEncoding = httpResponse.Content.Headers.ContentType;
             if (!GrpcProtocolHelpers.IsGrpcContentType(grpcEncoding))
             {
-                FinishResponse(throwOnFail: false, new Status(StatusCode.Cancelled, "Bad gRPC response. Invalid content-type value: " + grpcEncoding));
-                return;
+                return new Status(StatusCode.Cancelled, "Bad gRPC response. Invalid content-type value: " + grpcEncoding);
             }
             else
             {
-                if (TryGetStatusCore(HttpResponse.Headers, out var status))
+                // gRPC status can be returned in the header when there is no message (e.g. unimplemented status)
+                if (GrpcProtocolHelpers.TryGetStatusCore(httpResponse.Headers, out var status))
                 {
-                    // grpc-status is returned in the header when there is no message body
-                    // For example, unimplemented method/service status
-                    FinishResponse(throwOnFail: false, status);
-                    return;
+                    return status;
                 }
             }
 
-            // Success!
+            // Call is still in progress
+            return null;
         }
 
         public Metadata GetTrailers()
@@ -391,38 +285,20 @@ namespace Grpc.Net.Client.Internal
 
         private void SetMessageContent(TRequest request, HttpRequestMessage message)
         {
-            message.Content = new PushStreamContent(
-                (stream) =>
-                {
-                    var grpcEncoding = GrpcProtocolHelpers.GetRequestEncoding(message.Headers);
-
-                    var writeMessageTask = stream.WriteMessageAsync<TRequest>(
-                        Logger,
-                        request,
-                        Method.RequestMarshaller.ContextualSerializer,
-                        grpcEncoding,
-                        Channel.SendMaxMessageSize,
-                        Channel.CompressionProviders,
-                        Options);
-                    if (writeMessageTask.IsCompletedSuccessfully)
-                    {
-                        GrpcEventSource.Log.MessageSent();
-                        return Task.CompletedTask;
-                    }
-
-                    return WriteMessageCore(writeMessageTask);
-                },
+            message.Content = new PushUnaryContent<TRequest, TResponse>(
+                request,
+                this,
+                GrpcProtocolHelpers.GetRequestEncoding(message.Headers),
                 GrpcProtocolConstants.GrpcContentTypeHeaderValue);
-
-            static async Task WriteMessageCore(Task writeMessageTask)
-            {
-                await writeMessageTask.ConfigureAwait(false);
-                GrpcEventSource.Log.MessageSent();
-            }
         }
 
         private void CancelCall(Status status)
         {
+            // Set overall call status first. Status can be used in throw RpcException from cancellation.
+            // If response has successfully finished then the status will come from the trailers.
+            // If it didn't finish then complete with a status.
+            _callTcs.TrySetResult(status);
+
             // Checking if cancellation has already happened isn't threadsafe
             // but there is no adverse effect other than an extra log message
             if (!_callCts.IsCancellationRequested)
@@ -439,13 +315,19 @@ namespace Grpc.Net.Client.Internal
                 HttpResponse?.Dispose();
 
                 // Canceling call will cancel pending writes to the stream
-                _writeCompleteTcs?.TrySetCanceled();
-                _writeStreamTcs?.TrySetCanceled();
-            }
+                ClientStreamWriter?.WriteStreamTcs.TrySetCanceled();
+                ClientStreamWriter?.CompleteTcs.TrySetCanceled();
+                ClientStreamReader?.HttpResponseTcs.TrySetCanceled();
 
-            // If response has successfully finished then the status will come from the trailers
-            // If it didn't finish then complete with a status
-            _callTcs.TrySetResult(status);
+                if (!Channel.ThrowOperationCanceledOnCancellation)
+                {
+                    _metadataTcs.TrySetException(new RpcException(status));
+                }
+                else
+                {
+                    _metadataTcs.TrySetCanceled(_callCts.Token);
+                }
+            }
         }
 
         internal IDisposable? StartScope()
@@ -460,87 +342,180 @@ namespace Grpc.Net.Client.Internal
             return null;
         }
 
-        private async Task StartAsync(HttpRequestMessage request)
+        private async ValueTask RunCall(HttpRequestMessage request)
         {
             using (StartScope())
             {
-                if (_timeout != null && !Channel.DisableClientDeadlineTimer)
-                {
-                    Log.StartingDeadlineTimeout(Logger, _timeout.Value);
+                var (diagnosticSourceEnabled, activity) = InitializeCall(request);
 
-                    // Deadline timer will cancel the call CTS
-                    // Start timer after reader/writer have been created, otherwise a zero length deadline could cancel
-                    // the call CTS before they are created and leave them in a non-canceled state
-                    _deadlineTimer = new Timer(DeadlineExceeded, null, _timeout.Value, Timeout.InfiniteTimeSpan);
+                if (Options.Credentials != null || Channel.CallCredentials?.Count > 0)
+                {
+                    await ReadCredentials(request).ConfigureAwait(false);
                 }
 
-                Log.StartingCall(Logger, Method.Type, request.RequestUri);
-                GrpcEventSource.Log.CallStart(Method.FullName);
+                Status? status = null;
 
-                var diagnosticSourceEnabled =
-                    GrpcDiagnostics.DiagnosticListener.IsEnabled() &&
-                    GrpcDiagnostics.DiagnosticListener.IsEnabled(GrpcDiagnostics.ActivityName, request);
-
-                Activity? activity = null;
-
-                // Set activity if:
-                // 1. Diagnostic source is enabled
-                // 2. Logging is enabled
-                // 3. There is an existing activity (to enable activity propagation)
-                if (diagnosticSourceEnabled || Logger.IsEnabled(LogLevel.Critical) || Activity.Current != null)
+                try
                 {
-                    activity = new Activity(GrpcDiagnostics.ActivityName);
-                    activity.AddTag(GrpcDiagnostics.GrpcMethodTagName, Method.FullName);
-                    activity.Start();
-
-                    if (diagnosticSourceEnabled)
+                    try
                     {
-                        GrpcDiagnostics.DiagnosticListener.Write(GrpcDiagnostics.ActivityStartKey, new { Request = request });
+                        HttpResponse = await Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token).ConfigureAwait(false);
                     }
-                }
-
-                SendTask = SendAsync(request);
-
-                // Wait until the call is complete
-                // TCS will be set in Dispose
-                var status = await CallTask.ConfigureAwait(false);
-
-                if (status.StatusCode != StatusCode.OK)
-                {
-                    Log.GrpcStatusError(Logger, status.StatusCode, status.Detail);
-                    GrpcEventSource.Log.CallFailed(status.StatusCode);
-                }
-                Log.FinishedCall(Logger);
-                GrpcEventSource.Log.CallStop();
-
-                // Activity needs to be stopped in the same execution context it was started
-                if (activity != null)
-                {
-                    var statusText = status.StatusCode.ToString("D");
-                    if (statusText != null)
+                    catch (Exception ex)
                     {
-                        activity.AddTag(GrpcDiagnostics.GrpcStatusCodeTagName, statusText);
+                        Log.ErrorStartingCall(Logger, ex);
+                        throw;
                     }
 
-                    if (diagnosticSourceEnabled)
+                    BuildMetadata(HttpResponse);
+
+                    status = ValidateHeaders(HttpResponse);
+
+                    // A status means either the call has failed or grpc-status was returned in the response header
+                    if (status != null)
                     {
-                        // Stop sets the end time if it was unset, but we want it set before we issue the write
-                        // so we do it now.   
-                        if (activity.Duration == TimeSpan.Zero)
+                        if (_responseTcs != null)
                         {
-                            activity.SetEndTime(DateTime.UtcNow);
+                            // gRPC status in the header
+                            if (status.Value.StatusCode != StatusCode.OK)
+                            {
+                                _responseTcs.TrySetException(new RpcException(status.Value));
+                            }
+                            else
+                            {
+                                // The server should never return StatusCode.OK in the header for a unary call.
+                                // If it does then throw an error that no message was returned from the server.
+                                Log.MessageNotReturned(Logger);
+                                _responseTcs.TrySetException(new InvalidOperationException("Call did not return a response message."));
+                            }
                         }
 
-                        GrpcDiagnostics.DiagnosticListener.Write(GrpcDiagnostics.ActivityStopKey, new { Request = request, Response = HttpResponse });
+                        FinishResponse(status.Value);
+                    }
+                    else
+                    {
+                        if (_responseTcs != null)
+                        {
+                            // Read entire response body immediately and read status from trailers
+                                // Trailers are only available once the response body had been read
+                                var responseStream = await HttpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                                var message = await responseStream.ReadSingleMessageAsync(
+                                    Logger,
+                                    Method.ResponseMarshaller.ContextualDeserializer,
+                                    GrpcProtocolHelpers.GetGrpcEncoding(HttpResponse),
+                                    Channel.ReceiveMaxMessageSize,
+                                    Channel.CompressionProviders,
+                                    _callCts.Token).ConfigureAwait(false);
+                                status = GrpcProtocolHelpers.GetResponseStatus(HttpResponse);
+                                FinishResponse(status.Value);
+
+                            if (message == null)
+                            {
+                                Log.MessageNotReturned(Logger);
+                                _responseTcs.TrySetException(new RpcException(status.Value));
+                            }
+                            else
+                            {
+                                GrpcEventSource.Log.MessageReceived();
+
+                                if (status.Value.StatusCode == StatusCode.OK)
+                                {
+                                    _responseTcs.TrySetResult(message);
+                                }
+                                else
+                                {
+                                    _responseTcs.TrySetException(new RpcException(status.Value));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // Duplex or server streaming call
+                            Debug.Assert(ClientStreamReader != null);
+                            ClientStreamReader.HttpResponseTcs.TrySetResult((HttpResponse, status));
+
+                            // Wait until the response has been read and status read from trailers.
+                            // TCS will also be set in Dispose.
+                            status = await CallTask.ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Exception resolvedException;
+                    if (ex is OperationCanceledException)
+                    {
+                        status = (CallTask.IsCompletedSuccessfully) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
+                        resolvedException = Channel.ThrowOperationCanceledOnCancellation ? ex : new RpcException(status.Value);
+                    }
+                    else if (ex is RpcException rpcException)
+                    {
+                        status = rpcException.Status;
+                        resolvedException = new RpcException(status.Value);
+                    }
+                    else
+                    {
+                        status = new Status(StatusCode.Internal, "Error starting gRPC call: " + ex.Message);
+                        resolvedException = new RpcException(status.Value);
                     }
 
-                    activity.Stop();
+                    _metadataTcs.TrySetException(resolvedException);
+                    _responseTcs?.TrySetException(resolvedException);
+
+                    Cleanup(status!.Value);
                 }
+
+                FinishCall(request, diagnosticSourceEnabled, activity, status);
             }
         }
 
-        private async Task SendAsync(HttpRequestMessage request)
+        private void BuildMetadata(HttpResponseMessage httpResponse)
         {
+            try
+            {
+                _metadataTcs.TrySetResult(GrpcProtocolHelpers.BuildMetadata(httpResponse.Headers));
+            }
+            catch (Exception ex)
+            {
+                _metadataTcs.TrySetException(ex);
+            }
+        }
+
+        private (bool diagnosticSourceEnabled, Activity? activity) InitializeCall(HttpRequestMessage request)
+        {
+            if (_timeout != null && !Channel.DisableClientDeadlineTimer)
+            {
+                Log.StartingDeadlineTimeout(Logger, _timeout.Value);
+
+                // Deadline timer will cancel the call CTS
+                // Start timer after reader/writer have been created, otherwise a zero length deadline could cancel
+                // the call CTS before they are created and leave them in a non-canceled state
+                _deadlineTimer = new Timer(DeadlineExceeded, null, _timeout.Value, Timeout.InfiniteTimeSpan);
+            }
+
+            Log.StartingCall(Logger, Method.Type, request.RequestUri);
+            GrpcEventSource.Log.CallStart(Method.FullName);
+
+            var diagnosticSourceEnabled = GrpcDiagnostics.DiagnosticListener.IsEnabled() &&
+                GrpcDiagnostics.DiagnosticListener.IsEnabled(GrpcDiagnostics.ActivityName, request);
+            Activity? activity = null;
+
+            // Set activity if:
+            // 1. Diagnostic source is enabled
+            // 2. Logging is enabled
+            // 3. There is an existing activity (to enable activity propagation)
+            if (diagnosticSourceEnabled || Logger.IsEnabled(LogLevel.Critical) || Activity.Current != null)
+            {
+                activity = new Activity(GrpcDiagnostics.ActivityName);
+                activity.AddTag(GrpcDiagnostics.GrpcMethodTagName, Method.FullName);
+                activity.Start();
+
+                if (diagnosticSourceEnabled)
+                {
+                    GrpcDiagnostics.DiagnosticListener.Write(GrpcDiagnostics.ActivityStartKey, new { Request = request });
+                }
+            }
+
             if (Options.CancellationToken.CanBeCanceled)
             {
                 // The cancellation token will cancel the call CTS.
@@ -555,133 +530,92 @@ namespace Grpc.Net.Client.Internal
                 });
             }
 
-            if (Options.Credentials != null || Channel.CallCredentials?.Count > 0)
-            {
-                // In C-Core the call credential auth metadata is only applied if the channel is secure
-                // The equivalent in grpc-dotnet is only applying metadata if HttpClient is using TLS
-                // HttpClient scheme will be HTTP if it is using H2C (HTTP2 without TLS)
-                if (Channel.Address.Scheme == Uri.UriSchemeHttps)
-                {
-                    var configurator = new DefaultCallCredentialsConfigurator();
+            return (diagnosticSourceEnabled, activity);
+        }
 
-                    if (Options.Credentials != null)
+        private void FinishCall(HttpRequestMessage request, bool diagnosticSourceEnabled, Activity? activity, Status? status)
+        {
+            if (status!.Value.StatusCode != StatusCode.OK)
+            {
+                Log.GrpcStatusError(Logger, status.Value.StatusCode, status.Value.Detail);
+                GrpcEventSource.Log.CallFailed(status.Value.StatusCode);
+            }
+            Log.FinishedCall(Logger);
+            GrpcEventSource.Log.CallStop();
+
+            // Activity needs to be stopped in the same execution context it was started
+            if (activity != null)
+            {
+                var statusText = status.Value.StatusCode.ToString("D");
+                if (statusText != null)
+                {
+                    activity.AddTag(GrpcDiagnostics.GrpcStatusCodeTagName, statusText);
+                }
+
+                if (diagnosticSourceEnabled)
+                {
+                    // Stop sets the end time if it was unset, but we want it set before we issue the write
+                    // so we do it now.   
+                    if (activity.Duration == TimeSpan.Zero)
                     {
-                        await ReadCredentialMetadata(configurator, Channel, request, Options.Credentials).ConfigureAwait(false);
+                        activity.SetEndTime(DateTime.UtcNow);
                     }
-                    if (Channel.CallCredentials?.Count > 0)
+
+                    GrpcDiagnostics.DiagnosticListener.Write(GrpcDiagnostics.ActivityStopKey, new { Request = request, Response = HttpResponse });
+                }
+
+                activity.Stop();
+            }
+        }
+
+        private async Task ReadCredentials(HttpRequestMessage request)
+        {
+            // In C-Core the call credential auth metadata is only applied if the channel is secure
+            // The equivalent in grpc-dotnet is only applying metadata if HttpClient is using TLS
+            // HttpClient scheme will be HTTP if it is using H2C (HTTP2 without TLS)
+            if (Channel.Address.Scheme == Uri.UriSchemeHttps)
+            {
+                var configurator = new DefaultCallCredentialsConfigurator();
+
+                if (Options.Credentials != null)
+                {
+                    await GrpcProtocolHelpers.ReadCredentialMetadata(configurator, Channel, request, Method, Options.Credentials).ConfigureAwait(false);
+                }
+                if (Channel.CallCredentials?.Count > 0)
+                {
+                    foreach (var credentials in Channel.CallCredentials)
                     {
-                        foreach (var credentials in Channel.CallCredentials)
-                        {
-                            await ReadCredentialMetadata(configurator, Channel, request, credentials).ConfigureAwait(false);
-                        }
+                        await GrpcProtocolHelpers.ReadCredentialMetadata(configurator, Channel, request, Method, credentials).ConfigureAwait(false);
                     }
                 }
-                else
-                {
-                    Log.CallCredentialsNotUsed(Logger);
-                }
             }
-
-            try
+            else
             {
-                HttpResponse = await Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Log.ErrorStartingCall(Logger, ex);
-                CancelCall(new Status(StatusCode.Cancelled, "Error starting gRPC call."));
-                throw;
-            }
-
-            ValidateHeaders();
-        }
-
-        private async Task ReadCredentialMetadata(
-            DefaultCallCredentialsConfigurator configurator,
-            GrpcChannel channel,
-            HttpRequestMessage message,
-            CallCredentials credentials)
-        {
-            credentials.InternalPopulateConfiguration(configurator, null);
-
-            if (configurator.Interceptor != null)
-            {
-                var authInterceptorContext = CreateAuthInterceptorContext(channel.Address, Method);
-                var metadata = new Metadata();
-                await configurator.Interceptor(authInterceptorContext, metadata).ConfigureAwait(false);
-
-                foreach (var entry in metadata)
-                {
-                    AddHeader(message.Headers, entry);
-                }
-            }
-
-            if (configurator.Credentials != null)
-            {
-                // Copy credentials locally. ReadCredentialMetadata will update it.
-                var callCredentials = configurator.Credentials;
-                foreach (var c in callCredentials)
-                {
-                    configurator.Reset();
-                    await ReadCredentialMetadata(configurator, channel, message, c).ConfigureAwait(false);
-                }
+                Log.CallCredentialsNotUsed(Logger);
             }
         }
 
-        private static AuthInterceptorContext CreateAuthInterceptorContext(Uri baseAddress, IMethod method)
+        private void CreateWriter(HttpRequestMessage message)
         {
-            var authority = baseAddress.Authority;
-            if (baseAddress.Scheme == Uri.UriSchemeHttps && authority.EndsWith(":443", StringComparison.Ordinal))
-            {
-                // The service URL can be used by auth libraries to construct the "aud" fields of the JWT token,
-                // so not producing serviceUrl compatible with other gRPC implementations can lead to auth failures.
-                // For https and the default port 443, the port suffix should be stripped.
-                // https://github.com/grpc/grpc/blob/39e982a263e5c48a650990743ed398c1c76db1ac/src/core/lib/security/transport/client_auth_filter.cc#L205
-                authority = authority.Substring(0, authority.Length - 4);
-            }
-            var serviceUrl = baseAddress.Scheme + "://" + authority + baseAddress.AbsolutePath;
-            if (!serviceUrl.EndsWith("/", StringComparison.Ordinal))
-            {
-                serviceUrl += "/";
-            }
-            serviceUrl += method.ServiceName;
-            return new AuthInterceptorContext(serviceUrl, method.Name);
-        }
+            ClientStreamWriter = new HttpContentClientStreamWriter<TRequest, TResponse>(this, message);
 
-        private HttpContentClientStreamWriter<TRequest, TResponse> CreateWriter(HttpRequestMessage message)
-        {
-            _writeStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _writeCompleteTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            message.Content = new PushStreamContent(
-                async stream =>
-                {
-                    // Immediately flush request stream to send headers
-                    // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
-                    await stream.FlushAsync().ConfigureAwait(false);
-
-                    // Pass request stream to writer
-                    _writeStreamTcs.TrySetResult(stream);
-
-                    // Wait for the writer to report it is complete
-                    await _writeCompleteTcs.Task.ConfigureAwait(false);
-                },
-                GrpcProtocolConstants.GrpcContentTypeHeaderValue);
-
-            var writer = new HttpContentClientStreamWriter<TRequest, TResponse>(this, message, _writeStreamTcs.Task, _writeCompleteTcs);
-            return writer;
+            message.Content = new PushStreamContent<TRequest, TResponse>(ClientStreamWriter, GrpcProtocolConstants.GrpcContentTypeHeaderValue);
         }
 
         private HttpRequestMessage CreateHttpRequestMessage()
         {
-            var message = new HttpRequestMessage(HttpMethod.Post, new Uri(Channel.Address, _uri));
-            message.Version = new Version(2, 0);
-            // User agent is optional but recommended
-            message.Headers.UserAgent.Add(GrpcProtocolConstants.UserAgentHeader);
-            // TE is required by some servers, e.g. C Core
-            // A missing TE header results in servers aborting the gRPC call
-            message.Headers.TE.Add(GrpcProtocolConstants.TEHeader);
-            message.Headers.Add(GrpcProtocolConstants.MessageAcceptEncodingHeader, Channel.MessageAcceptEncoding);
+            var message = new HttpRequestMessage(HttpMethod.Post, _uri);
+            message.Version = GrpcProtocolConstants.ProtocolVersion;
+
+            // Set raw headers on request using name/values. Typed headers allocate additional objects.
+            var headers = message.Headers;
+
+            // User agent is optional but recommended.
+            headers.Add(GrpcProtocolConstants.UserAgentHeader, GrpcProtocolConstants.UserAgentHeaderValue);
+            // TE is required by some servers, e.g. C Core.
+            // A missing TE header results in servers aborting the gRPC call.
+            headers.Add(GrpcProtocolConstants.TEHeader, GrpcProtocolConstants.TEHeaderValue);
+            headers.Add(GrpcProtocolConstants.MessageAcceptEncodingHeader, Channel.MessageAcceptEncoding);
 
             if (Options.Headers != null && Options.Headers.Count > 0)
             {
@@ -697,49 +631,21 @@ namespace Grpc.Net.Client.Internal
                         // grpc-internal-encoding-request is used in the client to set message compression.
                         // 'grpc-encoding' is sent even if WriteOptions.Flags = NoCompress. In that situation
                         // individual messages will not be written with compression.
-                        message.Headers.Add(GrpcProtocolConstants.MessageEncodingHeader, entry.Value);
+                        headers.Add(GrpcProtocolConstants.MessageEncodingHeader, entry.Value);
                     }
                     else
                     {
-                        AddHeader(message.Headers, entry);
+                        GrpcProtocolHelpers.AddHeader(headers, entry);
                     }
                 }
             }
 
             if (_timeout != null)
             {
-                message.Headers.Add(GrpcProtocolConstants.TimeoutHeader, GrpcProtocolHelpers.EncodeTimeout(Convert.ToInt64(_timeout.Value.TotalMilliseconds)));
+                headers.Add(GrpcProtocolConstants.TimeoutHeader, GrpcProtocolHelpers.EncodeTimeout(Convert.ToInt64(_timeout.Value.TotalMilliseconds)));
             }
 
             return message;
-        }
-
-        private static void AddHeader(HttpRequestHeaders headers, Metadata.Entry entry)
-        {
-            var value = entry.IsBinary ? Convert.ToBase64String(entry.ValueBytes) : entry.Value;
-            headers.Add(entry.Key, value);
-        }
-
-        private class DefaultCallCredentialsConfigurator : CallCredentialsConfiguratorBase
-        {
-            public AsyncAuthInterceptor? Interceptor { get; private set; }
-            public IReadOnlyList<CallCredentials>? Credentials { get; private set; }
-
-            public void Reset()
-            {
-                Interceptor = null;
-                Credentials = null;
-            }
-
-            public override void SetAsyncAuthInterceptorCredentials(object state, AsyncAuthInterceptor interceptor)
-            {
-                Interceptor = interceptor;
-            }
-
-            public override void SetCompositeCredentials(object state, IReadOnlyList<CallCredentials> credentials)
-            {
-                Credentials = credentials;
-            }
         }
 
         private void DeadlineExceeded(object state)
@@ -755,82 +661,6 @@ namespace Grpc.Net.Client.Internal
             }
         }
 
-        private static bool TryGetStatusCore(HttpResponseMessage httpResponseMessage, [NotNullWhen(true)]out Status? status)
-        {
-            if (TryGetStatusCore(httpResponseMessage.TrailingHeaders, out status))
-            {
-                return true;
-            }
-
-            // A gRPC server may return gRPC status in the headers when the response stream is empty
-            // For example, C Core server returns them together in the empty_stream interop test
-            if (TryGetStatusCore(httpResponseMessage.Headers, out status))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private static bool TryGetStatusCore(HttpResponseHeaders headers, [NotNullWhen(true)]out Status? status)
-        {
-            var grpcStatus = GetHeaderValue(headers, GrpcProtocolConstants.StatusTrailer);
-
-            // grpc-status is a required trailer
-            if (grpcStatus == null)
-            {
-                status = null;
-                return false;
-            }
-
-            int statusValue;
-            if (!int.TryParse(grpcStatus, out statusValue))
-            {
-                throw new InvalidOperationException("Unexpected grpc-status value: " + grpcStatus);
-            }
-
-            // grpc-message is optional
-            // Always read the gRPC message from the same headers collection as the status
-            var grpcMessage = GetHeaderValue(headers, GrpcProtocolConstants.MessageTrailer);
-
-            if (!string.IsNullOrEmpty(grpcMessage))
-            {
-                // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
-                // The value portion of Status-Message is conceptually a Unicode string description of the error,
-                // physically encoded as UTF-8 followed by percent-encoding.
-                grpcMessage = Uri.UnescapeDataString(grpcMessage);
-            }
-
-            status = new Status((StatusCode)statusValue, grpcMessage);
-            return true;
-        }
-
-        private static string? GetHeaderValue(HttpHeaders? headers, string name)
-        {
-            if (headers == null)
-            {
-                return null;
-            }
-
-            if (!headers.TryGetValues(name, out var values))
-            {
-                return null;
-            }
-
-            // HttpHeaders appears to always return an array, but fallback to converting values to one just in case
-            var valuesArray = values as string[] ?? values.ToArray();
-
-            switch (valuesArray.Length)
-            {
-                case 0:
-                    return null;
-                case 1:
-                    return valuesArray[0];
-                default:
-                    throw new InvalidOperationException($"Multiple {name} headers.");
-            }
-        }
-
         private void ValidateTrailersAvailable()
         {
             // Response is finished
@@ -839,22 +669,9 @@ namespace Grpc.Net.Client.Internal
                 return;
             }
 
-            // HttpClient.SendAsync could have failed
-            Debug.Assert(SendTask != null);
-            if (SendTask.IsFaulted)
-            {
-                throw new InvalidOperationException("Can't get the call trailers because an error occured when making the request.", SendTask.Exception);
-            }
-
-            // Call could have been canceled or deadline exceeded
-            if (_callCts.IsCancellationRequested)
-            {
-                // Throw InvalidOperationException here because documentation on GetTrailers says that
-                // InvalidOperationException is thrown if the call is not complete.
-                throw new InvalidOperationException("Can't get the call trailers because the call was canceled.");
-            }
-
-            throw new InvalidOperationException("Can't get the call trailers because the call is not complete.");
+            // Throw InvalidOperationException here because documentation on GetTrailers says that
+            // InvalidOperationException is thrown if the call is not complete.
+            throw new InvalidOperationException("Can't get the call trailers because the call has not completed successfully.");
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/GrpcMethodInfo.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcMethodInfo.cs
@@ -1,0 +1,38 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.Core;
+
+namespace Grpc.Net.Client.Internal
+{
+    /// <summary>
+    /// Cached log scope and URI for a gRPC <see cref="IMethod"/>.
+    /// </summary>
+    internal class GrpcMethodInfo
+    {
+        public GrpcMethodInfo(GrpcCallScope logScope, Uri callUri)
+        {
+            LogScope = logScope;
+            CallUri = callUri;
+        }
+
+        public GrpcCallScope LogScope { get; }
+        public Uri CallUri { get; }
+    }
+}

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -51,8 +51,12 @@ namespace Grpc.Net.Client.Internal
 
         internal static readonly string DefaultMessageAcceptEncodingValue;
 
-        internal static readonly ProductInfoHeaderValue UserAgentHeader;
-        internal static readonly TransferCodingWithQualityHeaderValue TEHeader;
+        internal static readonly Version ProtocolVersion = new Version(2, 0);
+
+        internal static readonly string UserAgentHeader;
+        internal static readonly string UserAgentHeaderValue;
+        internal static readonly string TEHeader;
+        internal static readonly string TEHeaderValue;
 
         static GrpcProtocolConstants()
         {
@@ -75,9 +79,10 @@ namespace Grpc.Net.Client.Internal
                 userAgent += "/" + assemblyVersion.Version;
             }
 
-            UserAgentHeader = ProductInfoHeaderValue.Parse(userAgent);
-
-            TEHeader = new TransferCodingWithQualityHeaderValue("trailers");
+            UserAgentHeader = "User-Agent";
+            UserAgentHeaderValue = userAgent;
+            TEHeader = "TE";
+            TEHeaderValue = "trailers";
 
             DefaultMessageAcceptEncodingValue = IdentityGrpcEncoding + "," + string.Join(',', DefaultCompressionProviders.Select(p => p.Key));
         }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -18,10 +18,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Compression;
 
@@ -29,30 +31,26 @@ namespace Grpc.Net.Client.Internal
 {
     internal static class GrpcProtocolHelpers
     {
-        public static bool IsGrpcContentType(string contentType)
+        public static bool IsGrpcContentType(MediaTypeHeaderValue contentType)
         {
             if (contentType == null)
             {
                 return false;
             }
 
-            if (!contentType.StartsWith(GrpcProtocolConstants.GrpcContentType, StringComparison.OrdinalIgnoreCase))
+            if (!contentType.MediaType.StartsWith(GrpcProtocolConstants.GrpcContentType, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
-            if (contentType.Length == GrpcProtocolConstants.GrpcContentType.Length)
+            if (contentType.MediaType.Length == GrpcProtocolConstants.GrpcContentType.Length)
             {
                 // Exact match
                 return true;
             }
 
             // Support variations on the content-type (e.g. +proto, +json)
-            char nextChar = contentType[GrpcProtocolConstants.GrpcContentType.Length];
-            if (nextChar == ';')
-            {
-                return true;
-            }
+            var nextChar = contentType.MediaType[GrpcProtocolConstants.GrpcContentType.Length];
             if (nextChar == '+')
             {
                 // Accept any message format. Marshaller could be set to support third-party formats
@@ -242,6 +240,143 @@ namespace Grpc.Net.Client.Internal
             var canCompress = (writeOptions.Flags & WriteFlags.NoCompress) != WriteFlags.NoCompress;
 
             return canCompress;
+        }
+
+        internal static AuthInterceptorContext CreateAuthInterceptorContext(Uri baseAddress, IMethod method)
+        {
+            var authority = baseAddress.Authority;
+            if (baseAddress.Scheme == Uri.UriSchemeHttps && authority.EndsWith(":443", StringComparison.Ordinal))
+            {
+                // The service URL can be used by auth libraries to construct the "aud" fields of the JWT token,
+                // so not producing serviceUrl compatible with other gRPC implementations can lead to auth failures.
+                // For https and the default port 443, the port suffix should be stripped.
+                // https://github.com/grpc/grpc/blob/39e982a263e5c48a650990743ed398c1c76db1ac/src/core/lib/security/transport/client_auth_filter.cc#L205
+                authority = authority.Substring(0, authority.Length - 4);
+            }
+            var serviceUrl = baseAddress.Scheme + "://" + authority + baseAddress.AbsolutePath;
+            if (!serviceUrl.EndsWith("/", StringComparison.Ordinal))
+            {
+                serviceUrl += "/";
+            }
+            serviceUrl += method.ServiceName;
+            return new AuthInterceptorContext(serviceUrl, method.Name);
+        }
+
+        internal async static Task ReadCredentialMetadata(
+            DefaultCallCredentialsConfigurator configurator,
+            GrpcChannel channel,
+            HttpRequestMessage message,
+            IMethod method,
+            CallCredentials credentials)
+        {
+            credentials.InternalPopulateConfiguration(configurator, null);
+
+            if (configurator.Interceptor != null)
+            {
+                var authInterceptorContext = GrpcProtocolHelpers.CreateAuthInterceptorContext(channel.Address, method);
+                var metadata = new Metadata();
+                await configurator.Interceptor(authInterceptorContext, metadata).ConfigureAwait(false);
+
+                foreach (var entry in metadata)
+                {
+                    AddHeader(message.Headers, entry);
+                }
+            }
+
+            if (configurator.Credentials != null)
+            {
+                // Copy credentials locally. ReadCredentialMetadata will update it.
+                var callCredentials = configurator.Credentials;
+                foreach (var c in callCredentials)
+                {
+                    configurator.Reset();
+                    await ReadCredentialMetadata(configurator, channel, message, method, c).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public static void AddHeader(HttpRequestHeaders headers, Metadata.Entry entry)
+        {
+            var value = entry.IsBinary ? Convert.ToBase64String(entry.ValueBytes) : entry.Value;
+            headers.Add(entry.Key, value);
+        }
+
+        public static string? GetHeaderValue(HttpHeaders? headers, string name)
+        {
+            if (headers == null)
+            {
+                return null;
+            }
+
+            if (!headers.TryGetValues(name, out var values))
+            {
+                return null;
+            }
+
+            // HttpHeaders appears to always return an array, but fallback to converting values to one just in case
+            var valuesArray = values as string[] ?? values.ToArray();
+
+            switch (valuesArray.Length)
+            {
+                case 0:
+                    return null;
+                case 1:
+                    return valuesArray[0];
+                default:
+                    throw new InvalidOperationException($"Multiple {name} headers.");
+            }
+        }
+
+        public static Status GetResponseStatus(HttpResponseMessage httpResponse)
+        {
+            Status? status;
+            try
+            {
+                if (!TryGetStatusCore(httpResponse.TrailingHeaders, out status))
+                {
+                    status = new Status(StatusCode.Cancelled, "No grpc-status found on response.");
+                }
+            }
+            catch (Exception ex)
+            {
+                // Handle error from parsing badly formed status
+                status = new Status(StatusCode.Cancelled, ex.Message);
+            }
+
+            return status.Value;
+        }
+
+        public static bool TryGetStatusCore(HttpResponseHeaders headers, [NotNullWhen(true)]out Status? status)
+        {
+            var grpcStatus = GrpcProtocolHelpers.GetHeaderValue(headers, GrpcProtocolConstants.StatusTrailer);
+
+            // grpc-status is a required trailer
+            if (grpcStatus == null)
+            {
+                status = null;
+                return false;
+            }
+
+            int statusValue;
+            if (!int.TryParse(grpcStatus, out statusValue))
+            {
+                throw new InvalidOperationException("Unexpected grpc-status value: " + grpcStatus);
+            }
+
+            // grpc-message is optional
+            // Always read the gRPC message from the same headers collection as the status
+            var grpcMessage = GrpcProtocolHelpers.GetHeaderValue(headers, GrpcProtocolConstants.MessageTrailer);
+
+            if (!string.IsNullOrEmpty(grpcMessage))
+            {
+                // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
+                // The value portion of Status-Message is conceptually a Unicode string description of the error,
+                // physically encoded as UTF-8 followed by percent-encoding.
+                grpcMessage = Uri.UnescapeDataString(grpcMessage);
+            }
+
+            status = new Status((StatusCode)statusValue, grpcMessage);
+            return true;
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -124,7 +124,8 @@ namespace Grpc.Net.Client.Internal
                 throw new ObjectDisposedException(nameof(GrpcChannel));
             }
 
-            var call = new GrpcCall<TRequest, TResponse>(method, options, Channel);
+            var methodInfo = Channel.GrpcMethodInfo(method);
+            var call = new GrpcCall<TRequest, TResponse>(method, methodInfo.CallUri, methodInfo.LogScope, options, Channel);
 
             return call;
         }

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -124,8 +124,8 @@ namespace Grpc.Net.Client.Internal
                 throw new ObjectDisposedException(nameof(GrpcChannel));
             }
 
-            var methodInfo = Channel.GrpcMethodInfo(method);
-            var call = new GrpcCall<TRequest, TResponse>(method, methodInfo.CallUri, methodInfo.LogScope, options, Channel);
+            var methodInfo = Channel.GetCachedGrpcMethodInfo(method);
+            var call = new GrpcCall<TRequest, TResponse>(method, methodInfo, options, Channel);
 
             return call;
         }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -36,6 +36,7 @@ namespace Grpc.Net.Client.Internal
         private readonly GrpcCall<TRequest, TResponse> _call;
         private readonly object _moveNextLock;
 
+        public TaskCompletionSource<(HttpResponseMessage, Status?)> HttpResponseTcs { get; }
         private HttpResponseMessage? _httpResponse;
         private Stream? _responseStream;
         private Task<bool>? _moveNextTask;
@@ -44,6 +45,7 @@ namespace Grpc.Net.Client.Internal
         {
             _call = call;
             _moveNextLock = new object();
+            HttpResponseTcs = new TaskCompletionSource<(HttpResponseMessage, Status?)>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         // IAsyncStreamReader<T> should declare Current as nullable
@@ -127,11 +129,13 @@ namespace Grpc.Net.Client.Internal
 
                 if (_httpResponse == null)
                 {
-                    Debug.Assert(_call.SendTask != null);
-                    await _call.SendTask.ConfigureAwait(false);
+                    var (httpResponse, status) = await HttpResponseTcs.Task.ConfigureAwait(false);
+                    if (status != null && status.Value.StatusCode != StatusCode.OK)
+                    {
+                        throw new RpcException(status.Value);
+                    }
 
-                    Debug.Assert(_call.HttpResponse != null);
-                    _httpResponse = _call.HttpResponse;
+                    _httpResponse = httpResponse;
                 }
                 if (_responseStream == null)
                 {
@@ -143,20 +147,8 @@ namespace Grpc.Net.Client.Internal
                     {
                         // The response was disposed while waiting for the content stream to start.
                         // This will happen if there is no content stream (e.g. a streaming call finishes with no messages).
-                        if (_call.ResponseFinished)
-                        {
-                            // Call status will have been set before dispose.
-                            var status = await _call.CallTask.ConfigureAwait(false);
-                            if (status.StatusCode != StatusCode.OK)
-                            {
-                                throw new RpcException(status);
-                            }
-
-                            // Return false to indicate that the stream is complete without a message.
-                            return false;
-                        }
-
-                        throw;
+                        // Treat this like a cancellation.
+                        throw new OperationCanceledException();
                     }
                 }
 
@@ -170,7 +162,13 @@ namespace Grpc.Net.Client.Internal
                 if (Current == null)
                 {
                     // No more content in response so mark as finished
-                    _call.FinishResponse(throwOnFail: true);
+                    var status = GrpcProtocolHelpers.GetResponseStatus(_httpResponse);
+                    _call.FinishResponse(status);
+                    if (status.StatusCode != StatusCode.OK)
+                    {
+                        throw new RpcException(status);
+                    }
+
                     return false;
                 }
 
@@ -179,6 +177,17 @@ namespace Grpc.Net.Client.Internal
             }
             catch (OperationCanceledException) when (!_call.Channel.ThrowOperationCanceledOnCancellation)
             {
+                if (_call.ResponseFinished)
+                {
+                    // Call status will have been set before dispose.
+                    var status = await _call.CallTask.ConfigureAwait(false);
+                    if (status.StatusCode == StatusCode.OK)
+                    {
+                        // Return false to indicate that the stream is complete without a message.
+                        return false;
+                    }
+                }
+
                 throw _call.CreateCanceledStatusException();
             }
             finally

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -132,7 +132,7 @@ namespace Grpc.Net.Client.Internal
                     var (httpResponse, status) = await HttpResponseTcs.Task.ConfigureAwait(false);
                     if (status != null && status.Value.StatusCode != StatusCode.OK)
                     {
-                        throw new RpcException(status.Value);
+                        throw _call.CreateFailureStatusException(status.Value);
                     }
 
                     _httpResponse = httpResponse;
@@ -166,7 +166,7 @@ namespace Grpc.Net.Client.Internal
                     _call.FinishResponse(status);
                     if (status.StatusCode != StatusCode.OK)
                     {
-                        throw new RpcException(status);
+                        throw _call.CreateFailureStatusException(status);
                     }
 
                     return false;

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -31,20 +31,19 @@ namespace Grpc.Net.Client.Internal
     {
         private readonly GrpcCall<TRequest, TResponse> _call;
         private readonly string _grpcEncoding;
-        private readonly Task<Stream> _writeStreamTask;
-        private readonly TaskCompletionSource<bool> _completeTcs;
         private readonly object _writeLock;
         private Task? _writeTask;
 
+        public TaskCompletionSource<Stream> WriteStreamTcs { get; }
+        public TaskCompletionSource<bool> CompleteTcs { get; }
+
         public HttpContentClientStreamWriter(
             GrpcCall<TRequest, TResponse> call,
-            HttpRequestMessage message,
-            Task<Stream> writeStreamTask,
-            TaskCompletionSource<bool> completeTcs)
+            HttpRequestMessage message)
         {
             _call = call;
-            _writeStreamTask = writeStreamTask;
-            _completeTcs = completeTcs;
+            WriteStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
+            CompleteTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _writeLock = new object();
             WriteOptions = _call.Options.WriteOptions;
             _grpcEncoding = GrpcProtocolHelpers.GetRequestEncoding(message.Headers);
@@ -71,7 +70,7 @@ namespace Grpc.Net.Client.Internal
                     }
 
                     // Notify that the client stream is complete
-                    _completeTcs.TrySetResult(true);
+                    CompleteTcs.TrySetResult(true);
                 }
             }
 
@@ -111,7 +110,8 @@ namespace Grpc.Net.Client.Internal
                     }
 
                     // CompleteAsync has already been called
-                    if (_completeTcs.Task.IsCompletedSuccessfully)
+                    // Use IsCompleted here because that will track success and cancellation
+                    else if (CompleteTcs.Task.IsCompleted)
                     {
                         return CreateErrorTask("Can't write the message because the client stream writer is complete.");
                     }
@@ -146,7 +146,7 @@ namespace Grpc.Net.Client.Internal
             try
             {
                 // Wait until the client stream has started
-                var writeStream = await _writeStreamTask.ConfigureAwait(false);
+                var writeStream = await WriteStreamTcs.Task.ConfigureAwait(false);
 
                 // WriteOptions set on the writer take precedence over the CallOptions.WriteOptions
                 var callOptions = _call.Options;

--- a/src/Grpc.Net.Client/Internal/PushUnaryContent.cs
+++ b/src/Grpc.Net.Client/Internal/PushUnaryContent.cs
@@ -1,0 +1,75 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Grpc.Net.Client.Internal
+{
+    internal class PushUnaryContent<TRequest, TResponse> : HttpContent
+        where TRequest : class
+        where TResponse : class
+    {
+        private readonly TRequest _content;
+        private readonly GrpcCall<TRequest, TResponse> _call;
+        private readonly string _grpcEncoding;
+
+        public PushUnaryContent(TRequest content, GrpcCall<TRequest, TResponse> call, string grpcEncoding, MediaTypeHeaderValue mediaType)
+        {
+            _content = content;
+            _call = call;
+            _grpcEncoding = grpcEncoding;
+            Headers.ContentType = mediaType;
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            var writeMessageTask = stream.WriteMessageAsync<TRequest>(
+                _call.Logger,
+                _content,
+                _call.Method.RequestMarshaller.ContextualSerializer,
+                _grpcEncoding,
+                _call.Channel.SendMaxMessageSize,
+                _call.Channel.CompressionProviders,
+                _call.Options);
+            if (writeMessageTask.IsCompletedSuccessfully)
+            {
+                GrpcEventSource.Log.MessageSent();
+                return Task.CompletedTask;
+            }
+
+            return WriteMessageCore(writeMessageTask);
+        }
+
+        private static async Task WriteMessageCore(ValueTask writeMessageTask)
+        {
+            await writeMessageTask.ConfigureAwait(false);
+            GrpcEventSource.Log.MessageSent();
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            // We can't know the length of the content being pushed to the output stream.
+            length = -1;
+            return false;
+        }
+    }
+}

--- a/test/FunctionalTests/Client/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/Client/MaxMessageSizeTests.cs
@@ -43,7 +43,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             {
                 if (writeContext.LoggerName == "Grpc.Net.Client.Internal.GrpcCall" &&
                     writeContext.EventId.Name == "ErrorReadingMessage" &&
-                    writeContext.State.ToString() == "Error reading message.")
+                    writeContext.Message == "Error reading message.")
+                {
+                    return true;
+                }
+
+                if (writeContext.LoggerName == "Grpc.Net.Client.Internal.GrpcCall" &&
+                    writeContext.EventId.Name == "GrpcStatusError" &&
+                    writeContext.Message == "Call failed with gRPC error status. Status code: 'ResourceExhausted', Message: 'Received message exceeds the maximum configured message size.'.")
                 {
                     return true;
                 }

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -248,9 +248,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
                 // Response will only be headers so the call is "done" on the server side
                 await call.ResponseHeadersAsync.DefaultTimeout();
-                await call.RequestStream.CompleteAsync();
+                await call.RequestStream.CompleteAsync().DefaultTimeout();
 
-                var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext());
+                var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
                 var status = call.GetStatus();
 
                 // Assert
@@ -276,7 +276,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
             var client = new StreamService.StreamServiceClient(Channel);
 
-            var (sent, received) = await EchoData(total, data, client);
+            var (sent, received) = await EchoData(total, data, client).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(sent, total);
@@ -291,7 +291,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
             var readTask = Task.Run(async () =>
             {
-                await foreach (var message in call.ResponseStream.ReadAllAsync())
+                await foreach (var message in call.ResponseStream.ReadAllAsync().DefaultTimeout())
                 {
                     received += message.Data.Length;
 
@@ -314,7 +314,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             }
 
             await call.RequestStream.CompleteAsync().DefaultTimeout();
-            await readTask;
+            await readTask.DefaultTimeout();
 
             return (sent, received);
         }
@@ -356,7 +356,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
                 if (writeContext.LoggerName == "Grpc.Net.Client.Internal.GrpcCall" &&
                     writeContext.EventId.Name == "GrpcStatusError" &&
-                    writeContext.Message == "Call failed with gRPC error status. Status code: 'Cancelled', Message: 'Error starting gRPC call.'.")
+                    writeContext.Message == "Call failed with gRPC error status. Status code: 'Cancelled', Message: ''.")
                 {
                     return true;
                 }

--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -294,11 +294,11 @@ namespace Grpc.Net.Client.Tests
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions());
 
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.RequestStream.WriteAsync(new HelloRequest())).DefaultTimeout();
+            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => call.RequestStream.WriteAsync(new HelloRequest())).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
-            Assert.AreEqual(StatusCode.Cancelled, call.GetStatus().StatusCode);
+            Assert.AreEqual("Can't write the message because the call is complete.", ex.Message);
+            Assert.AreEqual(StatusCode.Internal, call.GetStatus().StatusCode);
         }
     }
 }

--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -76,11 +76,11 @@ namespace Grpc.Net.Client.Tests
         public async Task AsyncClientStreamingCall_Success_RequestContentSent()
         {
             // Arrange
-            PushStreamContent? content = null;
+            PushStreamContent<HelloRequest, HelloReply>? content = null;
 
             var httpClient = ClientTestHelpers.CreateTestClient(async request =>
             {
-                content = (PushStreamContent)request.Content;
+                content = (PushStreamContent<HelloRequest, HelloReply>)request.Content;
                 await content.PushComplete.DefaultTimeout();
 
                 HelloReply reply = new HelloReply
@@ -118,7 +118,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,
                 GrpcProtocolConstants.DefaultCompressionProviders,
-                CancellationToken.None).DefaultTimeout();
+                CancellationToken.None).AsTask().DefaultTimeout();
             Assert.AreEqual("1", requestMessage.Name);
             requestMessage = await requestContent.ReadStreamedMessageAsync(
                 NullLogger.Instance,
@@ -126,7 +126,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,
                 GrpcProtocolConstants.DefaultCompressionProviders,
-                CancellationToken.None).DefaultTimeout();
+                CancellationToken.None).AsTask().DefaultTimeout();
             Assert.AreEqual("2", requestMessage.Name);
 
             var responseMessage = await responseTask.DefaultTimeout();

--- a/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
@@ -92,11 +92,11 @@ namespace Grpc.Net.Client.Tests
             // Arrange
             var streamContent = new SyncPointMemoryStream();
 
-            PushStreamContent? content = null;
+            PushStreamContent<HelloRequest, HelloReply>? content = null;
 
             var httpClient = ClientTestHelpers.CreateTestClient(async request =>
             {
-                content = (PushStreamContent)request.Content;
+                content = (PushStreamContent<HelloRequest, HelloReply>)request.Content;
                 await content.PushComplete.DefaultTimeout();
 
                 return ResponseUtils.CreateResponse(HttpStatusCode.OK, new StreamContent(streamContent));
@@ -123,7 +123,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,
                 GrpcProtocolConstants.DefaultCompressionProviders,
-                CancellationToken.None).DefaultTimeout();
+                CancellationToken.None).AsTask().DefaultTimeout();
             Assert.AreEqual("1", requestMessage.Name);
             requestMessage = await requestContent.ReadStreamedMessageAsync(
                 NullLogger.Instance,
@@ -131,7 +131,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,
                 GrpcProtocolConstants.DefaultCompressionProviders,
-                CancellationToken.None).DefaultTimeout();
+                CancellationToken.None).AsTask().DefaultTimeout();
             Assert.AreEqual("2", requestMessage.Name);
 
             Assert.IsNull(responseStream.Current);

--- a/test/Grpc.Net.Client.Tests/AsyncServerStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncServerStreamingCallTests.cs
@@ -186,8 +186,8 @@ namespace Grpc.Net.Client.Tests
 
             // Act
             var call = invoker.AsyncServerStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest());
-            var headers = await call.ResponseHeadersAsync;
-            await call.ResponseStream.MoveNext(CancellationToken.None);
+            var headers = await call.ResponseHeadersAsync.DefaultTimeout();
+            Assert.IsFalse(await call.ResponseStream.MoveNext(CancellationToken.None).DefaultTimeout());
 
             // Assert
             Assert.NotNull(responseMessage);
@@ -215,8 +215,8 @@ namespace Grpc.Net.Client.Tests
 
             // Act
             var call = invoker.AsyncServerStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest());
-            var headers = await call.ResponseHeadersAsync;
-            await call.ResponseStream.MoveNext(CancellationToken.None);
+            var headers = await call.ResponseHeadersAsync.DefaultTimeout();
+            await call.ResponseStream.MoveNext(CancellationToken.None).DefaultTimeout();
 
             // Assert
             Assert.IsTrue(responseMessage!.TrailingHeaders.TryGetValues(GrpcProtocolConstants.StatusTrailer, out _)); // sanity status is in trailers

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -68,11 +68,10 @@ namespace Grpc.Net.Client.Tests
             Assert.AreEqual(HttpMethod.Post, httpRequestMessage.Method);
             Assert.AreEqual(new Uri("https://localhost/ServiceName/MethodName"), httpRequestMessage.RequestUri);
             Assert.AreEqual(new MediaTypeHeaderValue("application/grpc"), httpRequestMessage.Content.Headers.ContentType);
-            Assert.AreEqual(GrpcProtocolConstants.TEHeader, httpRequestMessage.Headers.TE.Single());
+            Assert.AreEqual(GrpcProtocolConstants.TEHeaderValue, httpRequestMessage.Headers.TE.Single().Value);
             Assert.AreEqual("identity,gzip", httpRequestMessage.Headers.GetValues(GrpcProtocolConstants.MessageAcceptEncodingHeader).Single());
 
             var userAgent = httpRequestMessage.Headers.UserAgent.Single();
-            Assert.AreEqual(GrpcProtocolConstants.UserAgentHeader, userAgent);
             Assert.AreEqual("grpc-dotnet", userAgent.Product.Name);
             Assert.IsTrue(!string.IsNullOrEmpty(userAgent.Product.Version));
 
@@ -118,7 +117,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,
                 GrpcProtocolConstants.DefaultCompressionProviders,
-                CancellationToken.None).DefaultTimeout();
+                CancellationToken.None).AsTask().DefaultTimeout();
 
             Assert.AreEqual("World", requestMessage.Name);
         }

--- a/test/Grpc.Net.Client.Tests/CompressionTests.cs
+++ b/test/Grpc.Net.Client.Tests/CompressionTests.cs
@@ -80,8 +80,9 @@ namespace Grpc.Net.Client.Tests
             });
 
             // Assert
-            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => call.ResponseAsync).DefaultTimeout();
-            Assert.AreEqual("Could not find compression provider for 'not-supported'.", ex.Message);
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
+            Assert.AreEqual(StatusCode.Internal, ex.StatusCode);
+            Assert.AreEqual("Error starting gRPC call: Could not find compression provider for 'not-supported'.", ex.Status.Detail);
         }
 
         [TestCase(true)]

--- a/test/Grpc.Net.Client.Tests/GetTrailersTests.cs
+++ b/test/Grpc.Net.Client.Tests/GetTrailersTests.cs
@@ -101,7 +101,7 @@ namespace Grpc.Net.Client.Tests
             var ex = Assert.Throws<InvalidOperationException>(() => call.GetTrailers());
 
             // Assert
-            Assert.AreEqual("Can't get the call trailers because the call is not complete.", ex.Message);
+            Assert.AreEqual("Can't get the call trailers because the call has not completed successfully.", ex.Message);
         }
 
         [Test]
@@ -121,8 +121,7 @@ namespace Grpc.Net.Client.Tests
             var ex = Assert.Throws<InvalidOperationException>(() => call.GetTrailers());
 
             // Assert
-            Assert.AreEqual("Can't get the call trailers because an error occured when making the request.", ex.Message);
-            Assert.AreEqual("An error!", ex.InnerException?.InnerException?.Message);
+            Assert.AreEqual("Can't get the call trailers because the call has not completed successfully.", ex.Message);
         }
 
         [Test]
@@ -143,7 +142,7 @@ namespace Grpc.Net.Client.Tests
             var ex = Assert.Throws<InvalidOperationException>(() => call.GetTrailers());
 
             // Assert
-            Assert.AreEqual("Can't get the call trailers because the call is not complete.", ex.Message);
+            Assert.AreEqual("Can't get the call trailers because the call has not completed successfully.", ex.Message);
         }
 
         [Test]
@@ -164,7 +163,7 @@ namespace Grpc.Net.Client.Tests
             var ex = Assert.Throws<InvalidOperationException>(() => call.GetTrailers());
 
             // Assert
-            Assert.AreEqual("Can't get the call trailers because the call is not complete.", ex.Message);
+            Assert.AreEqual("Can't get the call trailers because the call has not completed successfully.", ex.Message);
         }
 
         [Test]
@@ -195,7 +194,7 @@ namespace Grpc.Net.Client.Tests
             var ex = Assert.Throws<InvalidOperationException>(() => call.GetTrailers());
 
             // Assert
-            Assert.AreEqual("Can't get the call trailers because the call is not complete.", ex.Message);
+            Assert.AreEqual("Can't get the call trailers because the call has not completed successfully.", ex.Message);
         }
 
         [Test]
@@ -241,7 +240,7 @@ namespace Grpc.Net.Client.Tests
 
             var httpClient = ClientTestHelpers.CreateTestClient(request =>
             {
-                var content = (PushStreamContent)request.Content;
+                var content = (PushStreamContent<HelloRequest, HelloReply>)request.Content;
                 var stream = new SyncPointMemoryStream();
                 var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, new StreamContent(stream));
 
@@ -291,7 +290,7 @@ namespace Grpc.Net.Client.Tests
             var ex = Assert.Throws<InvalidOperationException>(() => call.GetTrailers());
 
             // Assert
-            Assert.AreEqual("Can't get the call trailers because the call is not complete.", ex.Message);
+            Assert.AreEqual("Can't get the call trailers because the call has not completed successfully.", ex.Message);
         }
 
         [Test]

--- a/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Net.Http.Headers;
 using Grpc.Net.Client.Internal;
 using NUnit.Framework;
 
@@ -51,6 +52,21 @@ namespace Grpc.Net.Client.Tests
         {
             var encoded = GrpcProtocolHelpers.EncodeTimeout(milliseconds);
             Assert.AreEqual(expected, encoded);
+        }
+
+        [TestCase("application/grpc", true)]
+        [TestCase("APPLICATION/GRPC", true)]
+        [TestCase("application/grpc+proto", true)]
+        [TestCase("application/grpc+json", true)]
+        [TestCase("application/grpc+BLAH", true)]
+        [TestCase("application/grpc+json; charset=utf8", true)]
+        [TestCase("text/plain", false)]
+        [TestCase("text/plain+json", false)]
+        public void IsGrpcContentType(string contentType, bool valid)
+        {
+            var v = MediaTypeHeaderValue.Parse(contentType);
+
+            Assert.AreEqual(valid, GrpcProtocolHelpers.IsGrpcContentType(v));
         }
     }
 }

--- a/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
+++ b/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
@@ -53,11 +53,11 @@ namespace Grpc.Net.Client.Tests
             call.StartServerStreaming(new HelloRequest());
 
             // Act
-            var moveNextTask1 = call.ClientStreamReader!.MoveNext(cts.Token);
+            var moveNextTask = call.ClientStreamReader!.MoveNext(cts.Token);
 
             // Assert
-            Assert.IsTrue(moveNextTask1.IsCompleted);
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => moveNextTask1).DefaultTimeout();
+            Assert.IsTrue(moveNextTask.IsCompleted);
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => moveNextTask).DefaultTimeout();
 
             Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
         }
@@ -81,11 +81,11 @@ namespace Grpc.Net.Client.Tests
             call.StartServerStreaming(new HelloRequest());
 
             // Act
-            var moveNextTask1 = call.ClientStreamReader!.MoveNext(cts.Token);
+            var moveNextTask = call.ClientStreamReader!.MoveNext(cts.Token);
 
             // Assert
-            Assert.IsTrue(moveNextTask1.IsCompleted);
-            await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => moveNextTask1).DefaultTimeout();
+            Assert.IsTrue(moveNextTask.IsCompleted);
+            await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => moveNextTask).DefaultTimeout();
         }
 
         [Test]
@@ -106,14 +106,14 @@ namespace Grpc.Net.Client.Tests
             call.StartServerStreaming(new HelloRequest());
 
             // Act
-            var moveNextTask1 = call.ClientStreamReader!.MoveNext(cts.Token);
+            var moveNextTask = call.ClientStreamReader!.MoveNext(cts.Token);
 
             // Assert
-            Assert.IsFalse(moveNextTask1.IsCompleted);
+            Assert.IsFalse(moveNextTask.IsCompleted);
 
             cts.Cancel();
 
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => moveNextTask1).DefaultTimeout();
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => moveNextTask).DefaultTimeout();
 
             Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
         }
@@ -136,14 +136,14 @@ namespace Grpc.Net.Client.Tests
             call.StartServerStreaming(new HelloRequest());
 
             // Act
-            var moveNextTask1 = call.ClientStreamReader!.MoveNext(cts.Token);
+            var moveNextTask = call.ClientStreamReader!.MoveNext(cts.Token);
 
             // Assert
-            Assert.IsFalse(moveNextTask1.IsCompleted);
+            Assert.IsFalse(moveNextTask.IsCompleted);
 
             cts.Cancel();
 
-            await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => moveNextTask1).DefaultTimeout();
+            await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => moveNextTask).DefaultTimeout();
         }
 
         [Test]
@@ -178,8 +178,7 @@ namespace Grpc.Net.Client.Tests
 
             return new GrpcCall<HelloRequest, HelloReply>(
                 ClientTestHelpers.ServiceMethod,
-                uri,
-                new GrpcCallScope(ClientTestHelpers.ServiceMethod.Type, uri),
+                new GrpcMethodInfo(new GrpcCallScope(ClientTestHelpers.ServiceMethod.Type, uri), uri),
                 new CallOptions(),
                 channel);
         }

--- a/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
+++ b/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
@@ -49,7 +49,7 @@ namespace Grpc.Net.Client.Tests
             });
 
             var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions { HttpClient = httpClient });
-            var call = new GrpcCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, new CallOptions(), channel);
+            var call = CreateGrpcCall(channel);
             call.StartServerStreaming(new HelloRequest());
 
             // Act
@@ -58,7 +58,34 @@ namespace Grpc.Net.Client.Tests
             // Assert
             Assert.IsTrue(moveNextTask1.IsCompleted);
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => moveNextTask1).DefaultTimeout();
+
             Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
+        }
+
+        [Test]
+        public async Task MoveNext_TokenCanceledBeforeCall_ThrowOperationCanceledExceptionOnCancellation_ThrowError()
+        {
+            // Arrange
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var httpClient = ClientTestHelpers.CreateTestClient(request =>
+            {
+                var stream = new SyncPointMemoryStream();
+                var content = new StreamContent(stream);
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, content));
+            });
+
+            var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions { HttpClient = httpClient, ThrowOperationCanceledOnCancellation = true });
+            var call = CreateGrpcCall(channel);
+            call.StartServerStreaming(new HelloRequest());
+
+            // Act
+            var moveNextTask1 = call.ClientStreamReader!.MoveNext(cts.Token);
+
+            // Assert
+            Assert.IsTrue(moveNextTask1.IsCompleted);
+            await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => moveNextTask1).DefaultTimeout();
         }
 
         [Test]
@@ -75,7 +102,7 @@ namespace Grpc.Net.Client.Tests
             });
 
             var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions { HttpClient = httpClient });
-            var call = new GrpcCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, new CallOptions(), channel);
+            var call = CreateGrpcCall(channel);
             call.StartServerStreaming(new HelloRequest());
 
             // Act
@@ -87,6 +114,7 @@ namespace Grpc.Net.Client.Tests
             cts.Cancel();
 
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => moveNextTask1).DefaultTimeout();
+
             Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
         }
 
@@ -104,7 +132,7 @@ namespace Grpc.Net.Client.Tests
             });
 
             var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions { HttpClient = httpClient, ThrowOperationCanceledOnCancellation = true });
-            var call = new GrpcCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, new CallOptions(), channel);
+            var call = CreateGrpcCall(channel);
             call.StartServerStreaming(new HelloRequest());
 
             // Act
@@ -130,7 +158,7 @@ namespace Grpc.Net.Client.Tests
             });
 
             var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions { HttpClient = httpClient });
-            var call = new GrpcCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, new CallOptions(), channel);
+            var call = CreateGrpcCall(channel);
             call.StartServerStreaming(new HelloRequest());
 
             // Act
@@ -142,6 +170,18 @@ namespace Grpc.Net.Client.Tests
 
             var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => moveNextTask2).DefaultTimeout();
             Assert.AreEqual("Can't read the next message because the previous read is still in progress.", ex.Message);
+        }
+
+        private static GrpcCall<HelloRequest, HelloReply> CreateGrpcCall(GrpcChannel channel)
+        {
+            var uri = new Uri("http://localhost");
+
+            return new GrpcCall<HelloRequest, HelloReply>(
+                ClientTestHelpers.ServiceMethod,
+                uri,
+                new GrpcCallScope(ClientTestHelpers.ServiceMethod.Type, uri),
+                new CallOptions(),
+                channel);
         }
     }
 }

--- a/test/Grpc.Net.Client.Tests/ResponseAsyncTests.cs
+++ b/test/Grpc.Net.Client.Tests/ResponseAsyncTests.cs
@@ -122,7 +122,7 @@ namespace Grpc.Net.Client.Tests
         }
 
         [Test]
-        public void AsyncUnaryCall_ErrorSendingRequest_ThrowsError()
+        public async Task AsyncUnaryCall_ErrorSendingRequest_ThrowsError()
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(request =>
@@ -133,10 +133,12 @@ namespace Grpc.Net.Client.Tests
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest());
-            var ex = Assert.CatchAsync<Exception>(() => call.ResponseAsync);
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual("An error!", ex.Message);
+            Assert.AreEqual(StatusCode.Internal, ex.StatusCode);
+            Assert.AreEqual("Error starting gRPC call: An error!", ex.Status.Detail);
+            Assert.AreEqual(StatusCode.Internal, call.GetStatus().StatusCode);
         }
 
         [Test]

--- a/test/Grpc.Net.Client.Tests/ResponseHeadersAsyncTests.cs
+++ b/test/Grpc.Net.Client.Tests/ResponseHeadersAsyncTests.cs
@@ -140,7 +140,7 @@ namespace Grpc.Net.Client.Tests
         }
 
         [Test]
-        public void AsyncServerStreamingCall_ErrorSendingRequest_ReturnsError()
+        public async Task AsyncServerStreamingCall_ErrorSendingRequest_ReturnsError()
         {
             // Arrange
             var httpClient = ClientTestHelpers.CreateTestClient(request =>
@@ -151,10 +151,12 @@ namespace Grpc.Net.Client.Tests
 
             // Act
             var call = invoker.AsyncServerStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest());
-            var ex = Assert.CatchAsync<Exception>(() => call.ResponseHeadersAsync);
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseHeadersAsync).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual("An error!", ex.Message);
+            Assert.AreEqual(StatusCode.Internal, ex.StatusCode);
+            Assert.AreEqual("Error starting gRPC call: An error!", ex.Status.Detail);
+            Assert.AreEqual(StatusCode.Internal, call.GetStatus().StatusCode);
         }
 
         [Test]

--- a/test/Shared/ExceptionAssert.cs
+++ b/test/Shared/ExceptionAssert.cs
@@ -30,8 +30,6 @@ namespace Grpc.Tests.Shared
             try
             {
                 await action();
-
-                throw new Exception($"Exception of type {typeof(TException).Name} expected. No exception thrown.");
             }
             catch (TException ex)
             {
@@ -53,6 +51,8 @@ namespace Grpc.Tests.Shared
             {
                 throw new Exception(string.Format("Exception of type {0} expected; got exception of type {1}.", typeof(TException).Name, ex.GetType().Name), ex);
             }
+
+            throw new Exception($"Exception of type {typeof(TException).Name} expected. No exception thrown.");
         }
     }
 }


### PR DESCRIPTION
* Cache Uri and call scope for methods on channel
* Hardcode GrpcCall logger name to avoid reflection
* Reduce async state machines allocated
* Switch from Task to ValueTask where possible
* Reuse System.Version
* Optimize content-type validation
* Optimize fields on GrpcCall
* Create PushUnaryContent and PushStreamContent