### PR TITLE
Rename canceled exception property on channel

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -45,7 +45,7 @@ namespace Grpc.Net.Client
         internal int? SendMaxMessageSize { get; }
         internal int? ReceiveMaxMessageSize { get; }
         internal ILoggerFactory LoggerFactory { get; }
-        internal bool ThrowOperationCanceledExceptionOnCancellation { get; }
+        internal bool ThrowOperationCanceledOnCancellation { get; }
         internal bool? IsSecure { get; }
         internal List<CallCredentials>? CallCredentials { get; }
         internal Dictionary<string, ICompressionProvider> CompressionProviders { get; }
@@ -72,7 +72,7 @@ namespace Grpc.Net.Client
             CompressionProviders = ResolveCompressionProviders(channelOptions.CompressionProviders);
             MessageAcceptEncoding = GrpcProtocolHelpers.GetMessageAcceptEncoding(CompressionProviders);
             LoggerFactory = channelOptions.LoggerFactory ?? NullLoggerFactory.Instance;
-            ThrowOperationCanceledExceptionOnCancellation = channelOptions.ThrowOperationCanceledExceptionOnCancellation;
+            ThrowOperationCanceledOnCancellation = channelOptions.ThrowOperationCanceledOnCancellation;
 
             if (channelOptions.Credentials != null)
             {

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -82,7 +82,7 @@ namespace Grpc.Net.Client
         /// The default value is <c>false</c>.
         /// Note: experimental API that can change or be removed without any prior notice.
         /// </summary>
-        public bool ThrowOperationCanceledExceptionOnCancellation { get; set; }
+        public bool ThrowOperationCanceledOnCancellation { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GrpcChannelOptions"/> class.

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -249,7 +249,7 @@ namespace Grpc.Net.Client.Internal
                     return GrpcProtocolHelpers.BuildMetadata(HttpResponse.Headers);
                 }
             }
-            catch (OperationCanceledException) when (!Channel.ThrowOperationCanceledExceptionOnCancellation)
+            catch (OperationCanceledException) when (!Channel.ThrowOperationCanceledOnCancellation)
             {
                 throw CreateCanceledStatusException();
             }
@@ -322,7 +322,7 @@ namespace Grpc.Net.Client.Internal
                     return message;
                 }
             }
-            catch (OperationCanceledException) when (!Channel.ThrowOperationCanceledExceptionOnCancellation)
+            catch (OperationCanceledException) when (!Channel.ThrowOperationCanceledOnCancellation)
             {
                 throw CreateCanceledStatusException();
             }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -63,7 +63,7 @@ namespace Grpc.Net.Client.Internal
             // HTTP response has finished
             if (_call.CancellationToken.IsCancellationRequested)
             {
-                if (!_call.Channel.ThrowOperationCanceledExceptionOnCancellation)
+                if (!_call.Channel.ThrowOperationCanceledOnCancellation)
                 {
                     return Task.FromException<bool>(_call.CreateCanceledStatusException());
                 }
@@ -177,7 +177,7 @@ namespace Grpc.Net.Client.Internal
                 GrpcEventSource.Log.MessageReceived();
                 return true;
             }
-            catch (OperationCanceledException) when (!_call.Channel.ThrowOperationCanceledExceptionOnCancellation)
+            catch (OperationCanceledException) when (!_call.Channel.ThrowOperationCanceledOnCancellation)
             {
                 throw _call.CreateCanceledStatusException();
             }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -94,7 +94,7 @@ namespace Grpc.Net.Client.Internal
                     // Call has been canceled
                     if (_call.CancellationToken.IsCancellationRequested)
                     {
-                        if (!_call.Channel.ThrowOperationCanceledExceptionOnCancellation)
+                        if (!_call.Channel.ThrowOperationCanceledOnCancellation)
                         {
                             return Task.FromException(_call.CreateCanceledStatusException());
                         }
@@ -167,7 +167,7 @@ namespace Grpc.Net.Client.Internal
 
                 GrpcEventSource.Log.MessageSent();
             }
-            catch (OperationCanceledException) when (!_call.Channel.ThrowOperationCanceledExceptionOnCancellation)
+            catch (OperationCanceledException) when (!_call.Channel.ThrowOperationCanceledOnCancellation)
             {
                 throw _call.CreateCanceledStatusException();
             }

--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -270,7 +270,7 @@ namespace Grpc.Net.Client.Tests
             {
                 return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK));
             });
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledExceptionOnCancellation = true);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledOnCancellation = true);
 
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(cancellationToken: new CancellationToken(true)));

--- a/test/Grpc.Net.Client.Tests/CancellationTests.cs
+++ b/test/Grpc.Net.Client.Tests/CancellationTests.cs
@@ -81,7 +81,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var cts = new CancellationTokenSource();
-            var invoker = CreateTimedoutCallInvoker(configure: o => o.ThrowOperationCanceledExceptionOnCancellation = true);
+            var invoker = CreateTimedoutCallInvoker(configure: o => o.ThrowOperationCanceledOnCancellation = true);
 
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(cancellationToken: cts.Token));
@@ -102,7 +102,7 @@ namespace Grpc.Net.Client.Tests
         {
             // Arrange
             var cts = new CancellationTokenSource();
-            var invoker = CreateTimedoutCallInvoker(configure: o => o.ThrowOperationCanceledExceptionOnCancellation = true);
+            var invoker = CreateTimedoutCallInvoker(configure: o => o.ThrowOperationCanceledOnCancellation = true);
 
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(cancellationToken: cts.Token));

--- a/test/Grpc.Net.Client.Tests/DeadlineTests.cs
+++ b/test/Grpc.Net.Client.Tests/DeadlineTests.cs
@@ -155,7 +155,7 @@ namespace Grpc.Net.Client.Tests
                 return ResponseUtils.CreateResponse(HttpStatusCode.OK);
             });
             var testSystemClock = new TestSystemClock(DateTime.UtcNow);
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, systemClock: testSystemClock, configure: o => o.ThrowOperationCanceledExceptionOnCancellation = true);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, systemClock: testSystemClock, configure: o => o.ThrowOperationCanceledOnCancellation = true);
 
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: testSystemClock.UtcNow.AddSeconds(0.5)));

--- a/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
+++ b/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
@@ -103,7 +103,7 @@ namespace Grpc.Net.Client.Tests
                 return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, content));
             });
 
-            var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions { HttpClient = httpClient, ThrowOperationCanceledExceptionOnCancellation = true });
+            var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, new GrpcChannelOptions { HttpClient = httpClient, ThrowOperationCanceledOnCancellation = true });
             var call = new GrpcCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, new CallOptions(), channel);
             call.StartServerStreaming(new HelloRequest());
 

--- a/test/Grpc.Net.Client.Tests/ReadAllAsyncTests.cs
+++ b/test/Grpc.Net.Client.Tests/ReadAllAsyncTests.cs
@@ -205,7 +205,7 @@ namespace Grpc.Net.Client.Tests
 
                 return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent);
             });
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledExceptionOnCancellation = true);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledOnCancellation = true);
             var cts = new CancellationTokenSource();
 
             // Act

--- a/test/Grpc.Net.Client.Tests/ResponseAsyncTests.cs
+++ b/test/Grpc.Net.Client.Tests/ResponseAsyncTests.cs
@@ -106,7 +106,7 @@ namespace Grpc.Net.Client.Tests
                 response.Headers.Add("custom", "value!");
                 return Task.FromResult(response);
             });
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledExceptionOnCancellation = true);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledOnCancellation = true);
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "World" });

--- a/test/Grpc.Net.Client.Tests/ResponseHeadersAsyncTests.cs
+++ b/test/Grpc.Net.Client.Tests/ResponseHeadersAsyncTests.cs
@@ -200,7 +200,7 @@ namespace Grpc.Net.Client.Tests
                 response.Headers.Add("custom", "ABC");
                 return response;
             });
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledExceptionOnCancellation = true);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, configure: o => o.ThrowOperationCanceledOnCancellation = true);
 
             // Act
             var call = invoker.AsyncServerStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest());


### PR DESCRIPTION
I noticed this property is really long:

![image](https://user-images.githubusercontent.com/303201/64333909-a4e2aa00-d02b-11e9-9a29-6c65045c99c5.png)

Shortened it some:

![image](https://user-images.githubusercontent.com/303201/64333930-ad3ae500-d02b-11e9-8665-1d3af2f01dc2.png)
