### PR TITLE
Fix not canceling in-progress stream calls

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -424,12 +424,13 @@ namespace Grpc.Net.Client.Internal
             {
                 Log.CanceledCall(Logger);
 
-                // Cancel in-progress HttpClient.SendAsync and Stream.ReadAsync.
+                // Cancel in-progress HttpClient.SendAsync and Stream.ReadAsync tasks.
+                // Cancel will send RST_STREAM if HttpClient.SendAsync isn't complete.
                 // Cancellation will also cause reader/writer to throw if used afterwards.
                 _callCts.Cancel();
 
-                // Cancellation token won't cancel call that has returned response.
-                // Dispose to cancel server and duplex streaming calls.
+                // Cancellation token won't send RST_STREAM if HttpClient.SendAsync is complete.
+                // Dispose HttpResponseMessage to send RST_STREAM to server for in-progress calls.
                 HttpResponse?.Dispose();
 
                 // Canceling call will cancel pending writes to the stream

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -424,11 +424,12 @@ namespace Grpc.Net.Client.Internal
             {
                 Log.CanceledCall(Logger);
 
-                // Cancel inprogress HttpClient.SendAsync and Stream.ReadAsync.
+                // Cancel in-progress HttpClient.SendAsync and Stream.ReadAsync.
                 // Cancellation will also cause reader/writer to throw if used afterwards.
                 _callCts.Cancel();
 
-                //
+                // Cancellation token won't cancel call that has returned response.
+                // Dispose to cancel server and duplex streaming calls.
                 HttpResponse?.Dispose();
 
                 // Canceling call will cancel pending writes to the stream
@@ -577,8 +578,6 @@ namespace Grpc.Net.Client.Internal
 
             try
             {
-                _callCts.Token.Register(() => Logger.LogInformation("SendAsync canceled!"));
-
                 HttpResponse = await Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token).ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
Found by a user: https://twitter.com/stevejgordon/status/1169995743568048129

Canceling a streaming call that has returned response headers will not send RST_STREAM to the server. Disposing the call will send RST_STREAM.

This will be a problem if:
1. If the server method is waiting for cancellation (e.g. `while (!token.IsCancellationRequested) { }`)
2. The user doesn't dispose the call

In this situation the client would consider itself canceled and the client app would go about its business, but the server would continue running forever (or more realistically the deadline will end the call). Under load the server would run out of resources and/or clients would hit the HTTP/2 stream limit for a connection and new calls would hang.

Serious enough to warrant 2.23.1?