### PR TITLE
Server call handler logger name shouldn't be service type name

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -49,7 +49,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             ServiceOptions = serviceOptions;
             ServiceActivator = serviceActivator;
             ServiceProvider = serviceProvider;
-            Logger = loggerFactory.CreateLogger(typeof(TService));
+            Logger = loggerFactory.CreateLogger(typeof(ServerCallHandlerBase<TService, TRequest, TResponse>));
         }
 
         public Task HandleCallAsync(HttpContext httpContext)

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -32,6 +32,8 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
         where TRequest : class
         where TResponse : class
     {
+        private const string LoggerName = "Grpc.AspNetCore.Server.ServerCallHandler";
+
         protected Method<TRequest, TResponse> Method { get; }
         protected GrpcServiceOptions ServiceOptions { get; }
         protected IGrpcServiceActivator<TService> ServiceActivator { get; }
@@ -49,7 +51,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             ServiceOptions = serviceOptions;
             ServiceActivator = serviceActivator;
             ServiceProvider = serviceProvider;
-            Logger = loggerFactory.CreateLogger(typeof(ServerCallHandlerBase<TService, TRequest, TResponse>));
+            Logger = loggerFactory.CreateLogger(LoggerName);
         }
 
         public Task HandleCallAsync(HttpContext httpContext)

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
@@ -52,7 +53,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         {
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER FunctionalTestsWebsite.Services.StreamService")
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName)
                 {
                     // Kestrel cancellation error message
                     if (writeContext.Exception is IOException &&

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Tests.Shared;
@@ -368,7 +369,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER FunctionalTestsWebsite.Services.StreamService")
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName)
                 {
                     return true;
                 }

--- a/test/FunctionalTests/Infrastructure/TestConstants.cs
+++ b/test/FunctionalTests/Infrastructure/TestConstants.cs
@@ -1,0 +1,25 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    internal static class TestConstants
+    {
+        public const string ServerCallHandlerTestName = "SERVER Grpc.AspNetCore.Server.Internal.CallHandlers.ServerCallHandlerBase";
+    }
+}

--- a/test/FunctionalTests/Infrastructure/TestConstants.cs
+++ b/test/FunctionalTests/Infrastructure/TestConstants.cs
@@ -20,6 +20,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 {
     internal static class TestConstants
     {
-        public const string ServerCallHandlerTestName = "SERVER Grpc.AspNetCore.Server.Internal.CallHandlers.ServerCallHandlerBase";
+        public const string ServerCallHandlerTestName = "SERVER Grpc.AspNetCore.Server.ServerCallHandler";
     }
 }

--- a/test/FunctionalTests/Server/ClientStreamingMethodTests.cs
+++ b/test/FunctionalTests/Server/ClientStreamingMethodTests.cs
@@ -81,7 +81,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER " + typeof(CounterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "RpcConnectionError" &&
                     writeContext.State.ToString() == "Error status code 'Internal' raised." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Incomplete message.")
@@ -89,7 +89,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER " + typeof(CounterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "ErrorReadingMessage" &&
                     writeContext.State.ToString() == "Error reading message." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Incomplete message.")
@@ -139,7 +139,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             SetExpectedErrorsFilter(writeContext =>
             {
-                return writeContext.LoggerName == "SERVER " + typeof(DynamicService).FullName &&
+                return writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                        writeContext.EventId.Name == "RpcConnectionError" &&
                        writeContext.State.ToString() == "Error status code 'Cancelled' raised." &&
                        GetRpcExceptionDetail(writeContext.Exception) == "No message returned from method.";
@@ -246,7 +246,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                return writeContext.LoggerName == "SERVER " + typeof(DynamicService).FullName;
+                return writeContext.LoggerName == TestConstants.ServerCallHandlerTestName;
             });
 
             var method = Fixture.DynamicGrpc.AddClientStreamingMethod<CounterRequest, CounterReply>(AccumulateCount);

--- a/test/FunctionalTests/Server/CompressionTests.cs
+++ b/test/FunctionalTests/Server/CompressionTests.cs
@@ -223,14 +223,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "RpcConnectionError" &&
                     writeContext.State.ToString() == "Error status code 'Internal' raised.")
                 {
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "ErrorReadingMessage" &&
                     writeContext.State.ToString() == "Error reading message.")
                 {
@@ -291,7 +291,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "RpcConnectionError" &&
                     writeContext.State.ToString() == "Error status code 'Unimplemented' raised." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Unsupported grpc-encoding value 'DOES_NOT_EXIST'. Supported encodings: identity, gzip")
@@ -299,7 +299,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "ErrorReadingMessage" &&
                     writeContext.State.ToString() == "Error reading message." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Unsupported grpc-encoding value 'DOES_NOT_EXIST'. Supported encodings: identity, gzip")
@@ -360,7 +360,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "RpcConnectionError" &&
                     writeContext.State.ToString() == "Error status code 'Internal' raised." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Request did not include grpc-encoding value with compressed message.")
@@ -368,7 +368,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "ErrorReadingMessage" &&
                     writeContext.State.ToString() == "Error reading message." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Request did not include grpc-encoding value with compressed message.")

--- a/test/FunctionalTests/Server/DeadlineTests.cs
+++ b/test/FunctionalTests/Server/DeadlineTests.cs
@@ -146,7 +146,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                return writeContext.LoggerName == "SERVER " + typeof(DynamicService).FullName &&
+                return writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                        writeContext.EventId.Name == "ErrorExecutingServiceMethod" &&
                        writeContext.State.ToString() == "Error when executing service method 'WriteUntilError'." &&
                        writeContext.Exception!.Message == "Cannot write message after request is complete.";

--- a/test/FunctionalTests/Server/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/Server/MaxMessageSizeTests.cs
@@ -36,7 +36,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "RpcConnectionError" &&
                     writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Received message exceeds the maximum configured message size.")
@@ -44,7 +44,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "ErrorReadingMessage" &&
                     writeContext.State.ToString() == "Error reading message." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Received message exceeds the maximum configured message size.")
@@ -78,7 +78,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "RpcConnectionError" &&
                     writeContext.State.ToString() == "Error status code 'ResourceExhausted' raised." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Sending message exceeds the maximum configured message size.")
@@ -86,7 +86,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "ErrorSendingMessage" &&
                     writeContext.State.ToString() == "Error sending message." &&
                     GetRpcExceptionDetail(writeContext.Exception) == "Sending message exceeds the maximum configured message size.")

--- a/test/FunctionalTests/Server/UnaryMethodTests.cs
+++ b/test/FunctionalTests/Server/UnaryMethodTests.cs
@@ -101,14 +101,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "RpcConnectionError" &&
                     writeContext.State.ToString() == "Error status code 'Internal' raised.")
                 {
                     return true;
                 }
 
-                if (writeContext.LoggerName == "SERVER " + typeof(GreeterService).FullName &&
+                if (writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                     writeContext.EventId.Name == "ErrorReadingMessage" &&
                     writeContext.State.ToString() == "Error reading message.")
                 {
@@ -164,7 +164,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                return writeContext.LoggerName == "SERVER " + typeof(DynamicService).FullName &&
+                return writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                        writeContext.EventId.Name == "ErrorExecutingServiceMethod" &&
                        writeContext.State.ToString() == "Error when executing service method 'ReturnHeadersTwice'." &&
                        writeContext.Exception!.Message == "Response headers can only be sent once per call.";
@@ -200,7 +200,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             SetExpectedErrorsFilter(writeContext =>
             {
-                return writeContext.LoggerName == "SERVER " + typeof(DynamicService).FullName &&
+                return writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                        writeContext.EventId.Name == "RpcConnectionError" &&
                        writeContext.State.ToString() == "Error status code 'Cancelled' raised." &&
                        GetRpcExceptionDetail(writeContext.Exception) == "No message returned from method.";
@@ -239,7 +239,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             SetExpectedErrorsFilter(writeContext =>
             {
-                return writeContext.LoggerName == "SERVER " + typeof(DynamicService).FullName &&
+                return writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                        writeContext.EventId.Name == "RpcConnectionError" &&
                        writeContext.State.ToString() == "Error status code 'Unknown' raised." &&
                        GetRpcExceptionDetail(writeContext.Exception) == "User error";
@@ -316,7 +316,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             SetExpectedErrorsFilter(writeContext =>
             {
-                return writeContext.LoggerName == "SERVER " + typeof(DynamicService).FullName &&
+                return writeContext.LoggerName == TestConstants.ServerCallHandlerTestName &&
                        writeContext.EventId.Name == "ErrorExecutingServiceMethod";
             });
 


### PR DESCRIPTION
re: https://twitter.com/JamesNK/status/1170454441364819968

Change call handler logger name to `Grpc.AspNetCore.Server.ServerCallHandler`. It currently uses the user service type name which makes filtering out framework log messages more difficult.