### PR TITLE
Allow for a base URI that includes path components.

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -68,7 +68,7 @@ namespace Grpc.Net.Client.Internal
             _callCts = new CancellationTokenSource();
             _callTcs = new TaskCompletionSource<Status>(TaskContinuationOptions.RunContinuationsAsynchronously);
             Method = method;
-            _uri = new Uri(method.FullName, UriKind.Relative);
+            _uri = new Uri(RemoveLeadingSlash(method.FullName), UriKind.Relative);
             _logScope = new GrpcCallScope(method.Type, _uri);
             Options = options;
             Channel = channel;
@@ -88,6 +88,8 @@ namespace Grpc.Net.Client.Internal
                 throw new InvalidOperationException("Deadline must have a kind DateTimeKind.Utc or be equal to DateTime.MaxValue or DateTime.MinValue.");
             }
         }
+
+        private string RemoveLeadingSlash(string uri) => uri.StartsWith('/') ? uri.Substring(1) : uri;
 
         public Task<Status> CallTask => _callTcs.Task;
 

--- a/test/Grpc.Net.Client.Tests/LoggingTests.cs
+++ b/test/Grpc.Net.Client.Tests/LoggingTests.cs
@@ -79,7 +79,7 @@ namespace Grpc.Net.Client.Tests
             {
                 var scope = (IReadOnlyList<KeyValuePair<string, object>>)log.Scope;
                 Assert.AreEqual(MethodType.Unary, scope[0].Value);
-                Assert.AreEqual(new Uri("/ServiceName/MethodName", UriKind.Relative), scope[1].Value);
+                Assert.AreEqual(new Uri("ServiceName/MethodName", UriKind.Relative), scope[1].Value);
             }
         }
     }


### PR DESCRIPTION
Fixes handling of relative paths in gRPC calls to allow for a base URI that includes path components. Without this change, only 'bare' domains can be used for the base address on a gRPC client.