### PR TITLE
Workaround for bug in System.CommandLine

### DIFF
--- a/src/dotnet-grpc/Commands/ListCommand.cs
+++ b/src/dotnet-grpc/Commands/ListCommand.cs
@@ -95,7 +95,16 @@ namespace Grpc.Dotnet.Cli.Commands
             }
 
             var screen = new ScreenView(consoleRenderer, Console) { Child = table };
-            screen.Render(new Region(0, 0, System.Console.WindowWidth, System.Console.WindowWidth));
+            Region region;
+            try
+            {
+                region = new Region(0, 0, System.Console.WindowWidth, System.Console.WindowHeight);
+            }
+            catch (IOException)
+            {
+                region = new Region(0, 0, int.MaxValue, int.MaxValue);
+            }
+            screen.Child?.Render(consoleRenderer, region);
         }
     }
 }

--- a/src/dotnet-grpc/Commands/ListCommand.cs
+++ b/src/dotnet-grpc/Commands/ListCommand.cs
@@ -98,6 +98,7 @@ namespace Grpc.Dotnet.Cli.Commands
             Region region;
             try
             {
+                // System.Console.WindowWidth can throw an IOException when runnning without a console attached
                 region = new Region(0, 0, System.Console.WindowWidth, System.Console.WindowHeight);
             }
             catch (IOException)

--- a/test/dotnet-grpc.Tests/ListCommandTests.cs
+++ b/test/dotnet-grpc.Tests/ListCommandTests.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.CommandLine;
+using System.CommandLine.Rendering;
 using System.IO;
 using Grpc.Dotnet.Cli.Commands;
 using NUnit.Framework;
@@ -28,7 +29,7 @@ namespace Grpc.Dotnet.Cli.Tests
     public class ListCommandTests : TestBase
     {
         [Test]
-        [Ignore("https://github.com/grpc/grpc-dotnet/issues/457")]
+        //[Ignore("https://github.com/grpc/grpc-dotnet/issues/457")]
         public void List_ListsReferences()
         {
             var currentDir = Directory.GetCurrentDirectory();

--- a/test/dotnet-grpc.Tests/ListCommandTests.cs
+++ b/test/dotnet-grpc.Tests/ListCommandTests.cs
@@ -18,7 +18,6 @@
 
 using System;
 using System.CommandLine;
-using System.CommandLine.Rendering;
 using System.IO;
 using Grpc.Dotnet.Cli.Commands;
 using NUnit.Framework;
@@ -29,7 +28,6 @@ namespace Grpc.Dotnet.Cli.Tests
     public class ListCommandTests : TestBase
     {
         [Test]
-        //[Ignore("https://github.com/grpc/grpc-dotnet/issues/457")]
         public void List_ListsReferences()
         {
             var currentDir = Directory.GetCurrentDirectory();


### PR DESCRIPTION
There are a bunch of bugs in `System.CommandLine` when using the `TestConsole`
- `System.Console.WindowWidth` (and `WindowHeight`) throws an `IOException`
- `SystemConsoleTerminal.HideCursor()` (and `ShowCursor()`) throws an `IOException`

Additionally,  there was a small logic bug

```
screen.Render(new Region(0, 0, System.Console.WindowWidth, System.Console.WindowWidth));
                                                                          ^^^^ Should have been WindowHeight
```

This addresses https://github.com/grpc/grpc-dotnet/issues/457