### PR TITLE
Fix generating XML documentation

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,7 +16,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)Grpc.DotNet.ruleset</CodeAnalysisRuleset>
   </PropertyGroup>

--- a/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
+++ b/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 

--- a/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
+++ b/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 

--- a/src/Grpc.Net.Common/Grpc.Net.Common.csproj
+++ b/src/Grpc.Net.Common/Grpc.Net.Common.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
I noticed that the XML docs file is missing from the gRPC package 😭 Apparently Directory.Build.targets is too late to set the value.