### PR TITLE
[2.23.x] Fix generating XML docs and disable deterministic packaging

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,7 @@
     <Version>$(GrpcDotnetVersion)</Version>
     <AssemblyVersion>$(GrpcDotnetAssemblyVersion)</AssemblyVersion>
     <FileVersion>$(GrpcDotnetAssemblyFileVersion)</FileVersion>
+    <Deterministic>false</Deterministic>
 
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,7 +16,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)Grpc.DotNet.ruleset</CodeAnalysisRuleset>
   </PropertyGroup>

--- a/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
+++ b/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 

--- a/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
+++ b/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 

--- a/src/Grpc.Net.Common/Grpc.Net.Common.csproj
+++ b/src/Grpc.Net.Common/Grpc.Net.Common.csproj
@@ -5,6 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
Cherry picked from master.

Deterministic packaging problem is potentially serious. Recommendation is for all packages impacted by it to release a fixed version.

> A problematic feature in recent NuGet versions would clear the modified date of .NET project output (DLL, PDB, XML) files. This means that deployment technologies that rely on modified date to deploy files could incorrectly skip files, leaving deploy apps in a broken state.
> 
> The feature is being disabled in NuGet, but our build used an effected version of NuGet. Workaround is to set `<Deterministic>` to false.
> 
> Fortunately for us, Authenticode signing has updated the DLL modified date of Grpc.* packages, so at worst only the PDB will be missed.
> 
> See https://github.com/dotnet/core/issues/3388 for more information.

By the way, I have checked Grpc.Core and it is not impacted.

See https://github.com/grpc/grpc-dotnet/pull/524 and https://github.com/grpc/grpc-dotnet/pull/527 for more details.