### PR TITLE
Log unsupported request content-type and protocol

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -63,7 +63,8 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
                 GrpcProtocolHelpers.BuildHttpErrorResponse(httpContext.Response, StatusCodes.Status415UnsupportedMediaType, StatusCode.Internal, error);
                 return Task.CompletedTask;
             }
-            if (httpContext.Request.Protocol != GrpcProtocolConstants.Http2Protocol)
+            if (httpContext.Request.Protocol != GrpcProtocolConstants.Http2Protocol &&
+                httpContext.Request.Protocol != GrpcProtocolConstants.Http20Protocol)
             {
                 Log.UnsupportedRequestProtocol(Logger, httpContext.Request.Protocol);
 

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -58,13 +58,17 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
         {
             if (GrpcProtocolHelpers.IsInvalidContentType(httpContext, out var error))
             {
-                GrpcProtocolHelpers.SendHttpError(httpContext.Response, StatusCodes.Status415UnsupportedMediaType, StatusCode.Internal, error);
+                Log.UnsupportedRequestContentType(Logger, httpContext.Request.ContentType);
+
+                GrpcProtocolHelpers.BuildHttpErrorResponse(httpContext.Response, StatusCodes.Status415UnsupportedMediaType, StatusCode.Internal, error);
                 return Task.CompletedTask;
             }
             if (httpContext.Request.Protocol != GrpcProtocolConstants.Http2Protocol)
             {
+                Log.UnsupportedRequestProtocol(Logger, httpContext.Request.Protocol);
+
                 var protocolError = $"Request protocol '{httpContext.Request.Protocol}' is not supported.";
-                GrpcProtocolHelpers.SendHttpError(httpContext.Response, StatusCodes.Status426UpgradeRequired, StatusCode.Internal, protocolError);
+                GrpcProtocolHelpers.BuildHttpErrorResponse(httpContext.Response, StatusCodes.Status426UpgradeRequired, StatusCode.Internal, protocolError);
                 httpContext.Response.Headers[HeaderNames.Upgrade] = GrpcProtocolConstants.Http2Protocol;
                 return Task.CompletedTask;
             }
@@ -143,9 +147,25 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             private static readonly Action<ILogger, Exception?> _unableToDisableMaxRequestBodySize =
                 LoggerMessage.Define(LogLevel.Debug, new EventId(1, "UnableToDisableMaxRequestBodySizeLimit"), "Unable to disable the max request body size limit.");
 
+            private static readonly Action<ILogger, string?, Exception?> _unsupportedRequestContentType =
+                LoggerMessage.Define<string?>(LogLevel.Information, new EventId(2, "UnsupportedRequestContentType"), "Request content-type of '{ContentType}' is not supported.");
+
+            private static readonly Action<ILogger, string?, Exception?> _unsupportedRequestProtocol =
+                LoggerMessage.Define<string?>(LogLevel.Information, new EventId(3, "UnsupportedRequestProtocol"), "Request protocol of '{Protocol}' is not supported.");
+
             public static void UnableToDisableMaxRequestBodySize(ILogger logger)
             {
                 _unableToDisableMaxRequestBodySize(logger, null);
+            }
+
+            public static void UnsupportedRequestContentType(ILogger logger, string? contentType)
+            {
+                _unsupportedRequestContentType(logger, contentType, null);
+            }
+
+            public static void UnsupportedRequestProtocol(ILogger logger, string? protocol)
+            {
+                _unsupportedRequestProtocol(logger, protocol, null);
             }
         }
     }

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
@@ -25,7 +25,8 @@ namespace Grpc.AspNetCore.Server.Internal
     internal static class GrpcProtocolConstants
     {
         internal const string GrpcContentType = "application/grpc";
-        internal const string Http2Protocol = "HTTP/2";
+        internal const string Http2Protocol = "HTTP/2"; // This is what Kestrel sets
+        internal const string Http20Protocol = "HTTP/2.0"; // This is what IIS sets
 
         internal const string TimeoutHeader = "grpc-timeout";
         internal const string MessageEncodingHeader = "grpc-encoding";

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -123,7 +123,7 @@ namespace Grpc.AspNetCore.Server.Internal
             return false;
         }
 
-        public static void SendHttpError(HttpResponse response, int httpStatusCode, StatusCode grpcStatusCode, string message)
+        public static void BuildHttpErrorResponse(HttpResponse response, int httpStatusCode, StatusCode grpcStatusCode, string message)
         {
             response.StatusCode = httpStatusCode;
             SetStatus(GetTrailersDestination(response), new Status(grpcStatusCode, message));


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/526

Make it easier for developers to debug badly formed requests that are sent to gRPC endpoints.