### PR TITLE
Attempt to add scripts for generating API docs

### DIFF
--- a/docfx/.gitignore
+++ b/docfx/.gitignore
@@ -1,0 +1,2 @@
+html
+obj

--- a/docfx/README.md
+++ b/docfx/README.md
@@ -1,0 +1,28 @@
+DocFX-generated C# API Reference
+--------------------------------
+
+## Generating docs manually (on Windows)
+
+Install docfx based on instructions here: https://github.com/dotnet/docfx
+
+```
+# generate docfx documentation into ./html directory
+$ docfx
+```
+
+## Release process: script for regenerating the docs automatically
+
+After each gRPC C# release, the docs need to be regenerated
+and updated on the grpc.io site. The automated script will
+re-generate the docs (using dockerized docfx installation)
+and make everything ready for creating a PR to update the docs.
+
+```
+# 1. Run the script on Linux with docker installed
+$ ./generate_reference_docs.sh
+
+# 2. Enter the git repo with updated "gh-pages" branch
+$ cd grpc-gh-pages
+
+# 3. Review the changes and create a pull request
+```

--- a/docfx/README.md
+++ b/docfx/README.md
@@ -8,6 +8,9 @@ Install docfx based on instructions here: https://github.com/dotnet/docfx
 ```
 # generate docfx documentation into ./html directory
 $ docfx
+
+# view the resulting docs
+$ docfx server html
 ```
 
 ## Release process: script for regenerating the docs automatically

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -1,0 +1,38 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": ["Grpc.Core.Api/Grpc.Core.Api.csproj",
+                    "Grpc.Core/Grpc.Core.csproj",
+                    "Grpc.Auth/Grpc.Auth.csproj",
+                    "Grpc.Core.Testing/Grpc.Core.Testing.csproj",
+                    "Grpc.HealthCheck/Grpc.HealthCheck.csproj",
+                    "Grpc.Reflection/Grpc.HealthCheck.csproj"],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "cwd": ".."
+        }
+      ],
+      "properties": { "TargetFramework": "net45" },
+      "dest": "obj/api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "cwd": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "toc.yml"]
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "gRPC C#",
+      "_enableSearch": true,
+      "_disableContribution": true
+    },
+    "dest": "html"
+  }
+}

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -16,6 +16,7 @@
           "cwd": ".."
         }
       ],
+      "properties": { "TargetFramework": "netcoreapp3.0" },
       "dest": "obj/api"
     }
   ],

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -3,7 +3,9 @@
     {
       "src": [
         {
-          "files": ["src/Grpc.AspNetCore/Grpc.AspNetCore.csproj",
+          "files": [
+            "docfx/grpc-main-repo/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj",
+            "src/Grpc.AspNetCore/Grpc.AspNetCore.csproj",
             "src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj",
             "src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj",
             "src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj",

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -3,17 +3,17 @@
     {
       "src": [
         {
-          "files": ["Grpc.Core.Api/Grpc.Core.Api.csproj",
-                    "Grpc.Core/Grpc.Core.csproj",
-                    "Grpc.Auth/Grpc.Auth.csproj",
-                    "Grpc.Core.Testing/Grpc.Core.Testing.csproj",
-                    "Grpc.HealthCheck/Grpc.HealthCheck.csproj",
-                    "Grpc.Reflection/Grpc.HealthCheck.csproj"],
+          "files": ["src/Grpc.AspNetCore/Grpc.AspNetCore.csproj",
+            "src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj",
+            "src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj",
+            "src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj",
+            "src/Grpc.Net.Client/Grpc.Net.Client.csproj",
+            "src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj",
+            "src/Grpc.Net.Common/Grpc.Net.Common.csproj"],
           "exclude": [ "**/bin/**", "**/obj/**" ],
           "cwd": ".."
         }
       ],
-      "properties": { "TargetFramework": "net45" },
       "dest": "obj/api"
     }
   ],
@@ -29,7 +29,7 @@
       }
     ],
     "globalMetadata": {
-      "_appTitle": "gRPC C#",
+      "_appTitle": "gRPC for .NET",
       "_enableSearch": true,
       "_disableContribution": true
     },

--- a/docfx/generate_reference_docs.sh
+++ b/docfx/generate_reference_docs.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generates C# API docs using docfx inside docker.
+set -ex
+cd $(dirname $0)
+
+# cleanup temporary files
+rm -rf html obj grpc-gh-pages
+
+# generate into src/csharp/doc/html directory
+cd ..
+docker run --rm -v "$(pwd)":/work -w /work/doc --user "$(id -u):$(id -g)" -it tsgkadot/docker-docfx:latest docfx
+cd docfx
+
+# prepare a clone of "gh-pages" branch where the generated docs are stored
+GITHUB_USER="${USER}"
+git clone -b gh-pages -o upstream git@github.com:grpc/grpc.git grpc-gh-pages
+cd grpc-gh-pages
+git remote add origin "git@github.com:${GITHUB_USER}/grpc.git"
+
+# replace old generated docs by the ones we just generated
+rm -r csharp
+cp -r ../html csharp
+
+echo "Done. Go to src/csharp/docfx/grpc-gh-pages git repository and create a pull request to update the generated docs."

--- a/docfx/generate_reference_docs.sh
+++ b/docfx/generate_reference_docs.sh
@@ -20,9 +20,9 @@ cd $(dirname $0)
 # cleanup temporary files
 rm -rf html obj grpc-gh-pages
 
-# generate into src/csharp/doc/html directory
+# generate into src/csharp/docfx/html directory
 cd ..
-docker run --rm -v "$(pwd)":/work -w /work/doc --user "$(id -u):$(id -g)" -it tsgkadot/docker-docfx:latest docfx
+docker run --rm -v "$(pwd)":/work -w /work/docfx --user "$(id -u):$(id -g)" -it tsgkadot/docker-docfx:latest docfx --disableGitFeatures
 cd docfx
 
 # prepare a clone of "gh-pages" branch where the generated docs are stored

--- a/docfx/generate_reference_docs.sh
+++ b/docfx/generate_reference_docs.sh
@@ -21,9 +21,10 @@ cd $(dirname $0)
 rm -rf html obj grpc-gh-pages grpc-main-repo
 
 # clone the grpc/grpc repository to gain access to be able to include Grpc.Core.Api docs
-git clone -b v1.24.0-pre2 -o upstream git@github.com:grpc/grpc.git grpc-main-repo
+# TODO(jtattermusch): the tag needs to be updated according to the Grpc.Core.Api nuget version used
+git clone -b v1.23.0 -o upstream git@github.com:grpc/grpc.git grpc-main-repo
 
-# generate into docfx/html directory
+# generate into docfx/html directory by running the "docfx" command using docker
 cd ..
 docker run --rm -v "$(pwd)":/work -w /work/docfx --user "$(id -u):$(id -g)" -it tsgkadot/docker-docfx:latest docfx --disableGitFeatures
 cd docfx
@@ -35,7 +36,7 @@ cd grpc-gh-pages
 git remote add origin "git@github.com:${GITHUB_USER}/grpc.git"
 
 # replace old generated docs by the ones we just generated
-rm -r csharp-dotnet
+rm -rf csharp-dotnet
 cp -r ../html csharp-dotnet
 
-echo "Done. Go to src/csharp/docfx/grpc-gh-pages git repository and create a pull request to update the generated docs."
+echo "Done. Go to docfx/grpc-gh-pages git repository and create a pull request to update the generated docs."

--- a/docfx/generate_reference_docs.sh
+++ b/docfx/generate_reference_docs.sh
@@ -20,9 +20,10 @@ cd $(dirname $0)
 # cleanup temporary files
 rm -rf html obj grpc-gh-pages grpc-main-repo
 
+# clone the grpc/grpc repository to gain access to be able to include Grpc.Core.Api docs
 git clone -b v1.24.0-pre2 -o upstream git@github.com:grpc/grpc.git grpc-main-repo
 
-# generate into src/csharp/docfx/html directory
+# generate into docfx/html directory
 cd ..
 docker run --rm -v "$(pwd)":/work -w /work/docfx --user "$(id -u):$(id -g)" -it tsgkadot/docker-docfx:latest docfx --disableGitFeatures
 cd docfx
@@ -34,7 +35,7 @@ cd grpc-gh-pages
 git remote add origin "git@github.com:${GITHUB_USER}/grpc.git"
 
 # replace old generated docs by the ones we just generated
-rm -r csharp
-cp -r ../html csharp
+rm -r csharp-dotnet
+cp -r ../html csharp-dotnet
 
 echo "Done. Go to src/csharp/docfx/grpc-gh-pages git repository and create a pull request to update the generated docs."

--- a/docfx/generate_reference_docs.sh
+++ b/docfx/generate_reference_docs.sh
@@ -18,7 +18,9 @@ set -ex
 cd $(dirname $0)
 
 # cleanup temporary files
-rm -rf html obj grpc-gh-pages
+rm -rf html obj grpc-gh-pages grpc-main-repo
+
+git clone -b v1.24.0-pre2 -o upstream git@github.com:grpc/grpc.git grpc-main-repo
 
 # generate into src/csharp/docfx/html directory
 cd ..

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -1,0 +1,3 @@
+- name: API Documentation
+  href: obj/api/
+  homepage: obj/api/Grpc.Core.yml


### PR DESCRIPTION
This this the result of my first attempt. It is slightly hacky, but it seems to work.

- the API docs will be added to grpc.io  in a separate section (so there will be gRPC C# and grpc-dotnet section, to avoid mixing up two different API for creating servers and channels in the same generated docs)
- the generated docs include docs for Grpc.Core.Api  (the way I added it is somewhat hacky)
- there are some warnings when generating the docfx docs, but overall the docs look fine, so these can be fixed later.
- the scripts are heavily inspired by https://github.com/grpc/grpc/tree/master/src/csharp/docfx