### PR TITLE
Use HttpClientHandler.DangerousAcceptAnyServerCertificateValidator

### DIFF
--- a/perf/benchmarkapps/BenchmarkClient/Worker/GrpcRawUnaryWorker.cs
+++ b/perf/benchmarkapps/BenchmarkClient/Worker/GrpcRawUnaryWorker.cs
@@ -89,7 +89,7 @@ namespace BenchmarkClient.Worker
         public Task ConnectAsync()
         {
             var handler = new HttpClientHandler();
-            handler.ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true;
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
             _client = new HttpClient(handler);
             return Task.CompletedTask;

--- a/perf/benchmarkapps/BenchmarkClient/Worker/JsonWorker.cs
+++ b/perf/benchmarkapps/BenchmarkClient/Worker/JsonWorker.cs
@@ -72,7 +72,7 @@ namespace BenchmarkClient.Worker
         public Task ConnectAsync()
         {
             var handler = new HttpClientHandler();
-            handler.ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true;
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
             _client = new HttpClient(handler);
             return Task.CompletedTask;

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -60,7 +60,7 @@ namespace GrpcAspNetCoreServer
                 {
                     loggerFactory.ClearProviders();
 
-                    if (Enum.TryParse(config["LogLevel"], out LogLevel logLevel))
+                    if (Enum.TryParse<LogLevel>(config["LogLevel"], out var logLevel))
                     {
                         Console.WriteLine($"Console Logging enabled with level '{logLevel}'");
                         loggerFactory.AddConsole().SetMinimumLevel(logLevel);

--- a/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
+++ b/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
@@ -34,7 +34,7 @@ class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
         await foreach (var item in requestStream.ReadAllAsync())
         {
             await responseStream.WriteAsync(CreateResponse(item));
-        };
+        }
     }
 
     public override async Task StreamingFromServer(SimpleRequest request, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)

--- a/testassets/InteropTestsClient/InteropClient.cs
+++ b/testassets/InteropTestsClient/InteropClient.cs
@@ -154,7 +154,7 @@ namespace InteropTestsClient
             }
 
             var httpClientHandler = new HttpClientHandler();
-            httpClientHandler.ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true;
+            httpClientHandler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
             if (options.UseTestCa ?? false)
             {


### PR DESCRIPTION
Makes it more obvious that not validating certs is not good for production systems.