### PR TITLE
Improve error when missing trailer feature, unit test

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -188,7 +188,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 var feature = response.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
                 if (feature?.Trailers == null || feature.Trailers.IsReadOnly)
                 {
-                    throw new InvalidOperationException("Trailers are not supported for this response.");
+                    throw new InvalidOperationException("Trailers are not supported for this response. The server may not support gRPC.");
                 }
 
                 return feature.Trailers;

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -27,6 +27,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.AspNetCore.Server.Internal;
+using Grpc.AspNetCore.Server.Tests.Infrastructure;
 using Grpc.Core;
 using Grpc.Tests.Shared;
 using Microsoft.AspNetCore.Http;
@@ -293,11 +294,6 @@ namespace Grpc.AspNetCore.Server.Tests
             Assert.AreEqual(2, responseTrailers.Count);
             Assert.AreEqual(StatusCode.OK.ToString("D"), responseTrailers[GrpcProtocolConstants.StatusTrailer]);
             Assert.AreEqual(Convert.ToBase64String(trailerBytes), responseTrailers["trailer-bin"]);
-        }
-
-        private class TestHttpResponseTrailersFeature : IHttpResponseTrailersFeature
-        {
-            public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
         }
 
         private class TestHttpResponseFeature : HttpResponseFeature

--- a/test/Grpc.AspNetCore.Server.Tests/Infrastructure/TestHttpResponseTrailersFeature.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/Infrastructure/TestHttpResponseTrailersFeature.cs
@@ -1,0 +1,28 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Grpc.AspNetCore.Server.Tests.Infrastructure
+{
+    public class TestHttpResponseTrailersFeature : IHttpResponseTrailersFeature
+    {
+        public IHeaderDictionary Trailers { get; set; } = new HeaderDictionary();
+    }
+}


### PR DESCRIPTION
Related to https://github.com/grpc/grpc-dotnet/issues/526#issuecomment-533272271

IIS will get passed HTTP/2 request, it is the lack of response trailers feature that will result in an error. Make error message guide users in that direction.