### PR TITLE
Fix benchmarks by writing to console on application start

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -19,6 +19,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using Common;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
@@ -29,6 +30,18 @@ using Microsoft.Extensions.Logging;
 
 namespace GrpcAspNetCoreServer
 {
+    public class sdfsf : IHostApplicationLifetime
+    {
+        public CancellationToken ApplicationStarted { get; }
+        public CancellationToken ApplicationStopped { get; }
+        public CancellationToken ApplicationStopping { get; }
+
+        public void StopApplication()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public class Program
     {
         public static void Main(string[] args)
@@ -86,6 +99,10 @@ namespace GrpcAspNetCoreServer
                             }
                         });
                     });
+                })
+                .ConfigureServices(services =>
+                {
+
                 })
                 .ConfigureLogging(loggerFactory =>
                 {

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -19,7 +19,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Threading;
 using Common;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
@@ -30,18 +29,6 @@ using Microsoft.Extensions.Logging;
 
 namespace GrpcAspNetCoreServer
 {
-    public class sdfsf : IHostApplicationLifetime
-    {
-        public CancellationToken ApplicationStarted { get; }
-        public CancellationToken ApplicationStopped { get; }
-        public CancellationToken ApplicationStopping { get; }
-
-        public void StopApplication()
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     public class Program
     {
         public static void Main(string[] args)
@@ -99,10 +86,6 @@ namespace GrpcAspNetCoreServer
                             }
                         });
                     });
-                })
-                .ConfigureServices(services =>
-                {
-
                 })
                 .ConfigureLogging(loggerFactory =>
                 {

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
@@ -16,12 +16,14 @@
 
 #endregion
 
+using System;
 using System.IO;
 using System.Text;
 using Grpc.Testing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 
 namespace GrpcAspNetCoreServer
@@ -34,8 +36,11 @@ namespace GrpcAspNetCoreServer
             services.AddControllers();
         }
 
-        public void Configure(IApplicationBuilder app)
+        public void Configure(IApplicationBuilder app, IHostApplicationLifetime applicationLifetime)
         {
+            // Required to notify performance infrastructure that it can begin benchmarks
+            applicationLifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started."));
+
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
Previously the web host automatically wrote this to the console. Need to write it manually with generic host.