### PR TITLE
Channel internal HttpClient created with no timeout

### DIFF
--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -43,6 +43,16 @@ namespace Grpc.Net.Client.Tests
         }
 
         [Test]
+        public void Build_NoHttpClient_InternalHttpClientHasInfiniteTimeout()
+        {
+            // Arrange & Act
+            var channel = GrpcChannel.ForAddress("https://localhost");
+
+            // Assert
+            Assert.AreEqual(Timeout.InfiniteTimeSpan, channel.HttpClient.Timeout);
+        }
+
+        [Test]
         public void Build_SslCredentialsWithHttp_ThrowsError()
         {
             // Arrange & Act

--- a/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -43,6 +43,27 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
     public class DefaultGrpcClientFactoryTests
     {
         [Test]
+        public void CreateClient_Default_InternalHttpClientHasInfiniteTimeout()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services
+                .AddGrpcClient<TestGreeterClient>(o => o.Address = new Uri("http://localhost"));
+
+            var serviceProvider = services.BuildServiceProvider(validateScopes: true);
+
+            var clientFactory = new DefaultGrpcClientFactory(
+                serviceProvider,
+                serviceProvider.GetRequiredService<IHttpClientFactory>());
+
+            // Act
+            var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
+
+            // Assert
+            Assert.AreEqual(Timeout.InfiniteTimeSpan, client.CallInvoker.Channel.HttpClient.Timeout);
+        }
+
+        [Test]
         public void CreateClient_MatchingConfigurationBasedOnTypeName_ReturnConfiguration()
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/593