### PR TITLE
Implement GetBufferWriter() via ArrayBufferWriter<byte> (#609)

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
     <GoogleProtobufPackageVersion>3.10.0</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.23.2</GrpcDotNetPackageVersion>
-    <GrpcPackageVersion>2.23.0</GrpcPackageVersion>
+    <GrpcPackageVersion>2.24.0</GrpcPackageVersion>
     <MicrosoftAspNetCorePackageVersion>3.0.0-preview8.19405.7</MicrosoftAspNetCorePackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -59,12 +59,13 @@ namespace Grpc.AspNetCore.Server.Internal
                 GrpcServerLog.SendingMessage(logger);
 
                 var serializationContext = serverCallContext.SerializationContext;
+                serializationContext.Reset();
                 serializer(response, serializationContext);
-
-                if (!serializationContext.TryConsumePayload(out var responsePayload))
+                if (!serializationContext.TryGetPayload(out var responsePayload))
                 {
                     throw new InvalidOperationException("Serialization did not return a payload.");
                 }
+
                 GrpcServerLog.SerializedMessage(serverCallContext.Logger, typeof(TResponse), responsePayload.Length);
 
                 // Must call StartAsync before the first pipeWriter.GetSpan() in WriteHeader

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -228,9 +228,7 @@ namespace Grpc.Net.Client
                 // Serialize message first. Need to know size to prefix the length in the header
                 var serializationContext = new DefaultSerializationContext();
                 serializer(message, serializationContext);
-                var data = serializationContext.Payload;
-
-                if (data == null)
+                if (!serializationContext.TryConsumePayload(out var data))
                 {
                     throw new InvalidOperationException("Serialization did not return a payload.");
                 }
@@ -269,7 +267,7 @@ namespace Grpc.Net.Client
             }
         }
 
-        private static byte[] CompressMessage(ILogger logger, string compressionEncoding, CompressionLevel? compressionLevel, Dictionary<string, ICompressionProvider> compressionProviders, byte[] messageData)
+        private static byte[] CompressMessage(ILogger logger, string compressionEncoding, CompressionLevel? compressionLevel, Dictionary<string, ICompressionProvider> compressionProviders, ReadOnlyMemory<byte> messageData)
         {
             if (compressionProviders.TryGetValue(compressionEncoding, out var compressionProvider))
             {
@@ -278,7 +276,7 @@ namespace Grpc.Net.Client
                 var output = new MemoryStream();
                 using (var compressionStream = compressionProvider.CreateCompressionStream(output, compressionLevel))
                 {
-                    compressionStream.Write(messageData, 0, messageData.Length);
+                    compressionStream.Write(messageData.Span);
                 }
 
                 return output.ToArray();

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -227,8 +227,9 @@ namespace Grpc.Net.Client
 
                 // Serialize message first. Need to know size to prefix the length in the header
                 var serializationContext = new DefaultSerializationContext();
+                serializationContext.Reset();
                 serializer(message, serializationContext);
-                if (!serializationContext.TryConsumePayload(out var data))
+                if (!serializationContext.TryGetPayload(out var data))
                 {
                     throw new InvalidOperationException("Serialization did not return a payload.");
                 }


### PR DESCRIPTION
Addresses #609 

This changes `DefaultSerializationContext` to (internally) allow an array, or an `IBufferWriter<byte>`. A new `enum` is introduced to avoid confusion over the internal state.

The `IBufferWriter<byte>` is lazily implemented using `ArrayBufferWriter<byte>` the first time (if ever) it is requested, and is then reset and reused for subsequent operations (this means the internal buffer in `ArrayBufferWriter<byte>` can be reused).

The consumption API is changed from `byte[]` to `ReadOnlyMemory<byte>`. In most places this makes no change as the `byte[]` was already being cast to `ReadOnlyMemory<byte>`. A question should be asked, however, about what `GZipStream` (the only compression-stream I could find) does in the `byte[]/int/int` vs `ReadOnlySpan<byte>` use-cases; does it add a copy, or does `GZipStream` directly consume the span? (I will try to investigate). If it (`GZipStream`) does *not* do the right thing, then we might prefer to use `ArraySegment<byte>`, but unfortunately `ArrayBufferWriter<byte>` does not directly expose this (maybe it should?)

I considered - and dismissed - the idea of using a single `object` field that was *either* the array *or* the writer, but this would prohibit full buffer-writer re-use, as every time an array is involved, we'd lose the writer. Having separate fields avoids this. Given the mandated minimum object size, in practice the extra field is free.

Edit: update, [`GZipStream` does "the right thing", so this should not present any issue](https://github.com/dotnet/corefx/blob/967eb3c5cb5fd36c8bb56d06f4c840f6a7a5a754/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs#L115-L129)


Edit: one additional question might be: should we `Reset()` *after* fully consuming the payload? (currently it resets *before* asking the *next* payload to serialize). The difference is simply: if a `byte[]` is provided, when does it become collectable? We should not `Reset()` before we have finished with all the writes, however. I suspect we'd be *fine*, but ***in theory*** `ArrayBufferWriter<byte>` could hypothetically and legitimately do things like give the memory to the array-pool when `Clear()` is called.

---

Tests are added, but doing so uncovered a second problem (doubly-compiled types, i.e. same full-name in two different assemblies). I have proposed a fix in #612