### PR TITLE
Update microbenchmarks to use server GC

### DIFF
--- a/perf/Grpc.AspNetCore.Microbenchmarks/DefaultCoreConfig.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/DefaultCoreConfig.cs
@@ -43,7 +43,6 @@ namespace Grpc.AspNetCore.Microbenchmarks
 
             Add(JitOptimizationsValidator.FailOnError);
 
-            // TODO(JamesNK): Change to out of process and enable server GC when https://github.com/dotnet/BenchmarkDotNet/issues/1023 is fixed
             Add(Job.Core
                 .With(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp3.0", null, ".NET Core 3.0")))
                 .With(new GcMode { Server = true })

--- a/perf/Grpc.AspNetCore.Microbenchmarks/DefaultCoreConfig.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/DefaultCoreConfig.cs
@@ -46,7 +46,7 @@ namespace Grpc.AspNetCore.Microbenchmarks
             // TODO(JamesNK): Change to out of process and enable server GC when https://github.com/dotnet/BenchmarkDotNet/issues/1023 is fixed
             Add(Job.Core
                 .With(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp3.0", null, ".NET Core 3.0")))
-                .With(InProcessToolchain.Instance)
+                .With(new GcMode { Server = true })
                 .With(RunStrategy.Throughput));
         }
     }


### PR DESCRIPTION
React to https://github.com/dotnet/BenchmarkDotNet/issues/1023 being fixed.