### PR TITLE
Add healthchecks example

### DIFF
--- a/Grpc.DotNet.sln
+++ b/Grpc.DotNet.sln
@@ -108,6 +108,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrpcAspNetCoreServer", "per
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrpcCoreServer", "perf\benchmarkapps\GrpcCoreServer\GrpcCoreServer.csproj", "{781111FC-8F3C-433E-BC96-D88ADAEE3064}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.HealthChecks", "src\Grpc.AspNetCore.HealthChecks\Grpc.AspNetCore.HealthChecks.csproj", "{E46446FE-2B93-4F42-84C8-A4D09B48B173}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -206,6 +208,10 @@ Global
 		{781111FC-8F3C-433E-BC96-D88ADAEE3064}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{781111FC-8F3C-433E-BC96-D88ADAEE3064}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{781111FC-8F3C-433E-BC96-D88ADAEE3064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E46446FE-2B93-4F42-84C8-A4D09B48B173}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E46446FE-2B93-4F42-84C8-A4D09B48B173}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E46446FE-2B93-4F42-84C8-A4D09B48B173}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E46446FE-2B93-4F42-84C8-A4D09B48B173}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -243,6 +249,7 @@ Global
 		{69C50655-71EE-4E69-BC2C-ABCA568F6E76} = {8C62055F-8CD7-4859-9001-634D544DF2AE}
 		{1D9AB69D-244C-4871-867E-DCEC52B552A4} = {1B8B6117-CE39-4580-BAFA-D8026102767A}
 		{781111FC-8F3C-433E-BC96-D88ADAEE3064} = {1B8B6117-CE39-4580-BAFA-D8026102767A}
+		{E46446FE-2B93-4F42-84C8-A4D09B48B173} = {8C62055F-8CD7-4859-9001-634D544DF2AE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD5C2B19-49B4-480A-990C-36D98A719B07}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
     <GoogleProtobufPackageVersion>3.10.0</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.25.0</GrpcDotNetPackageVersion>  <!-- Only use for example projects -->
-    <GrpcPackageVersion>2.25.0</GrpcPackageVersion>
+    <GrpcPackageVersion>2.27.0-dev201912051123</GrpcPackageVersion>
     <MicrosoftAspNetCorePackageVersion>3.0.0</MicrosoftAspNetCorePackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>

--- a/examples/README.md
+++ b/examples/README.md
@@ -136,3 +136,13 @@ The progressor shows how to use server streaming to notify the caller about prog
 
 * Server streaming
 * Using [`Progress<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.progress-1) to notify progress on the client
+
+## [Vigor](./Vigor)
+
+The vigor example shows how to integrate [ASP.NET Core health checks](https://docs.microsoft.com/aspnet/core/host-and-deploy/health-checks) with the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) service, and call its methods from a client.
+
+##### Scenarios:
+
+* Hosting gRPC Health Checking Protocol service
+* Integrate [ASP.NET Core health checks](https://docs.microsoft.com/aspnet/core/host-and-deploy/health-checks) with gRPC health checks
+* Calling service with `Grpc.HealthCheck` client

--- a/examples/Vigor/Client/Client.csproj
+++ b/examples/Vigor/Client/Client.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.HealthCheck" Version="$(GrpcPackageVersion)" />
+
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/examples/Vigor/Client/Program.cs
+++ b/examples/Vigor/Client/Program.cs
@@ -1,0 +1,62 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Health.V1;
+using Grpc.Net.Client;
+
+namespace Client
+{
+    public class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var channel = GrpcChannel.ForAddress("https://localhost:5001");
+            var client = new Health.HealthClient(channel);
+
+            Console.WriteLine("Watching health status");
+            Console.WriteLine("Press any key to exit...");
+
+            var cts = new CancellationTokenSource();
+            var call = client.Watch(new HealthCheckRequest { Service = "" }, cancellationToken: cts.Token);
+            var watchTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var message in call.ResponseStream.ReadAllAsync())
+                    {
+                        Console.WriteLine($"{DateTime.Now}: Service is {message.Status}");
+                    }
+                }
+                catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
+                {
+                    // Handle cancellation exception.
+                }
+            });
+
+            Console.ReadKey();
+            Console.WriteLine("Finished");
+
+            cts.Cancel();
+            await watchTask;
+        }
+    }
+}

--- a/examples/Vigor/Server/Program.cs
+++ b/examples/Vigor/Server/Program.cs
@@ -1,0 +1,38 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Server
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/examples/Vigor/Server/Properties/launchSettings.json
+++ b/examples/Vigor/Server/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "profiles": {
+    "Server": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/examples/Vigor/Server/Server.csproj
+++ b/examples/Vigor/Server/Server.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- TODO(JamesNK): Reference Grpc.AspNetCore.HealthChecks package when it is available on NuGet -->
+    <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.HealthChecks\Grpc.AspNetCore.HealthChecks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Vigor/Server/Server.csproj
+++ b/examples/Vigor/Server/Server.csproj
@@ -5,12 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!-- TODO(JamesNK): Reference Grpc.AspNetCore.HealthChecks package when it is available on NuGet -->
     <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.HealthChecks\Grpc.AspNetCore.HealthChecks.csproj" />
+    <ProjectReference Include="..\..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/Vigor/Server/Startup.cs
+++ b/examples/Vigor/Server/Startup.cs
@@ -1,0 +1,61 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+
+namespace Server
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddGrpc();
+            services.AddGrpcHealthChecks()
+                .AddAsyncCheck("", () =>
+                {
+                    var r = new Random();
+                    var result = r.Next() % 5 == 0
+                        ? HealthCheckResult.Unhealthy()
+                        : HealthCheckResult.Healthy();
+
+                    return Task.FromResult(result);
+                }, Array.Empty<string>());
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGrpcHealthChecksService();
+            });
+        }
+    }
+}

--- a/examples/Vigor/Server/appsettings.Development.json
+++ b/examples/Vigor/Server/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Grpc": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/examples/Vigor/Server/appsettings.json
+++ b/examples/Vigor/Server/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}

--- a/examples/Vigor/Vigor.sln
+++ b/examples/Vigor/Vigor.sln
@@ -1,0 +1,49 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29230.61
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.HealthChecks", "..\..\src\Grpc.AspNetCore.HealthChecks\Grpc.AspNetCore.HealthChecks.csproj", "{C40E1DEA-07D6-4F68-82BD-98BA124E2446}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.Server", "..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj", "{CC5AEB7C-37B5-40BC-ADC9-A2F535745E91}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.Net.Common", "..\..\src\Grpc.Net.Common\Grpc.Net.Common.csproj", "{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C40E1DEA-07D6-4F68-82BD-98BA124E2446}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C40E1DEA-07D6-4F68-82BD-98BA124E2446}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C40E1DEA-07D6-4F68-82BD-98BA124E2446}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C40E1DEA-07D6-4F68-82BD-98BA124E2446}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC5AEB7C-37B5-40BC-ADC9-A2F535745E91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC5AEB7C-37B5-40BC-ADC9-A2F535745E91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC5AEB7C-37B5-40BC-ADC9-A2F535745E91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC5AEB7C-37B5-40BC-ADC9-A2F535745E91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D22B3129-3BFB-41FA-9FCE-E45EBEF8C2DD}
+	EndGlobalSection
+EndGlobal

--- a/examples/Vigor/Vigor.sln
+++ b/examples/Vigor/Vigor.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.Server", ".
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.Net.Common", "..\..\src\Grpc.Net.Common\Grpc.Net.Common.csproj", "{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore", "..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj", "{5D3C6AD6-B76F-44C3-A616-3FBE238D4EF6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{479F5D6C-E76C-4696-A75E-ACE6EAFB9B75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D3C6AD6-B76F-44C3-A616-3FBE238D4EF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D3C6AD6-B76F-44C3-A616-3FBE238D4EF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D3C6AD6-B76F-44C3-A616-3FBE238D4EF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D3C6AD6-B76F-44C3-A616-3FBE238D4EF6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/Worker/Server/Server.csproj
+++ b/examples/Worker/Server/Server.csproj
@@ -9,6 +9,9 @@
 
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensions30PackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
+
+    <!-- This is required to avoid a build server error when using a preview version of Grpc.Tools -->
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
+++ b/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Integration of ASP.NET Core health checks with Grpc.HealthCheck</Description>
+    <PackageTags>gRPC RPC HTTP/2 health check</PackageTags>
+
+    <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <!-- Disable analysis for ConfigureAwait(false) -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+
+    <DefineConstants>$(DefineConstants);GRPC_SUPPORT_WATCH;</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    
+    <PackageReference Include="Grpc.HealthCheck" Version="$(GrpcPackageVersion)" />
+
+    <ProjectReference Include="..\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
+++ b/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
@@ -11,8 +11,6 @@
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>
     <NoWarn>$(NoWarn);CA2007</NoWarn>
-
-    <DefineConstants>$(DefineConstants);GRPC_SUPPORT_WATCH;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksEndpointRouteBuilderExtensions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,46 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.HealthCheck;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to add gRPC service endpoints.
+    /// </summary>
+    public static class GrpcHealthChecksEndpointRouteBuilderExtensions
+    {
+        /// <summary>
+        /// Maps incoming requests to the gRPC health checks service.
+        /// This service can be queried to discover the health of the server.
+        /// </summary>
+        /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <returns>An <see cref="GrpcServiceEndpointConventionBuilder"/> for endpoints associated with the service.</returns>
+        public static GrpcServiceEndpointConventionBuilder MapGrpcHealthChecksService(this IEndpointRouteBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.MapGrpcService<HealthServiceImpl>();
+        }
+    }
+}

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
@@ -1,0 +1,56 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Health.V1;
+using Grpc.HealthCheck;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Grpc.AspNetCore.HealthChecks
+{
+    internal class GrpcHealthChecksPublisher : IHealthCheckPublisher
+    {
+        private readonly HealthServiceImpl _healthService;
+
+        public GrpcHealthChecksPublisher(HealthServiceImpl healthService)
+        {
+            _healthService = healthService;
+        }
+
+        public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+        {
+            foreach (var entry in report.Entries)
+            {
+                var status = entry.Value.Status;
+
+                _healthService.SetStatus(entry.Key, ResolveStatus(status));
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static HealthCheckResponse.Types.ServingStatus ResolveStatus(HealthStatus status)
+        {
+            return status == HealthStatus.Unhealthy
+                ? HealthCheckResponse.Types.ServingStatus.NotServing
+                : HealthCheckResponse.Types.ServingStatus.Serving;
+        }
+    }
+
+}

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksServiceExtensions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksServiceExtensions.cs
@@ -1,0 +1,52 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.AspNetCore.HealthChecks;
+using Grpc.HealthCheck;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for the gRPC health checks services.
+    /// </summary>
+    public static class GrpcHealthChecksServiceExtensions
+    {
+        /// <summary>
+        /// Adds gRPC health check services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> for adding services.</param>
+        /// <returns>An instance of <see cref="IHealthChecksBuilder"/> from which health checks can be registered.</returns>
+        public static IHealthChecksBuilder AddGrpcHealthChecks(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            // HealthServiceImpl is designed to be a singleton
+            services.TryAddSingleton<HealthServiceImpl>();
+
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthCheckPublisher, GrpcHealthChecksPublisher>());
+
+            return services.AddHealthChecks();
+        }
+    }
+}

--- a/src/Grpc.AspNetCore.HealthChecks/Properties/AssemblyInfo.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Properties/AssemblyInfo.cs
@@ -1,0 +1,25 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Grpc.AspNetCore.Server.Tests,PublicKey=" +
+    "00240000048000009400000006020000002400005253413100040000010001002f5797a92c6fcde81bd4098f43" +
+    "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
+    "27fc95aff3dc604a6971417453f9483c7b5e836756d5b271bf8f2403fe186e31956148c03d804487cf642f8cc0" +
+    "71394ee9672dfe5b55ea0f95dfd5a7f77d22c962ccf51320d3")]

--- a/src/Grpc.AspNetCore.HealthChecks/README.md
+++ b/src/Grpc.AspNetCore.HealthChecks/README.md
@@ -1,0 +1,5 @@
+# Experimental project
+
+Grpc.AspNetCore.HealthChecks provides integration between [Health checks in ASP.NET Core](https://docs.microsoft.com/aspnet/core/host-and-deploy/health-checks) and the [Grpc.HealthCheck package](https://www.nuget.org/packages/Grpc.HealthCheck).
+
+This project is currently not published, but you can copy the code to use in your own applications. If a published package of Grpc.AspNetCore.HealthChecks would be useful for you, please give feedback at https://github.com/grpc/grpc-dotnet/issues

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -18,6 +18,7 @@
     <Compile Include="..\Shared\ResponseUtils.cs" Link="Infrastructure\ResponseUtils.cs" />
     <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
     <Compile Include="..\Shared\TestHttpMessageHandler.cs" Link="Infrastructure\TestHttpMessageHandler.cs" />
+    <Compile Include="..\Shared\TestServerCallContext.cs" Link="Infrastructure\TestServerCallContext.cs" />
 
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />
 

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -23,12 +23,14 @@
     <Compile Include="..\Shared\TestHttpContextAccessor.cs" Link="Infrastructure\TestHttpContextAccessor.cs" />
     <Compile Include="..\Shared\TestRequestBodyPipeFeature.cs" Link="Infrastructure\TestRequestBodyPipeFeature.cs" />
     <Compile Include="..\Shared\TestResponseBodyFeature.cs" Link="Infrastructure\TestResponseBodyFeature.cs" />
+    <Compile Include="..\Shared\TestServerCallContext.cs" Link="Infrastructure\TestServerCallContext.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Grpc.AspNetCore.HealthChecks\Grpc.AspNetCore.HealthChecks.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.Reflection\Grpc.AspNetCore.Server.Reflection.csproj" />
 
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsPackageVersion)" />

--- a/test/Grpc.AspNetCore.Server.Tests/HealthChecks/GrpcHealthChecksPublisherTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HealthChecks/GrpcHealthChecksPublisherTests.cs
@@ -1,0 +1,163 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.HealthChecks;
+using Grpc.AspNetCore.Server.Tests.Infrastructure;
+using Grpc.Core;
+using Grpc.Health.V1;
+using Grpc.HealthCheck;
+using Grpc.Tests.Shared;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.Server.Tests.Reflection
+{
+    [TestFixture]
+    public class GrpcHealthChecksPublisherTests
+    {
+        [Test]
+        public async Task PublishAsync_Check_ChangingStatus()
+        {
+            // Arrange
+            var healthService = new HealthServiceImpl();
+            var publisher = new GrpcHealthChecksPublisher(healthService);
+
+            HealthCheckResponse response;
+
+            // Act 1
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => healthService.Check(new HealthCheckRequest { Service = "" }, context: null));
+
+            // Assert 1
+            Assert.AreEqual(StatusCode.NotFound, ex.StatusCode);
+
+            // Act 2
+            var report = CreateSimpleHealthReport(HealthStatus.Healthy);
+            await publisher.PublishAsync(report, CancellationToken.None);
+
+            response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null);
+
+            // Assert 2
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
+
+            // Act 3
+            report = CreateSimpleHealthReport(HealthStatus.Unhealthy);
+            await publisher.PublishAsync(report, CancellationToken.None);
+
+            response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null);
+
+            // Act 3
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.NotServing, response.Status);
+        }
+
+        private static HealthReport CreateSimpleHealthReport(HealthStatus healthStatus)
+        {
+            return new HealthReport(
+                new Dictionary<string, HealthReportEntry>
+                {
+                    [""] = new HealthReportEntry(healthStatus, "Description!", TimeSpan.Zero, exception: null, data: null)
+                },
+                TimeSpan.Zero);
+        }
+
+        [Test]
+        public async Task PublishAsync_Check_MapStatuses()
+        {
+            // Arrange
+            var healthService = new HealthServiceImpl();
+            var publisher = new GrpcHealthChecksPublisher(healthService);
+
+            // Act
+            HealthCheckResponse response;
+
+            var report = new HealthReport(
+                new Dictionary<string, HealthReportEntry>
+                {
+                    [nameof(HealthStatus.Healthy)] = new HealthReportEntry(HealthStatus.Healthy, "Description!", TimeSpan.Zero, exception: null, data: null),
+                    [nameof(HealthStatus.Degraded)] = new HealthReportEntry(HealthStatus.Degraded, "Description!", TimeSpan.Zero, exception: null, data: null),
+                    [nameof(HealthStatus.Unhealthy)] = new HealthReportEntry(HealthStatus.Unhealthy, "Description!", TimeSpan.Zero, exception: null, data: null)
+                },
+                TimeSpan.Zero);
+            await publisher.PublishAsync(report, CancellationToken.None);
+
+            // Assert
+            response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Healthy) }, context: null);
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
+
+            response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Degraded) }, context: null);
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
+
+            response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Unhealthy) }, context: null);
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.NotServing, response.Status);
+        }
+
+        [Test]
+        public async Task PublishAsync_Watch_ChangingStatus()
+        {
+            // Arrange
+            var healthService = new HealthServiceImpl();
+            var publisher = new GrpcHealthChecksPublisher(healthService);
+            var responseStream = new TestServerStreamWriter<HealthCheckResponse>();
+            var cts = new CancellationTokenSource();
+            var serverCallContext = new TestServerCallContext(DateTime.MinValue, cts.Token);
+
+            // Act 1
+            var call = healthService.Watch(new HealthCheckRequest { Service = "" }, responseStream, serverCallContext);
+
+            // Assert 1
+            await TestHelpers.AssertIsTrueRetryAsync(() => responseStream.Responses.Count == 1, "Unexpected response count.");
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.ServiceUnknown, responseStream.Responses.Last().Status);
+
+            // Act 2
+            await publisher.PublishAsync(CreateSimpleHealthReport(HealthStatus.Healthy), CancellationToken.None);
+
+            // Assert 2
+            await TestHelpers.AssertIsTrueRetryAsync(() => responseStream.Responses.Count == 2, "Unexpected response count.");
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, responseStream.Responses.Last().Status);
+
+            // Act 3
+            await publisher.PublishAsync(CreateSimpleHealthReport(HealthStatus.Degraded), CancellationToken.None);
+
+            // Act 3
+            await TestHelpers.AssertIsTrueRetryAsync(() => responseStream.Responses.Count == 2, "Unexpected response count.");
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, responseStream.Responses.Last().Status);
+
+            // Act 4
+            await publisher.PublishAsync(CreateSimpleHealthReport(HealthStatus.Unhealthy), CancellationToken.None);
+
+            // Act 4
+            await TestHelpers.AssertIsTrueRetryAsync(() => responseStream.Responses.Count == 3, "Unexpected response count.");
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.NotServing, responseStream.Responses.Last().Status);
+
+            // End call
+            cts.Cancel();
+            await call.DefaultTimeout();
+
+            // Act 4
+            await publisher.PublishAsync(CreateSimpleHealthReport(HealthStatus.Healthy), CancellationToken.None);
+
+            // Act 4
+            await TestHelpers.AssertIsTrueRetryAsync(() => responseStream.Responses.Count == 3, "Unexpected response count.");
+            Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.NotServing, responseStream.Responses.Last().Status);
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/Infrastructure/TestServerStreamWriter.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/Infrastructure/TestServerStreamWriter.cs
@@ -1,0 +1,36 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Grpc.AspNetCore.Server.Tests.Infrastructure
+{
+    public class TestServerStreamWriter<T> : IServerStreamWriter<T>
+    {
+        public WriteOptions? WriteOptions { get; set; }
+        public List<T> Responses { get; } = new List<T>();
+
+        public Task WriteAsync(T message)
+        {
+            Responses.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/Reflection/ReflectionGrpcServiceActivatorTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/Reflection/ReflectionGrpcServiceActivatorTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Greet;
+using Grpc.AspNetCore.Server.Tests.Infrastructure;
 using Grpc.Core;
 using Grpc.Reflection;
 using Grpc.Reflection.V1Alpha;
@@ -67,7 +68,7 @@ namespace Grpc.AspNetCore.Server.Tests.Reflection
                     ListServices = "" // list all services
                 }
             };
-            var writer = new TestServerStreamWriter();
+            var writer = new TestServerStreamWriter<ServerReflectionResponse>();
             var context = HttpContextServerCallContextHelper.CreateServerCallContext();
 
             await service.ServerReflectionInfo(reader, writer, context);
@@ -82,18 +83,6 @@ namespace Grpc.AspNetCore.Server.Tests.Reflection
 
         private class GreeterService : Greeter.GreeterBase
         {
-        }
-
-        private class TestServerStreamWriter : IServerStreamWriter<ServerReflectionResponse>
-        {
-            public WriteOptions? WriteOptions { get; set; }
-            public List<ServerReflectionResponse> Responses { get; } = new List<ServerReflectionResponse>();
-
-            public Task WriteAsync(ServerReflectionResponse message)
-            {
-                Responses.Add(message);
-                return Task.CompletedTask;
-            }
         }
 
         private class TestAsyncStreamReader : IAsyncStreamReader<ServerReflectionRequest>

--- a/test/Shared/TestServerCallContext.cs
+++ b/test/Shared/TestServerCallContext.cs
@@ -21,7 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 
-namespace Grpc.AspNetCore.Server.ClientFactory.Tests.TestObjects
+namespace Grpc.Tests.Shared
 {
     public class TestServerCallContext : ServerCallContext
     {


### PR DESCRIPTION
Healthchecks package and example.

- ~Currently has a copy of health implementation. Will replace with Grpc.Healthchecks package reference when https://github.com/grpc/grpc/pull/21120 is merged and available~
- ~Health status is set manually. TODO: integration with ASP.NET Core healthchecks~