### PR TITLE
Test functional tests with TestServer

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <GoogleProtobufPackageVersion>3.11.2</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.27.0-pre1</GrpcDotNetPackageVersion>  <!-- Only use for example projects -->
     <GrpcPackageVersion>2.27.0-pre1</GrpcPackageVersion>
-    <MicrosoftAspNetCorePackageVersion>3.0.0</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftAspNetCorePackageVersion>3.1.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreBlazorPackageVersion>3.2.0-preview1.20073.1</MicrosoftAspNetCoreBlazorPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>

--- a/examples/Aggregator/Client/Client.csproj
+++ b/examples/Aggregator/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Aggregator/Server/Server.csproj
+++ b/examples/Aggregator/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Browser/Server/Server.csproj
+++ b/examples/Browser/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <SpaRoot>wwwroot\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**;$(SpaRoot)dist\**</DefaultItemExcludes>
   </PropertyGroup>

--- a/examples/Certifier/Client/Client.csproj
+++ b/examples/Certifier/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Certifier/Server/Server.csproj
+++ b/examples/Certifier/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Counter/Client/Client.csproj
+++ b/examples/Counter/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Counter/Server/Server.csproj
+++ b/examples/Counter/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Greeter/Client/Client.csproj
+++ b/examples/Greeter/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Greeter/Server/Server.csproj
+++ b/examples/Greeter/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Logger/Client/Client.csproj
+++ b/examples/Logger/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Logger/Server/Server.csproj
+++ b/examples/Logger/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Mailer/Client/Client.csproj
+++ b/examples/Mailer/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Mailer/Server/Server.csproj
+++ b/examples/Mailer/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Progressor/Client/Client.csproj
+++ b/examples/Progressor/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Progressor/Server/Server.csproj
+++ b/examples/Progressor/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/README.md
+++ b/examples/README.md
@@ -119,9 +119,7 @@ dotnet run --EnableOpenTelemetry=true
 
 ## [Tester](./Tester)
 
-The tester shows how to test gRPC services. The unit tests create and test a gRPC service directly. The functional tests show how to use [Microsoft.AspNetCore.TestHost](https://www.nuget.org/packages/Microsoft.AspNetCore.TestHost/) to host a gRPC service with an in-memory test server and call it using a gRPC client. The functional tests write client and server logs to the test output.
-
-> **NOTE:** There is a known issue in ASP.NET Core 3.0 that prevents functional testing of bidirectional gRPC methods. Bidirectional gRPC methods can still be unit tested.
+The tester shows how to test gRPC services. The unit tests create and test a gRPC service directly. The functional tests show how to use [Microsoft.AspNetCore.TestHost](https://www.nuget.org/packages/Microsoft.AspNetCore.TestHost/) (version 3.1.2 or greater required) to host a gRPC service with an in-memory test server and call it using a gRPC client. The functional tests write client and server logs to the test output.
 
 ##### Scenarios:
 

--- a/examples/Racer/Client/Client.csproj
+++ b/examples/Racer/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Racer/Server/Server.csproj
+++ b/examples/Racer/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Reflector/Client/Client.csproj
+++ b/examples/Reflector/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Reflector/Server/Server.csproj
+++ b/examples/Reflector/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Tester/Server/Server.csproj
+++ b/examples/Tester/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Tester/Tests/FunctionalTests/GreeterServiceTests.cs
+++ b/examples/Tester/Tests/FunctionalTests/GreeterServiceTests.cs
@@ -99,7 +99,6 @@ namespace Tests.FunctionalTests
         }
 
         [Test]
-        [Ignore("Bidirectional streaming is currently not supported in TestServer: https://github.com/aspnet/AspNetCore/pull/15591")]
         public async Task SayHelloBidirectionStreamingTest()
         {
             // Arrange
@@ -123,7 +122,7 @@ namespace Tests.FunctionalTests
             }
 
             // Assert
-            Assert.AreEqual(1, messages.Count);
+            Assert.AreEqual(3, messages.Count);
             Assert.AreEqual("Hello James", messages[0]);
         }
     }

--- a/examples/Tester/Tests/Tests.csproj
+++ b/examples/Tester/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Ticketer/Client/Client.csproj
+++ b/examples/Ticketer/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Ticketer/Server/Server.csproj
+++ b/examples/Ticketer/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Vigor/Client/Client.csproj
+++ b/examples/Vigor/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Vigor/Server/Server.csproj
+++ b/examples/Vigor/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Worker/Client/Client.csproj
+++ b/examples/Worker/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>dotnet-Client-33BD397C-6A11-40D0-AF85-24B9610F7517</UserSecretsId>
   </PropertyGroup>
 

--- a/examples/Worker/Server/Server.csproj
+++ b/examples/Worker/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/perf/benchmarkapps/BenchmarkClient/BenchmarkClient.csproj
+++ b/perf/benchmarkapps/BenchmarkClient/BenchmarkClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>
 

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Uncomment line below to enable gRPC-Web on the server -->

--- a/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/test/FunctionalTests/TestServer/FunctionalTestBase.cs
+++ b/test/FunctionalTests/TestServer/FunctionalTestBase.cs
@@ -1,0 +1,78 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using FunctionalTestsWebsite;
+using Grpc.Net.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Tests.FunctionalTests.Helpers;
+
+namespace Grpc.AspNetCore.FunctionalTests.TestServer
+{
+    public class FunctionalTestBase
+    {
+        private GrpcChannel? _channel;
+        private IDisposable? _testContext;
+
+        protected GrpcTestFixture<Startup> Fixture { get; private set; } = default!;
+
+        protected ILoggerFactory LoggerFactory => Fixture.LoggerFactory;
+
+        protected GrpcChannel Channel => _channel ??= CreateChannel();
+
+        protected GrpcChannel CreateChannel()
+        {
+            return GrpcChannel.ForAddress(Fixture.Client.BaseAddress, new GrpcChannelOptions
+            {
+                LoggerFactory = LoggerFactory,
+                HttpClient = Fixture.Client
+            });
+        }
+
+        protected virtual void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Fixture = new GrpcTestFixture<Startup>(ConfigureServices);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            Fixture.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testContext = Fixture.GetTestContext();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testContext?.Dispose();
+            _channel = null;
+        }
+    }
+}

--- a/test/FunctionalTests/TestServer/Helpers/ForwardingLoggerProvider.cs
+++ b/test/FunctionalTests/TestServer/Helpers/ForwardingLoggerProvider.cs
@@ -1,0 +1,69 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Tests.FunctionalTests.Helpers
+{
+    internal class ForwardingLoggerProvider : ILoggerProvider
+    {
+        private readonly LogMessage _logAction;
+
+        public ForwardingLoggerProvider(LogMessage logAction)
+        {
+            _logAction = logAction;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new ForwardingLogger(categoryName, _logAction);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        internal class ForwardingLogger : ILogger
+        {
+            private readonly string _categoryName;
+            private readonly LogMessage _logAction;
+
+            public ForwardingLogger(string categoryName, LogMessage logAction)
+            {
+                _categoryName = categoryName;
+                _logAction = logAction;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                _logAction(logLevel, _categoryName, eventId, formatter(state, exception), exception);
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/TestServer/Helpers/GrpcTestContext.cs
+++ b/test/FunctionalTests/TestServer/Helpers/GrpcTestContext.cs
@@ -1,0 +1,57 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Tests.FunctionalTests.Helpers
+{
+    internal class GrpcTestContext<TStartup> : IDisposable where TStartup : class
+    {
+        private readonly ExecutionContext _executionContext;
+        private readonly Stopwatch _stopwatch;
+        private readonly GrpcTestFixture<TStartup> _fixture;
+
+        public GrpcTestContext(GrpcTestFixture<TStartup> fixture)
+        {
+            _executionContext = ExecutionContext.Capture()!;
+            _stopwatch = Stopwatch.StartNew();
+            _fixture = fixture;
+            _fixture.LoggedMessage += WriteMessage;
+        }
+
+        private void WriteMessage(LogLevel logLevel, string category, EventId eventId, string message, Exception exception)
+        {
+            // Log using the passed in execution context.
+            // In the case of NUnit, console output is only captured by the test
+            // if it is written in the test's execution context.
+            ExecutionContext.Run(_executionContext, s =>
+            {
+                Console.WriteLine($"{_stopwatch.Elapsed.TotalSeconds:N3}s {category} - {logLevel}: {message}");
+            }, null);
+        }
+
+        public void Dispose()
+        {
+            _fixture.LoggedMessage -= WriteMessage;
+            _executionContext?.Dispose();
+        }
+    }
+}

--- a/test/FunctionalTests/TestServer/Helpers/GrpcTestFixture.cs
+++ b/test/FunctionalTests/TestServer/Helpers/GrpcTestFixture.cs
@@ -1,0 +1,107 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Tests.FunctionalTests.Helpers
+{
+    public delegate void LogMessage(LogLevel logLevel, string categoryName, EventId eventId, string message, Exception exception);
+
+    public class GrpcTestFixture<TStartup> : IDisposable where TStartup : class
+    {
+        private readonly TestServer _server;
+        private readonly IHost _host;
+
+        public event LogMessage? LoggedMessage;
+
+        public GrpcTestFixture() : this(null) { }
+
+        public GrpcTestFixture(Action<IServiceCollection>? initialConfigureServices)
+        {
+            LoggerFactory = new LoggerFactory();
+            LoggerFactory.AddProvider(new ForwardingLoggerProvider((logLevel, category, eventId, message, exception) =>
+            {
+                LoggedMessage?.Invoke(logLevel, category, eventId, message, exception);
+            }));
+
+            var builder = new HostBuilder()
+                .ConfigureServices(services =>
+                {
+                    initialConfigureServices?.Invoke(services);
+                    services.AddSingleton<ILoggerFactory>(LoggerFactory);
+                })
+                .ConfigureWebHostDefaults(webHost =>
+                {
+                    webHost
+                        .UseTestServer()
+                        .UseStartup<TStartup>();
+                });
+            _host = builder.Start();
+            _server = _host.GetTestServer();
+
+            // Need to set the response version to 2.0.
+            // Required because of this TestServer issue - https://github.com/aspnet/AspNetCore/issues/16940
+            var responseVersionHandler = new ResponseVersionHandler();
+            responseVersionHandler.InnerHandler = _server.CreateHandler();
+
+            var client = new HttpClient(responseVersionHandler);
+            client.BaseAddress = new Uri("http://localhost");
+
+            Client = client;
+        }
+
+        public LoggerFactory LoggerFactory { get; }
+
+        public HttpClient Client { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _host.Dispose();
+            _server.Dispose();
+        }
+
+        private class ResponseVersionHandler : DelegatingHandler
+        {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = await base.SendAsync(request, cancellationToken);
+                response.Version = request.Version;
+
+                return response;
+            }
+        }
+
+        public IDisposable GetTestContext()
+        {
+            return new GrpcTestContext<TStartup>(this);
+        }
+    }
+}

--- a/test/FunctionalTests/TestServer/TesterServiceTests.cs
+++ b/test/FunctionalTests/TestServer/TesterServiceTests.cs
@@ -1,0 +1,220 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Tests.Shared;
+using NUnit.Framework;
+using Test;
+
+namespace Grpc.AspNetCore.FunctionalTests.TestServer
+{
+    [TestFixture]
+    public class TesterServiceTests : FunctionalTestBase
+    {
+        [Test]
+        public async Task UnaryTest_Success()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            // Act
+            var response = await client.SayHelloUnaryAsync(new HelloRequest { Name = "Joe" }).ResponseAsync.DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual("Hello Joe", response.Message);
+        }
+
+        [Test]
+        public async Task UnaryTest_Error()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            // Act
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => client.SayHelloUnaryErrorAsync(new HelloRequest { Name = "Joe" }).ResponseAsync).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual(StatusCode.NotFound, ex.StatusCode);
+        }
+
+        [Test]
+        public async Task ClientStreamingTest_Success()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            var names = new[] { "James", "Jo", "Lee" };
+            HelloReply response;
+
+            // Act
+            using (var call = client.SayHelloClientStreaming())
+            {
+                foreach (var name in names)
+                {
+                    await call.RequestStream.WriteAsync(new HelloRequest { Name = name }).DefaultTimeout();
+                    await Task.Delay(50);
+                }
+                await call.RequestStream.CompleteAsync().DefaultTimeout();
+
+                response = await call.ResponseAsync.DefaultTimeout();
+            }
+
+            // Assert
+            Assert.AreEqual("Hello James, Jo, Lee", response.Message);
+        }
+
+        [Test]
+        public async Task ClientStreamingTest_Error()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            // Act
+            using var call = client.SayHelloClientStreamingError();
+
+            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                var names = new[] { "James", "Jo", "Lee" };
+
+                {
+                    foreach (var name in names)
+                    {
+                        await call.RequestStream.WriteAsync(new HelloRequest { Name = name }).DefaultTimeout();
+                        await Task.Delay(50);
+                    }
+                }
+            }).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual(StatusCode.NotFound, call.GetStatus().StatusCode);
+        }
+
+        [Test]
+        public async Task ServerStreamingTest_Success()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            var cts = new CancellationTokenSource();
+            var hasMessages = false;
+            var callCancelled = false;
+
+            // Act
+            using (var call = client.SayHelloServerStreaming(new HelloRequest { Name = "Joe" }, cancellationToken: cts.Token))
+            {
+                try
+                {
+                    await foreach (var message in call.ResponseStream.ReadAllAsync().DefaultTimeout())
+                    {
+                        hasMessages = true;
+                        cts.Cancel();
+                    }
+                }
+                catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
+                {
+                    callCancelled = true;
+                }
+            }
+
+            // Assert
+            Assert.IsTrue(hasMessages);
+            Assert.IsTrue(callCancelled);
+        }
+
+        [Test]
+        public async Task ServerStreamingTest_Throw()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            // Act
+            using var call = client.SayHelloServerStreamingError(new HelloRequest { Name = "Joe" });
+
+            // Assert
+            Assert.IsTrue(await call.ResponseStream.MoveNext());
+
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext());
+
+            Assert.AreEqual(StatusCode.NotFound, ex.StatusCode);
+        }
+
+        [Test]
+        public async Task BidirectionStreamingTest_Success()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            var names = new[] { "James", "Jo", "Lee" };
+            var messages = new List<string>();
+
+            // Act
+            using (var call = client.SayHelloBidirectionalStreaming())
+            {
+                foreach (var name in names)
+                {
+                    await call.RequestStream.WriteAsync(new HelloRequest { Name = name }).DefaultTimeout();
+
+                    Assert.IsTrue(await call.ResponseStream.MoveNext().DefaultTimeout());
+                    messages.Add(call.ResponseStream.Current.Message);
+                }
+
+                await call.RequestStream.CompleteAsync().DefaultTimeout();
+
+                Assert.IsFalse(await call.ResponseStream.MoveNext().DefaultTimeout());
+            }
+
+            // Assert
+            Assert.AreEqual(3, messages.Count);
+            Assert.AreEqual("Hello James", messages[0]);
+        }
+
+        [Test]
+        public async Task BidirectionStreamingTest_Error()
+        {
+            // Arrange
+            var client = new Tester.TesterClient(Channel);
+
+            // Act
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(async () =>
+            {
+                var names = new[] { "James", "Jo", "Lee" };
+
+                using (var call = client.SayHelloBidirectionalStreamingError())
+                {
+                    foreach (var name in names)
+                    {
+                        await call.RequestStream.WriteAsync(new HelloRequest { Name = name }).DefaultTimeout();
+
+                        Assert.IsTrue(await call.ResponseStream.MoveNext().DefaultTimeout());
+                    }
+
+                    await call.RequestStream.CompleteAsync().DefaultTimeout();
+
+                    Assert.IsFalse(await call.ResponseStream.MoveNext().DefaultTimeout());
+                }
+            }).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual(StatusCode.NotFound, ex.StatusCode);
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>

--- a/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
+++ b/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>
@@ -25,6 +25,7 @@
     <Protobuf Include="..\Proto\unimplemented.proto" Link="Protos\unimplemented.proto" />
     <Protobuf Include="..\Proto\echo.proto" Link="Protos\echo.proto" />
     <Protobuf Include="..\Proto\issue.proto" Link="Protos\issue.proto" />
+    <Protobuf Include="..\Proto\test.proto" Link="Protos\test.proto" />
   </ItemGroup>
   
 </Project>

--- a/testassets/FunctionalTestsWebsite/Services/TesterService.cs
+++ b/testassets/FunctionalTestsWebsite/Services/TesterService.cs
@@ -1,0 +1,114 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Streaming;
+using Test;
+
+namespace FunctionalTestsWebsite.Services
+{
+    public class TesterService : Tester.TesterBase
+    {
+        private readonly ILogger _logger;
+
+        public TesterService(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<TesterService>();
+        }
+
+        public override Task<HelloReply> SayHelloUnary(HelloRequest request, ServerCallContext context)
+        {
+            _logger.LogInformation($"Sending hello to {request.Name}");
+            return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+        }
+
+        public override async Task<HelloReply> SayHelloUnaryError(HelloRequest request, ServerCallContext context)
+        {
+            await Task.Yield();
+
+            throw new RpcException(new Status(StatusCode.NotFound, string.Empty));
+        }
+
+        public override async Task SayHelloServerStreaming(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            var i = 0;
+            while (!context.CancellationToken.IsCancellationRequested)
+            {
+                var message = $"How are you {request.Name}? {++i}";
+                _logger.LogInformation($"Sending greeting {message}.");
+
+                await responseStream.WriteAsync(new HelloReply { Message = message });
+
+                // Gotta look busy
+                await Task.Delay(1000);
+            }
+        }
+
+        public override async Task SayHelloServerStreamingError(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            await responseStream.WriteAsync(new HelloReply());
+
+            throw new RpcException(new Status(StatusCode.NotFound, string.Empty));
+        }
+
+        public override async Task<HelloReply> SayHelloClientStreaming(IAsyncStreamReader<HelloRequest> requestStream, ServerCallContext context)
+        {
+            var names = new List<string>();
+
+            await foreach (var message in requestStream.ReadAllAsync())
+            {
+                names.Add(message.Name);
+            }
+
+            return new HelloReply { Message = "Hello " + string.Join(", ", names) };
+        }
+
+        public override async Task<HelloReply> SayHelloClientStreamingError(IAsyncStreamReader<HelloRequest> requestStream, ServerCallContext context)
+        {
+            await Task.Yield();
+
+            throw new RpcException(new Status(StatusCode.NotFound, string.Empty));
+        }
+
+        public override async Task SayHelloBidirectionalStreaming(IAsyncStreamReader<HelloRequest> requestStream, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            await foreach (var message in requestStream.ReadAllAsync())
+            {
+                await responseStream.WriteAsync(new HelloReply { Message = "Hello " + message.Name });
+            }
+        }
+
+        public override async Task SayHelloBidirectionalStreamingError(IAsyncStreamReader<HelloRequest> requestStream, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            await foreach (var message in requestStream.ReadAllAsync())
+            {
+                await responseStream.WriteAsync(new HelloReply { Message = "Hello " + message.Name });
+            }
+
+            throw new RpcException(new Status(StatusCode.NotFound, string.Empty));
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -145,6 +145,7 @@ namespace FunctionalTestsWebsite
                 endpoints.MapGrpcService<RacerService>();
                 endpoints.MapGrpcService<EchoService>();
                 endpoints.MapGrpcService<IssueService>();
+                endpoints.MapGrpcService<TesterService>();
 
                 endpoints.DataSources.Add(endpoints.ServiceProvider.GetRequiredService<DynamicEndpointDataSource>());
 

--- a/testassets/Proto/test.proto
+++ b/testassets/Proto/test.proto
@@ -1,0 +1,36 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test;
+
+service Tester {
+  rpc SayHelloUnary (HelloRequest) returns (HelloReply);
+  rpc SayHelloUnaryError (HelloRequest) returns (HelloReply);
+  rpc SayHelloServerStreaming (HelloRequest) returns (stream HelloReply);
+  rpc SayHelloServerStreamingError (HelloRequest) returns (stream HelloReply);
+  rpc SayHelloClientStreaming (stream HelloRequest) returns (HelloReply);
+  rpc SayHelloClientStreamingError (stream HelloRequest) returns (HelloReply);
+  rpc SayHelloBidirectionalStreaming (stream HelloRequest) returns (stream HelloReply);
+  rpc SayHelloBidirectionalStreamingError (stream HelloRequest) returns (stream HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/738
Fixes https://github.com/grpc/grpc-dotnet/issues/740

Test using TestServer to run gRPC functional tests.

Blocked, waiting for release version of .NET Core 3.1