### PR TITLE
Improve error message when SslCredentials has arguments

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -203,7 +203,7 @@ namespace Grpc.Net.Client
                 {
                     throw new InvalidOperationException(
                         $"{nameof(SslCredentials)} with non-null arguments is not supported by {nameof(GrpcChannel)}. " +
-                        $"HttpClient is used by {nameof(GrpcChannel)} to make gRPC calls and it will automatically load root certificates from the operating system certificate store. " +
+                        $"HttpClient is used by {nameof(GrpcChannel)} to make gRPC calls and it automatically loads root certificates from the operating system certificate store. " +
                         $"Client certificates should be configured on HttpClient. See https://aka.ms/AA6we64 for details.");
                 }
 

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -203,7 +203,7 @@ namespace Grpc.Net.Client
                 {
                     throw new InvalidOperationException(
                         $"{nameof(SslCredentials)} with non-null arguments is not supported by {nameof(GrpcChannel)}. " +
-                        $"HttpClient is used by {nameof(GrpcChannel)} to make gRPC calls and it automatically loads root certificates from the operating system certificate store. " +
+                        $"{nameof(GrpcChannel)} uses HttpClient to make gRPC calls and HttpClient automatically loads root certificates from the operating system certificate store. " +
                         $"Client certificates should be configured on HttpClient. See https://aka.ms/AA6we64 for details.");
                 }
 

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -201,7 +201,10 @@ namespace Grpc.Net.Client
                     keyCertificatePair != null ||
                     verifyPeerCallback != null)
                 {
-                    throw new InvalidOperationException($"Using {nameof(SslCredentials)} with non-null arguments is not supported by {nameof(GrpcChannel)}.");
+                    throw new InvalidOperationException(
+                        $"{nameof(SslCredentials)} with non-null arguments is not supported by {nameof(GrpcChannel)}. " +
+                        $"HttpClient is used by {nameof(GrpcChannel)} to make gRPC calls and it will automatically load root certificates from the operating system certificate store. " +
+                        $"Client certificates should be configured on HttpClient. See https://aka.ms/AA6we64 for details.");
                 }
 
                 IsSecure = true;

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -31,8 +31,21 @@ namespace Grpc.Net.Client
     public sealed class GrpcChannelOptions
     {
         /// <summary>
-        /// Gets or sets the credentials for the channel.
+        /// Gets or sets the credentials for the channel. This setting is used to set <see cref="CallCredentials"/> for
+        /// a channel. Connection transport layer security (TLS) is determined by the address used to create the channel.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When configuring <see cref="CallCredentials"/> for a channel, the channel credentials you use must match the address TLS
+        /// setting. Use <see cref="ChannelCredentials.Insecure"/> for an "http" address and <see cref="SslCredentials"/> with
+        /// no arguments for "https".
+        /// </para>
+        /// <para>
+        /// The underlying <see cref="System.Net.Http.HttpClient"/> used by the channel automatically loads root certificates
+        /// from the operating system certificate store.
+        /// Client certificates should be configured on HttpClient. See https://aka.ms/AA6we64 for details.
+        /// </para>
+        /// </remarks>
         public ChannelCredentials? Credentials { get; set; }
 
         /// <summary>

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -36,9 +36,8 @@ namespace Grpc.Net.Client
         /// </summary>
         /// <remarks>
         /// <para>
-        /// When configuring <see cref="CallCredentials"/> for a channel, the channel credentials you use must match the address TLS
-        /// setting. Use <see cref="ChannelCredentials.Insecure"/> for an "http" address and <see cref="SslCredentials"/> with
-        /// no arguments for "https".
+        /// The channel credentials you use must match the address TLS setting. Use <see cref="ChannelCredentials.Insecure"/>
+        /// for an "http" address and <see cref="SslCredentials"/> with no arguments for "https".
         /// </para>
         /// <para>
         /// The underlying <see cref="System.Net.Http.HttpClient"/> used by the channel automatically loads root certificates

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -75,7 +75,10 @@ namespace Grpc.Net.Client.Tests
             }));
 
             // Assert
-            Assert.AreEqual("Using SslCredentials with non-null arguments is not supported by GrpcChannel.", ex.Message);
+            Assert.AreEqual(
+                "SslCredentials with non-null arguments is not supported by GrpcChannel. " +
+                "HttpClient is used by GrpcChannel to make gRPC calls and it automatically loads root certificates from the operating system certificate store. " +
+                "Client certificates should be configured on HttpClient. See https://aka.ms/AA6we64 for details.", ex.Message);
         }
 
         [Test]

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -77,7 +77,7 @@ namespace Grpc.Net.Client.Tests
             // Assert
             Assert.AreEqual(
                 "SslCredentials with non-null arguments is not supported by GrpcChannel. " +
-                "HttpClient is used by GrpcChannel to make gRPC calls and it automatically loads root certificates from the operating system certificate store. " +
+                "GrpcChannel uses HttpClient to make gRPC calls and HttpClient automatically loads root certificates from the operating system certificate store. " +
                 "Client certificates should be configured on HttpClient. See https://aka.ms/AA6we64 for details.", ex.Message);
         }
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/702