### PR TITLE
Add IGrpcServiceOptionsMetadata

### DIFF
--- a/src/Grpc.AspNetCore.Server/IGrpcServiceOptionsMetadata.cs
+++ b/src/Grpc.AspNetCore.Server/IGrpcServiceOptionsMetadata.cs
@@ -1,0 +1,31 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Grpc.AspNetCore.Server
+{
+    /// <summary>
+    /// Metadata for gRPC service options.
+    /// </summary>
+    public interface IGrpcServiceOptionsMetadata
+    {
+        /// <summary>
+        /// Gets gRPC service options.
+        /// </summary>
+        GrpcServiceOptions Options { get; }
+    }
+}

--- a/src/Grpc.AspNetCore.Server/IGrpcServiceOptionsMetadata.cs
+++ b/src/Grpc.AspNetCore.Server/IGrpcServiceOptionsMetadata.cs
@@ -19,7 +19,9 @@
 namespace Grpc.AspNetCore.Server
 {
     /// <summary>
-    /// Metadata for gRPC service options.
+    /// Metadata for gRPC service options. Options provided by this metadata will be used by the gRPC
+    /// endpoints that the metadata is applied to. Options specified by metadata have a higher precedence
+    /// than options configured with <c>AddGrpc</c> and <c>AddServiceOptions</c> on application startup.
     /// </summary>
     public interface IGrpcServiceOptionsMetadata
     {

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -54,6 +54,7 @@ namespace Grpc.AspNetCore.Server.Internal
 
         private MethodOptions CreateMethodOptions(IList<object> metadata)
         {
+            // Metadata added in ascending order of precedence
             var allOptions = new List<GrpcServiceOptions>();
             allOptions.Add(_globalOptions);
             allOptions.Add(_serviceOptions);

--- a/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
@@ -37,6 +37,11 @@ namespace Grpc.AspNetCore.Server.Model.Internal
 
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
             var (invoker, metadata) = CreateModelCore<ClientStreamingServerMethod<TService, TRequest, TResponse>>(
                 method.Name,
                 new[] { typeof(IAsyncStreamReader<TRequest>), typeof(ServerCallContext) });
@@ -46,6 +51,11 @@ namespace Grpc.AspNetCore.Server.Model.Internal
 
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
             var (invoker, metadata) = CreateModelCore<DuplexStreamingServerMethod<TService, TRequest, TResponse>>(
                 method.Name,
                 new[] { typeof(IAsyncStreamReader<TRequest>), typeof(IServerStreamWriter<TResponse>), typeof(ServerCallContext) });
@@ -55,6 +65,11 @@ namespace Grpc.AspNetCore.Server.Model.Internal
 
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
             var (invoker, metadata) = CreateModelCore<ServerStreamingServerMethod<TService, TRequest, TResponse>>(
                 method.Name,
                 new[] { typeof(TRequest), typeof(IServerStreamWriter<TResponse>), typeof(ServerCallContext) });
@@ -64,6 +79,11 @@ namespace Grpc.AspNetCore.Server.Model.Internal
 
         public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
             var (invoker, metadata) = CreateModelCore<UnaryServerMethod<TService, TRequest, TResponse>>(
                 method.Name,
                 new[] { typeof(TRequest), typeof(ServerCallContext) });

--- a/src/Grpc.AspNetCore.Server/Model/ServiceMethodProviderContext.cs
+++ b/src/Grpc.AspNetCore.Server/Model/ServiceMethodProviderContext.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using Grpc.AspNetCore.Server.Internal;
 using Grpc.AspNetCore.Server.Model.Internal;
@@ -53,6 +54,21 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
+            if (invoker == null)
+            {
+                throw new ArgumentNullException(nameof(invoker));
+            }
+
             var callHandler = _serverCallHandlerFactory.CreateUnary<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
@@ -69,6 +85,21 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
+            if (invoker == null)
+            {
+                throw new ArgumentNullException(nameof(invoker));
+            }
+
             var callHandler = _serverCallHandlerFactory.CreateServerStreaming<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
@@ -85,6 +116,21 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
+            if (invoker == null)
+            {
+                throw new ArgumentNullException(nameof(invoker));
+            }
+
             var callHandler = _serverCallHandlerFactory.CreateClientStreaming<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
@@ -101,6 +147,21 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
+            if (invoker == null)
+            {
+                throw new ArgumentNullException(nameof(invoker));
+            }
+
             var callHandler = _serverCallHandlerFactory.CreateDuplexStreaming<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
@@ -121,6 +182,26 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (metadata == null)
+            {
+                throw new ArgumentNullException(nameof(metadata));
+            }
+
+            if (pattern == null)
+            {
+                throw new ArgumentNullException(nameof(pattern));
+            }
+
+            if (invoker == null)
+            {
+                throw new ArgumentNullException(nameof(invoker));
+            }
+
             var methodModel = new MethodModel(method, pattern, metadata, invoker);
             Methods.Add(methodModel);
         }

--- a/src/Grpc.AspNetCore.Server/Model/ServiceMethodProviderContext.cs
+++ b/src/Grpc.AspNetCore.Server/Model/ServiceMethodProviderContext.cs
@@ -53,7 +53,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
-            var callHandler = _serverCallHandlerFactory.CreateUnary<TRequest, TResponse>(method, invoker);
+            var callHandler = _serverCallHandlerFactory.CreateUnary<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
 
@@ -69,7 +69,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
-            var callHandler = _serverCallHandlerFactory.CreateServerStreaming<TRequest, TResponse>(method, invoker);
+            var callHandler = _serverCallHandlerFactory.CreateServerStreaming<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
 
@@ -85,7 +85,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
-            var callHandler = _serverCallHandlerFactory.CreateClientStreaming<TRequest, TResponse>(method, invoker);
+            var callHandler = _serverCallHandlerFactory.CreateClientStreaming<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
 
@@ -101,7 +101,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TRequest : class
             where TResponse : class
         {
-            var callHandler = _serverCallHandlerFactory.CreateDuplexStreaming<TRequest, TResponse>(method, invoker);
+            var callHandler = _serverCallHandlerFactory.CreateDuplexStreaming<TRequest, TResponse>(method, metadata, invoker);
             AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
         }
 

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -16,6 +16,7 @@
     <Protobuf Include="..\Proto\compression.proto" Link="Protos\compression.proto" />
     <Protobuf Include="..\Proto\count.proto" Link="Protos\count.proto" />
     <Protobuf Include="..\Proto\greet.proto" Link="Protos\greet.proto" />
+    <Protobuf Include="..\Proto\intercept.proto" Link="Protos\intercept.proto" />
     <Protobuf Include="..\Proto\lifetime.proto" Link="Protos\lifetime.proto" />
     <Protobuf Include="..\Proto\nested.proto" Link="Protos\nested.proto" />
     <Protobuf Include="..\Proto\race.proto" Link="Protos\race.proto" />

--- a/testassets/FunctionalTestsWebsite/Infrastructure/InterceptorAttribute.cs
+++ b/testassets/FunctionalTestsWebsite/Infrastructure/InterceptorAttribute.cs
@@ -1,0 +1,40 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+using System;
+
+namespace FunctionalTestsWebsite.Infrastructure
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public class InterceptorAttribute : Attribute, IGrpcServiceOptionsMetadata
+    {
+        public InterceptorAttribute(System.Type interceptorType) : this(interceptorType, null)
+        {
+        }
+
+        public InterceptorAttribute(System.Type interceptorType, params object[]? args)
+        {
+            Options = new GrpcServiceOptions();
+            Options.Interceptors.Add(interceptorType, args ?? Array.Empty<object[]>());
+        }
+
+        public GrpcServiceOptions Options { get; }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Infrastructure/OrderedInterceptor.cs
+++ b/testassets/FunctionalTestsWebsite/Infrastructure/OrderedInterceptor.cs
@@ -1,0 +1,108 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using System;
+using System.Threading.Tasks;
+
+namespace FunctionalTestsWebsite.Infrastructure
+{
+    public class OrderedInterceptor : Interceptor
+    {
+        public static readonly string OrderHeaderKey = "Order";
+        private int _expectedOrder;
+
+        public OrderedInterceptor(int expectedOrder)
+        {
+            _expectedOrder = expectedOrder;
+        }
+
+        public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            EnsureIncomingOrder(context);
+            var result = await continuation(request, context);
+            EnsureOutgoingOrder(context);
+
+            return result;
+        }
+
+        public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, ServerCallContext context, ClientStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            EnsureIncomingOrder(context);
+            var result = await continuation(requestStream, context);
+            EnsureOutgoingOrder(context);
+
+            return result;
+        }
+
+        public override async Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, ServerStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            EnsureIncomingOrder(context);
+            await continuation(request, responseStream, context);
+            EnsureOutgoingOrder(context);
+        }
+
+        public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+        {
+            EnsureIncomingOrder(context);
+            await continuation(requestStream, responseStream, context);
+            EnsureOutgoingOrder(context);
+        }
+
+        private void EnsureIncomingOrder(ServerCallContext context)
+        {
+            var items = context.GetHttpContext().Items;
+
+            if (_expectedOrder == 0)
+            {
+                AssertValue(null, items[OrderHeaderKey]);
+            }
+            else
+            {
+                AssertValue(_expectedOrder - 1, items[OrderHeaderKey]);
+            }
+
+            items[OrderHeaderKey] = _expectedOrder;
+        }
+
+        private void EnsureOutgoingOrder(ServerCallContext context)
+        {
+            var items = context.GetHttpContext().Items;
+
+            AssertValue(_expectedOrder, items[OrderHeaderKey]);
+
+            if (_expectedOrder == 0)
+            {
+                items[OrderHeaderKey] = null;
+            }
+            else
+            {
+                items[OrderHeaderKey] = _expectedOrder - 1;
+            }
+        }
+
+        private void AssertValue(object? expectedValue, object? actualValue)
+        {
+            if (!Equals(expectedValue, actualValue))
+            {
+                throw new InvalidOperationException($"Expected {expectedValue}, got {actualValue}.");
+            }
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Services/InterceptorService.cs
+++ b/testassets/FunctionalTestsWebsite/Services/InterceptorService.cs
@@ -1,0 +1,52 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using FunctionalTestsWebsite.Infrastructure;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Intercept;
+using System;
+using System.Threading.Tasks;
+
+namespace FunctionalTestsWebsite.Services
+{
+    [Interceptor(typeof(OrderedInterceptor), 2)]
+    [Interceptor(typeof(OrderedInterceptor), 3)]
+    public class InterceptorService : Interceptor.InterceptorBase
+    {
+        private static readonly string OrderHeaderKey = "Order";
+
+        [Interceptor(typeof(OrderedInterceptor), 4)]
+        [Interceptor(typeof(OrderedInterceptor), 5)]
+        public override Task<OrderReply> GetInterceptorOrderHasMethodAttributes(Empty request, ServerCallContext context)
+        {
+            return GetInterceptorOrderCore(context);
+        }
+
+        public override Task<OrderReply> GetInterceptorOrderNoMethodAttributes(Empty request, ServerCallContext context)
+        {
+            return GetInterceptorOrderCore(context);
+        }
+
+        private static Task<OrderReply> GetInterceptorOrderCore(ServerCallContext context)
+        {
+            var items = context.GetHttpContext().Items;
+            return Task.FromResult(new OrderReply { Order = Convert.ToInt32(items[OrderHeaderKey]) });
+        }
+    }
+}

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -130,6 +130,7 @@ namespace FunctionalTestsWebsite
                 endpoints.MapGrpcService<GreeterService>();
                 endpoints.MapGrpcService<StreamService>();
                 endpoints.MapGrpcService<RacerService>();
+                endpoints.MapGrpcService<InterceptorService>();
 
                 endpoints.DataSources.Add(endpoints.ServiceProvider.GetRequiredService<DynamicEndpointDataSource>());
 

--- a/testassets/Proto/intercept.proto
+++ b/testassets/Proto/intercept.proto
@@ -1,0 +1,28 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package intercept;
+
+service Interceptor {
+  rpc GetInterceptorOrderNoMethodAttributes (google.protobuf.Empty) returns (OrderReply);
+  rpc GetInterceptorOrderHasMethodAttributes (google.protobuf.Empty) returns (OrderReply);
+}
+
+message OrderReply {
+  int32 order = 1;
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/520

This allows options to be set via endpoint metadata. I haven't added any attributes for setting values, but it is possible for developers to easily write an attribute to set whatever value on service options they want.

`InterceptorAttribute` in this PR's tests is an example of attributes that can be created with this.