### PR TITLE
Separating out ResponseMessageContext logic from HttpContextServerCallContext

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -212,17 +212,5 @@ namespace Grpc.AspNetCore.Server.Internal
                 values.Add(AuthProperty.Create(name, Encoding.UTF8.GetBytes(value)));
             }
         }
-
-        internal static bool CanWriteCompressed(WriteOptions? writeOptions)
-        {
-            if (writeOptions == null)
-            {
-                return true;
-            }
-
-            var canCompress = (writeOptions.Flags & WriteFlags.NoCompress) != WriteFlags.NoCompress;
-
-            return canCompress;
-        }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/ResponseMessageContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ResponseMessageContext.cs
@@ -1,0 +1,52 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+
+using Grpc.Core;
+using Grpc.Net.Compression;
+using System;
+using System.Diagnostics;
+
+namespace Grpc.AspNetCore.Server.Internal
+{
+    internal class ResponseMessageContext
+    {
+        private ServerCallContext _serverCallContext;
+
+        internal ResponseMessageContext(Type responseType, ServerCallContext serverCallContext)
+        {
+            ResponseType = responseType;
+            _serverCallContext = serverCallContext;
+        }
+
+        internal string? GrpcEncoding { get; set; }
+        internal Type ResponseType { get; }
+
+        internal bool CanCompress()
+        {
+            Debug.Assert(
+                GrpcEncoding != null,
+                "Response encoding should have been calculated at this point.");
+
+            bool compressionEnabled = _serverCallContext.WriteOptions == null || !_serverCallContext.WriteOptions.Flags.HasFlag(WriteFlags.NoCompress);
+
+            return compressionEnabled &&
+                !string.Equals(GrpcEncoding, GrpcProtocolConstants.IdentityGrpcEncoding, StringComparison.Ordinal);
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/ResponseMessageContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/ResponseMessageContextTests.cs
@@ -1,0 +1,90 @@
+﻿using Grpc.AspNetCore.Server.Internal;
+using Grpc.AspNetCore.Server.Tests.Infrastructure;
+using Grpc.Core;
+using Grpc.Net.Compression;
+using Grpc.Tests.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Grpc.AspNetCore.Server.Tests
+{
+    [TestFixture]
+    public class ResponseMessageContextTests
+    {
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void CanCompress_WithNoWriteOptions_AllowsIfEncodingSet(bool setEncoding, bool expectedCanCompressResult)
+        {
+            // Arrange
+            WriteOptions? writeOptions = null;
+
+            // Act
+            var responseMessageContext = CreateResponseMessageContext( writeOptions, setEncoding: setEncoding);
+            bool canCompress = responseMessageContext.CanCompress();
+
+            // Assert
+            Assert.AreEqual(expectedCanCompressResult, canCompress);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CanCompress_WithNoCompressSet_DoesNotAllow(bool setEncoding)
+        {
+            // Arrange
+            WriteOptions? writeOptions = new WriteOptions(WriteFlags.NoCompress);
+
+            // Act
+            var responseMessageContext = CreateResponseMessageContext(writeOptions, setEncoding: setEncoding);
+            bool canCompress = responseMessageContext.CanCompress();
+
+            // Assert
+            Assert.IsFalse(canCompress);
+        }
+
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void CanCompress_WithNoCompressNotSet_AllowsIfEncodingIsSet(bool setEncoding, bool expectedCanCompressResult)
+        {
+            // Arrange
+            WriteOptions? writeOptions = new WriteOptions(WriteFlags.BufferHint);
+
+            // Act
+            var responseMessageContext = CreateResponseMessageContext(writeOptions, setEncoding: setEncoding);
+            bool canCompress = responseMessageContext.CanCompress();
+
+            // Assert
+            Assert.AreEqual(expectedCanCompressResult, canCompress);
+        }
+
+
+        private ResponseMessageContext CreateResponseMessageContext(WriteOptions? writeOptions, bool setEncoding)
+        {
+            var httpContext = new DefaultHttpContext();
+
+            HttpContextServerCallContext serverCallContext;
+            if (setEncoding)
+            {
+                ICompressionProvider compressionProvider = new GzipCompressionProvider(System.IO.Compression.CompressionLevel.Fastest);
+                var compressionProviders = new List<ICompressionProvider>
+                {
+                    compressionProvider
+                };
+
+                httpContext.Request.Headers.Add(GrpcProtocolConstants.MessageEncodingHeader, compressionProvider.EncodingName);
+                httpContext.Request.Headers.Add(GrpcProtocolConstants.MessageAcceptEncodingHeader, compressionProvider.EncodingName);
+                serverCallContext = HttpContextServerCallContextHelper.CreateServerCallContext(httpContext, compressionProviders, compressionProvider.EncodingName);
+            }
+            else
+            {
+                serverCallContext = HttpContextServerCallContextHelper.CreateServerCallContext(httpContext);
+            }
+
+            serverCallContext.WriteOptions = writeOptions;
+            return serverCallContext.ResponseMessageContext;
+        }
+    }
+}


### PR DESCRIPTION
Hi, 

I initially started trying to make the HttpContextServerCallContext class use generics instead passing in types into the constructor but realized it was too large a change because it is passed into quite a few other classes such as the HttpContextSerializationContext and various methods in PipeExtensions. 

So this change is just trying to decouple the HttpContextServerCallContext from the HttpContextSerializationContext by instead passing through a new class ResponseMessageContext which has the needed information.

I understand that this is a little larger pull request which might require someone spending some time going through it. My intention is to try get a little more involved in the project but I definitely don't want to take you guys from the great work you have been doing. 

If you would prefer to not make this change I am happy to delete the pr and find something else to contribute.

Thanks!