### PR TITLE
Use new Grpc.Core.Api to get response headers only when requested

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
     <GoogleProtobufPackageVersion>3.10.0</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.25.0</GrpcDotNetPackageVersion>  <!-- Only use for example projects -->
-    <GrpcPackageVersion>2.27.0-dev201912051123</GrpcPackageVersion>
+    <GrpcPackageVersion>2.27.0-dev202001131222</GrpcPackageVersion>
     <MicrosoftAspNetCorePackageVersion>3.0.0</MicrosoftAspNetCorePackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -39,10 +39,11 @@ namespace Grpc.Net.Client.Internal
 
         private readonly CancellationTokenSource _callCts;
         private readonly TaskCompletionSource<Status> _callTcs;
-        private readonly TaskCompletionSource<Metadata> _metadataTcs;
         private readonly TimeSpan? _timeout;
         private readonly GrpcMethodInfo _grpcMethodInfo;
 
+        private Task<HttpResponseMessage>? _responseTask;
+        private Task<Metadata>? _responseHeadersTask;
         private Timer? _deadlineTimer;
         private Metadata? _trailers;
         private CancellationTokenRegistration? _ctsRegistration;
@@ -68,7 +69,6 @@ namespace Grpc.Net.Client.Internal
             _callCts = new CancellationTokenSource();
             // Run the callTcs continuation immediately to keep the same context. Required for Activity.
             _callTcs = new TaskCompletionSource<Status>();
-            _metadataTcs = new TaskCompletionSource<Metadata>(TaskCreationOptions.RunContinuationsAsynchronously);
             Method = method;
             _grpcMethodInfo = grpcMethodInfo;
             Options = options;
@@ -213,7 +213,29 @@ namespace Grpc.Net.Client.Internal
 
         public Task<Metadata> GetResponseHeadersAsync()
         {
-            return _metadataTcs.Task;
+            if (_responseHeadersTask == null)
+            {
+                // Allocate metadata and task only when requested
+                _responseHeadersTask = GetResponseHeadersCoreAsync();
+            }
+
+            return _responseHeadersTask;
+        }
+
+        private async Task<Metadata> GetResponseHeadersCoreAsync()
+        {
+            Debug.Assert(_responseTask != null);
+
+            try
+            {
+                var httpResponse = await _responseTask.ConfigureAwait(false);
+                return GrpcProtocolHelpers.BuildMetadata(httpResponse.Headers);
+            }
+            catch (Exception ex)
+            {
+                ResolveException(ex, out _, out var resolvedException);
+                throw resolvedException;
+            }
         }
 
         public Status GetStatus()
@@ -376,15 +398,6 @@ namespace Grpc.Net.Client.Internal
                 ClientStreamWriter?.WriteStreamTcs.TrySetCanceled();
                 ClientStreamWriter?.CompleteTcs.TrySetCanceled();
                 ClientStreamReader?.HttpResponseTcs.TrySetCanceled();
-
-                if (!Channel.ThrowOperationCanceledOnCancellation)
-                {
-                    _metadataTcs.TrySetException(CreateRpcException(status));
-                }
-                else
-                {
-                    _metadataTcs.TrySetCanceled(_callCts.Token);
-                }
             }
         }
 
@@ -423,15 +436,14 @@ namespace Grpc.Net.Client.Internal
                 {
                     try
                     {
-                        HttpResponse = await Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token).ConfigureAwait(false);
+                        _responseTask = Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token);
+                        HttpResponse = await _responseTask.ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
                         GrpcCallLog.ErrorStartingCall(Logger, ex);
                         throw;
                     }
-
-                    BuildMetadata(HttpResponse);
 
                     status = ValidateHeaders(HttpResponse);
 
@@ -508,29 +520,33 @@ namespace Grpc.Net.Client.Internal
                 catch (Exception ex)
                 {
                     Exception resolvedException;
-                    if (ex is OperationCanceledException)
-                    {
-                        status = (CallTask.IsCompletedSuccessfully) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
-                        resolvedException = Channel.ThrowOperationCanceledOnCancellation ? ex : CreateRpcException(status.Value);
-                    }
-                    else if (ex is RpcException rpcException)
-                    {
-                        status = rpcException.Status;
-                        resolvedException = CreateRpcException(status.Value);
-                    }
-                    else
-                    {
-                        status = new Status(StatusCode.Internal, "Error starting gRPC call: " + ex.Message);
-                        resolvedException = CreateRpcException(status.Value);
-                    }
+                    ResolveException(ex, out status, out resolvedException);
 
-                    _metadataTcs.TrySetException(resolvedException);
                     _responseTcs?.TrySetException(resolvedException);
 
                     Cleanup(status!.Value);
                 }
 
                 FinishCall(request, diagnosticSourceEnabled, activity, status);
+            }
+        }
+
+        private void ResolveException(Exception ex, out Status? status, out Exception resolvedException)
+        {
+            if (ex is OperationCanceledException)
+            {
+                status = (CallTask.IsCompletedSuccessfully) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
+                resolvedException = Channel.ThrowOperationCanceledOnCancellation ? ex : CreateRpcException(status.Value);
+            }
+            else if (ex is RpcException rpcException)
+            {
+                status = rpcException.Status;
+                resolvedException = CreateRpcException(status.Value);
+            }
+            else
+            {
+                status = new Status(StatusCode.Internal, "Error starting gRPC call: " + ex.Message);
+                resolvedException = CreateRpcException(status.Value);
             }
         }
 
@@ -565,18 +581,6 @@ namespace Grpc.Net.Client.Internal
             else
             {
                 return CreateRpcException(status);
-            }
-        }
-
-        private void BuildMetadata(HttpResponseMessage httpResponse)
-        {
-            try
-            {
-                _metadataTcs.TrySetResult(GrpcProtocolHelpers.BuildMetadata(httpResponse.Headers));
-            }
-            catch (Exception ex)
-            {
-                _metadataTcs.TrySetException(ex);
             }
         }
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -42,7 +42,7 @@ namespace Grpc.Net.Client.Internal
         private readonly TimeSpan? _timeout;
         private readonly GrpcMethodInfo _grpcMethodInfo;
 
-        private Task<HttpResponseMessage>? _responseTask;
+        private Task<HttpResponseMessage>? _httpResponseTask;
         private Task<Metadata>? _responseHeadersTask;
         private Timer? _deadlineTimer;
         private Metadata? _trailers;
@@ -224,11 +224,11 @@ namespace Grpc.Net.Client.Internal
 
         private async Task<Metadata> GetResponseHeadersCoreAsync()
         {
-            Debug.Assert(_responseTask != null);
+            Debug.Assert(_httpResponseTask != null);
 
             try
             {
-                var httpResponse = await _responseTask.ConfigureAwait(false);
+                var httpResponse = await _httpResponseTask.ConfigureAwait(false);
                 return GrpcProtocolHelpers.BuildMetadata(httpResponse.Headers);
             }
             catch (Exception ex)
@@ -436,8 +436,8 @@ namespace Grpc.Net.Client.Internal
                 {
                     try
                     {
-                        _responseTask = Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token);
-                        HttpResponse = await _responseTask.ConfigureAwait(false);
+                        _httpResponseTask = Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token);
+                        HttpResponse = await _httpResponseTask.ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client.Internal;
 
@@ -46,10 +47,11 @@ namespace Grpc.Net.Client.Internal
             return new AsyncClientStreamingCall<TRequest, TResponse>(
                 requestStream: call.ClientStreamWriter,
                 responseAsync: call.GetResponseAsync(),
-                responseHeadersAsync: call.GetResponseHeadersAsync(),
-                getStatusFunc: call.GetStatus,
-                getTrailersFunc: call.GetTrailers,
-                disposeAction: call.Dispose);
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
+                getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
+                disposeAction: Callbacks<TRequest, TResponse>.Dispose,
+                call);
         }
 
         /// <summary>
@@ -65,10 +67,11 @@ namespace Grpc.Net.Client.Internal
             return new AsyncDuplexStreamingCall<TRequest, TResponse>(
                 requestStream: call.ClientStreamWriter,
                 responseStream: call.ClientStreamReader,
-                responseHeadersAsync: call.GetResponseHeadersAsync(),
-                getStatusFunc: call.GetStatus,
-                getTrailersFunc: call.GetTrailers,
-                disposeAction: call.Dispose);
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
+                getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
+                disposeAction: Callbacks<TRequest, TResponse>.Dispose,
+                call);
         }
 
         /// <summary>
@@ -82,10 +85,11 @@ namespace Grpc.Net.Client.Internal
 
             return new AsyncServerStreamingCall<TResponse>(
                 responseStream: call.ClientStreamReader,
-                responseHeadersAsync: call.GetResponseHeadersAsync(),
-                getStatusFunc: call.GetStatus,
-                getTrailersFunc: call.GetTrailers,
-                disposeAction: call.Dispose);
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
+                getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
+                disposeAction: Callbacks<TRequest, TResponse>.Dispose,
+                call);
         }
 
         /// <summary>
@@ -98,10 +102,11 @@ namespace Grpc.Net.Client.Internal
 
             return new AsyncUnaryCall<TResponse>(
                 responseAsync: call.GetResponseAsync(),
-                responseHeadersAsync: call.GetResponseHeadersAsync(),
-                getStatusFunc: call.GetStatus,
-                getTrailersFunc: call.GetTrailers,
-                disposeAction: call.Dispose);
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
+                getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
+                disposeAction: Callbacks<TRequest, TResponse>.Dispose,
+                call);
         }
 
         /// <summary>
@@ -128,6 +133,17 @@ namespace Grpc.Net.Client.Internal
             var call = new GrpcCall<TRequest, TResponse>(method, methodInfo, options, Channel);
 
             return call;
+        }
+
+        // Store static callbacks so delegates are allocated once
+        private static class Callbacks<TRequest, TResponse>
+            where TRequest : class
+            where TResponse : class
+        {
+            internal static readonly Func<object, Task<Metadata>> GetResponseHeaders = state => ((GrpcCall<TRequest, TResponse>)state).GetResponseHeadersAsync();
+            internal static readonly Func<object, Status> GetStatus = state => ((GrpcCall<TRequest, TResponse>)state).GetStatus();
+            internal static readonly Func<object, Metadata> GetTrailers = state => ((GrpcCall<TRequest, TResponse>)state).GetTrailers();
+            internal static readonly Action<object> Dispose = state => ((GrpcCall<TRequest, TResponse>)state).Dispose();
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -47,7 +47,7 @@ namespace Grpc.Net.Client.Internal
             return new AsyncClientStreamingCall<TRequest, TResponse>(
                 requestStream: call.ClientStreamWriter,
                 responseAsync: call.GetResponseAsync(),
-                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeadersAsync,
                 getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
                 getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
                 disposeAction: Callbacks<TRequest, TResponse>.Dispose,
@@ -67,7 +67,7 @@ namespace Grpc.Net.Client.Internal
             return new AsyncDuplexStreamingCall<TRequest, TResponse>(
                 requestStream: call.ClientStreamWriter,
                 responseStream: call.ClientStreamReader,
-                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeadersAsync,
                 getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
                 getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
                 disposeAction: Callbacks<TRequest, TResponse>.Dispose,
@@ -85,7 +85,7 @@ namespace Grpc.Net.Client.Internal
 
             return new AsyncServerStreamingCall<TResponse>(
                 responseStream: call.ClientStreamReader,
-                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeadersAsync,
                 getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
                 getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
                 disposeAction: Callbacks<TRequest, TResponse>.Dispose,
@@ -102,7 +102,7 @@ namespace Grpc.Net.Client.Internal
 
             return new AsyncUnaryCall<TResponse>(
                 responseAsync: call.GetResponseAsync(),
-                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeaders,
+                responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeadersAsync,
                 getStatusFunc: Callbacks<TRequest, TResponse>.GetStatus,
                 getTrailersFunc: Callbacks<TRequest, TResponse>.GetTrailers,
                 disposeAction: Callbacks<TRequest, TResponse>.Dispose,
@@ -140,7 +140,7 @@ namespace Grpc.Net.Client.Internal
             where TRequest : class
             where TResponse : class
         {
-            internal static readonly Func<object, Task<Metadata>> GetResponseHeaders = state => ((GrpcCall<TRequest, TResponse>)state).GetResponseHeadersAsync();
+            internal static readonly Func<object, Task<Metadata>> GetResponseHeadersAsync = state => ((GrpcCall<TRequest, TResponse>)state).GetResponseHeadersAsync();
             internal static readonly Func<object, Status> GetStatus = state => ((GrpcCall<TRequest, TResponse>)state).GetStatus();
             internal static readonly Func<object, Metadata> GetTrailers = state => ((GrpcCall<TRequest, TResponse>)state).GetTrailers();
             internal static readonly Action<object> Dispose = state => ((GrpcCall<TRequest, TResponse>)state).Dispose();


### PR DESCRIPTION
Avoid allocating delegates per call, and only loads Metadata with response headers when response headers are requested by the user.

Will benchmark soon.