### PR TITLE
Explicitly specify ready state text in benchmarks

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/grpc-aspnetcore.json
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/grpc-aspnetcore.json
@@ -8,7 +8,9 @@
       "Repository": "https://github.com/grpc/grpc-dotnet.git",
       "BranchOrCommit": "master",
       "Project": "perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj"
-    }
+    },
+    
+    "ReadyStateText": "Application started."
   },
 
   "GrpcUnary-GrpcCore": {

--- a/perf/benchmarkapps/GrpcCoreServer/grpc-core.json
+++ b/perf/benchmarkapps/GrpcCoreServer/grpc-core.json
@@ -8,7 +8,9 @@
       "Repository": "https://github.com/grpc/grpc-dotnet.git",
       "BranchOrCommit": "master",
       "Project": "perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj"
-    }
+    },
+    
+    "ReadyStateText": "Application started."
   },
 
   "GrpcUnary-GrpcCore": {


### PR DESCRIPTION
There is no longer a default value. Will tell asp.net benchmark runner to look for this text rather than pinging to check for ready state.

@sebastienros