### PR TITLE
Update Grpc.Core.Api and Google.Protobuf dependencies

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <BenchmarkDotNetPackageVersion>0.11.3</BenchmarkDotNetPackageVersion>
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
-    <GoogleProtobufPackageVersion>3.10.0</GoogleProtobufPackageVersion>
+    <GoogleProtobufPackageVersion>3.11.2</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.25.0</GrpcDotNetPackageVersion>  <!-- Only use for example projects -->
-    <GrpcPackageVersion>2.27.0-dev202001131222</GrpcPackageVersion>
+    <GrpcPackageVersion>2.27.0-pre1</GrpcPackageVersion>
     <MicrosoftAspNetCorePackageVersion>3.0.0</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreBlazorPackageVersion>3.1.0-preview4.19579.2</MicrosoftAspNetCoreBlazorPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>


### PR DESCRIPTION
Update to 2.27.0-pre1 on NuGet