### PR TITLE
Fix error when client has a very large deadline

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -54,7 +54,7 @@ namespace Grpc.Net.Client
         internal bool Disposed { get; private set; }
         // Timing related options that are set in unit tests
         internal ISystemClock Clock = SystemClock.Instance;
-        internal bool DisableClientDeadlineTimer;
+        internal bool DisableClientDeadline;
         internal long MaxTimerDueTime = uint.MaxValue - 1; // Max System.Threading.Timer due time
 
         private bool _shouldDisposeHttpClient;

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -54,7 +54,8 @@ namespace Grpc.Net.Client
         internal bool Disposed { get; private set; }
         // Timing related options that are set in unit tests
         internal ISystemClock Clock = SystemClock.Instance;
-        internal bool DisableClientDeadlineTimer { get; set; }
+        internal bool DisableClientDeadlineTimer;
+        internal long MaxTimerDueTime = uint.MaxValue - 1; // Max System.Threading.Timer due time
 
         private bool _shouldDisposeHttpClient;
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -756,8 +756,12 @@ namespace Grpc.Net.Client.Internal
         {
             // Timer has a maximum allowed due time.
             // The called method will rechedule the timer if the deadline time has not passed.
-            var milliseconds = timeout.Ticks / TimeSpan.TicksPerMillisecond;
-            return Math.Min(milliseconds, Channel.MaxTimerDueTime);
+            var dueTimeMilliseconds = timeout.Ticks / TimeSpan.TicksPerMillisecond;
+            dueTimeMilliseconds = Math.Min(dueTimeMilliseconds, Channel.MaxTimerDueTime);
+            // Timer can't have a negative due time
+            dueTimeMilliseconds = Math.Max(dueTimeMilliseconds, 0);
+
+            return dueTimeMilliseconds;
         }
 
         private TimeSpan? GetTimeout()

--- a/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
@@ -93,6 +93,12 @@ namespace Grpc.Net.Client.Internal
         private static readonly Action<ILogger, string, Exception?> _decompressingMessage =
             LoggerMessage.Define<string>(LogLevel.Trace, new EventId(23, "DecompressingMessage"), "Decompressing message with '{MessageEncoding}' encoding.");
 
+        private static readonly Action<ILogger, TimeSpan, Exception?> _deadlineTimeoutTooLong =
+            LoggerMessage.Define<TimeSpan>(LogLevel.Debug, new EventId(24, "DeadlineTimeoutTooLong"), "Deadline timeout {Timeout} is above maximum allowed timeout of 99999999 seconds. Maximum timeout will be used.");
+
+        private static readonly Action<ILogger, TimeSpan, Exception?> _deadlineTimerRescheduled =
+            LoggerMessage.Define<TimeSpan>(LogLevel.Trace, new EventId(25, "DeadlineTimerRescheduled"), "Deadline timer triggered but {Remaining} remaining before deadline exceeded. Deadline timer rescheduled.");
+
         public static void StartingCall(ILogger logger, MethodType methodType, Uri uri)
         {
             _startingCall(logger, methodType, uri, null);
@@ -206,6 +212,16 @@ namespace Grpc.Net.Client.Internal
         public static void DecompressingMessage(ILogger logger, string messageEncoding)
         {
             _decompressingMessage(logger, messageEncoding, null);
+        }
+
+        public static void DeadlineTimeoutTooLong(ILogger logger, TimeSpan timeout)
+        {
+            _deadlineTimeoutTooLong(logger, timeout, null);
+        }
+
+        public static void DeadlineTimerRescheduled(ILogger logger, TimeSpan remaining)
+        {
+            _deadlineTimerRescheduled(logger, remaining, null);
         }
     }
 }

--- a/test/FunctionalTests/Client/EventSourceTests.cs
+++ b/test/FunctionalTests/Client/EventSourceTests.cs
@@ -201,7 +201,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
                 var channel = CreateChannel();
                 channel.Clock = clock;
-                channel.DisableClientDeadlineTimer = true;
+                channel.DisableClientDeadline = true;
 
                 var client = TestClientFactory.Create(channel, method);
 

--- a/test/FunctionalTests/Client/MaxMessageSizeTests.cs
+++ b/test/FunctionalTests/Client/MaxMessageSizeTests.cs
@@ -61,7 +61,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             var method = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(ReturnLargeMessage);
 
             var channel = CreateChannel();
-            channel.DisableClientDeadlineTimer = true;
+            channel.DisableClientDeadline = true;
 
             var client = TestClientFactory.Create(channel, method);
 

--- a/test/Grpc.Net.Client.Tests/DeadlineTests.cs
+++ b/test/Grpc.Net.Client.Tests/DeadlineTests.cs
@@ -27,6 +27,8 @@ using Grpc.Core;
 using Grpc.Net.Client.Internal;
 using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using NUnit.Framework;
 
 namespace Grpc.Net.Client.Tests
@@ -83,6 +85,37 @@ namespace Grpc.Net.Client.Tests
         }
 
         [Test]
+        public async Task AsyncUnaryCall_SetVeryLargeDeadline_MaximumDeadlineTimeoutSent()
+        {
+            // Arrange
+            var testSink = new TestSink();
+            var testLoggerFactory = new TestLoggerFactory(testSink, true);
+
+            HttpRequestMessage? httpRequestMessage = null;
+
+            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            {
+                httpRequestMessage = request;
+
+                var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent);
+            });
+            var testSystemClock = new TestSystemClock(DateTime.UtcNow);
+            var deadline = testSystemClock.UtcNow.AddDays(2000);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, loggerFactory: testLoggerFactory, systemClock: testSystemClock);
+
+            // Act
+            await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: deadline), new HelloRequest());
+
+            // Assert
+            Assert.IsNotNull(httpRequestMessage);
+            Assert.AreEqual("99999999S", httpRequestMessage!.Headers.GetValues(GrpcProtocolConstants.TimeoutHeader).Single());
+
+            var s = testSink.Writes.SingleOrDefault(w => w.EventId.Name == "DeadlineTimeoutTooLong");
+            Assert.AreEqual("Deadline timeout 2000.00:00:00 is above maximum allowed timeout of 99999999 seconds. Maximum timeout will be used.", s.Message);
+        }
+
+        [Test]
         public async Task AsyncUnaryCall_SendDeadlineHeaderAndDeadlineValue_DeadlineValueIsUsed()
         {
             // Arrange
@@ -131,12 +164,16 @@ namespace Grpc.Net.Client.Tests
             });
             var testSystemClock = new TestSystemClock(DateTime.UtcNow);
             var invoker = HttpClientCallInvokerFactory.Create(httpClient, systemClock: testSystemClock);
+            var deadline = testSystemClock.UtcNow.AddSeconds(0.1);
 
             // Act
-            var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: testSystemClock.UtcNow.AddSeconds(0.5)));
+            var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: deadline));
 
             // Assert
             var responseTask = call.ResponseAsync;
+
+            // Update time so deadline exceeds correctly
+            testSystemClock.UtcNow = deadline;
 
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => responseTask).DefaultTimeout();
             Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
@@ -156,12 +193,16 @@ namespace Grpc.Net.Client.Tests
             });
             var testSystemClock = new TestSystemClock(DateTime.UtcNow);
             var invoker = HttpClientCallInvokerFactory.Create(httpClient, systemClock: testSystemClock, configure: o => o.ThrowOperationCanceledOnCancellation = true);
+            var deadline = testSystemClock.UtcNow.AddSeconds(0.1);
 
             // Act
-            var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: testSystemClock.UtcNow.AddSeconds(0.5)));
+            var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: deadline));
 
             // Assert
             var responseTask = call.ResponseAsync;
+
+            // Update time so deadline exceeds correctly
+            testSystemClock.UtcNow = deadline;
 
             await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => responseTask).DefaultTimeout();
             Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
@@ -269,7 +310,9 @@ namespace Grpc.Net.Client.Tests
             // Act
             var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: systemClock.UtcNow.AddMilliseconds(10)));
 
-            await Task.Delay(200); // Ensure the deadline has passed
+            // Ensure the deadline has passed
+            systemClock.UtcNow = systemClock.UtcNow.AddMilliseconds(200);
+            await Task.Delay(200);
 
             // Assert
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.RequestStream.WriteAsync(new HelloRequest())).DefaultTimeout();
@@ -289,9 +332,12 @@ namespace Grpc.Net.Client.Tests
             });
             var systemClock = new TestSystemClock(DateTime.UtcNow);
             var invoker = HttpClientCallInvokerFactory.Create(httpClient, systemClock: systemClock);
+            var deadline = systemClock.UtcNow.AddMilliseconds(0.1);
 
             // Act
-            var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: systemClock.UtcNow.AddMilliseconds(10)));
+            var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: deadline));
+
+            systemClock.UtcNow = deadline;
 
             // Assert
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.RequestStream.WriteAsync(new HelloRequest())).DefaultTimeout();
@@ -368,6 +414,45 @@ namespace Grpc.Net.Client.Tests
             Assert.AreEqual("Deadline must have a kind DateTimeKind.Utc or be equal to DateTime.MaxValue or DateTime.MinValue.", ex.Message);
         }
 
+        [Test]
+        public async Task AsyncClientStreamingCall_DeadlineLargerThanMaxTimerDueTime_DeadlineExceeded()
+        {
+            // Arrange
+            var testSink = new TestSink();
+            var testLoggerFactory = new TestLoggerFactory(testSink, true);
+
+            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            {
+                var content = (PushStreamContent<HelloRequest, HelloReply>)request.Content;
+                await content.PushComplete.DefaultTimeout();
+
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK);
+            });
+            var testSystemClock = new TestSystemClock(DateTime.UtcNow);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, systemClock: testSystemClock, maxTimerPeriod: 20, loggerFactory: testLoggerFactory);
+            var timeout = TimeSpan.FromSeconds(0.2);
+            var deadline = testSystemClock.UtcNow.Add(timeout);
+
+            // Act
+            var call = invoker.AsyncClientStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: deadline));
+
+            // Assert
+            var responseTask = call.ResponseAsync;
+
+            await Task.Delay(timeout);
+
+            // Update time so deadline exceeds correctly
+            testSystemClock.UtcNow = deadline;
+
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => responseTask).DefaultTimeout();
+            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
+            Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+
+            var write = testSink.Writes.First(w => w.EventId.Name == "DeadlineTimerRescheduled");
+            Assert.AreEqual(LogLevel.Trace, write.LogLevel);
+            Assert.AreEqual("Deadline timer triggered but 00:00:00.2000000 remaining before deadline exceeded. Deadline timer rescheduled.", write.Message);
+        }
+
         private class TestSystemClock : ISystemClock
         {
             public TestSystemClock(DateTime utcNow)
@@ -375,7 +460,7 @@ namespace Grpc.Net.Client.Tests
                 UtcNow = utcNow;
             }
 
-            public DateTime UtcNow { get; }
+            public DateTime UtcNow { get; set; }
         }
     }
 }

--- a/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
@@ -30,7 +30,8 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             ILoggerFactory? loggerFactory = null,
             ISystemClock? systemClock = null,
             Action<GrpcChannelOptions>? configure = null,
-            bool? disableClientDeadlineTimer = null)
+            bool? disableClientDeadlineTimer = null,
+            long? maxTimerPeriod = null)
         {
             var channelOptions = new GrpcChannelOptions
             {
@@ -44,6 +45,10 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             if (disableClientDeadlineTimer != null)
             {
                 channel.DisableClientDeadlineTimer = disableClientDeadlineTimer.Value;
+            }
+            if (maxTimerPeriod != null)
+            {
+                channel.MaxTimerDueTime = maxTimerPeriod.Value;
             }
 
             return new HttpClientCallInvoker(channel);

--- a/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
@@ -30,7 +30,7 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             ILoggerFactory? loggerFactory = null,
             ISystemClock? systemClock = null,
             Action<GrpcChannelOptions>? configure = null,
-            bool? disableClientDeadlineTimer = null,
+            bool? disableClientDeadline = null,
             long? maxTimerPeriod = null)
         {
             var channelOptions = new GrpcChannelOptions
@@ -42,9 +42,9 @@ namespace Grpc.Net.Client.Tests.Infrastructure
 
             var channel = GrpcChannel.ForAddress(httpClient.BaseAddress, channelOptions);
             channel.Clock = systemClock ?? SystemClock.Instance;
-            if (disableClientDeadlineTimer != null)
+            if (disableClientDeadline != null)
             {
-                channel.DisableClientDeadlineTimer = disableClientDeadlineTimer.Value;
+                channel.DisableClientDeadline = disableClientDeadline.Value;
             }
             if (maxTimerPeriod != null)
             {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/751

@shshzi I ended up using the solution you suggested. There is a limit of 99999999 seconds that matches what I found in Grpc.Core.

Also makes the calls with a past deadline fail immediately, without sending a HTTP request to the server. @jtattermusch I saw that behavior in ccore but it would be great if you could confirm that is how gRPC clients handle starting a call with a deadline that has already past.