### PR TITLE
Support large deadlines on the server

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/Deadline/DefaultServerCallDeadlineManager.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/Deadline/DefaultServerCallDeadlineManager.cs
@@ -1,0 +1,35 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading;
+
+namespace Grpc.AspNetCore.Server.Internal
+{
+    internal class DefaultServerCallDeadlineManager : ServerCallDeadlineManager
+    {
+        public DefaultServerCallDeadlineManager(HttpContextServerCallContext serverCallContext) : base(serverCallContext)
+        {
+        }
+
+        protected override CancellationTokenSource CreateCancellationTokenSource(TimeSpan timeout, ISystemClock clock)
+        {
+            return new CancellationTokenSource(timeout);
+        }
+    }
+}

--- a/src/Grpc.AspNetCore.Server/Internal/Deadline/LongTimeoutServerCallDeadlineManager.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/Deadline/LongTimeoutServerCallDeadlineManager.cs
@@ -1,0 +1,72 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading;
+
+namespace Grpc.AspNetCore.Server.Internal
+{
+    internal class LongTimeoutServerCallDeadlineManager : ServerCallDeadlineManager
+    {
+        private Timer? _longDeadlineTimer;
+        private ISystemClock? _systemClock;
+        // Internal for unit testing
+        internal long MaxTimerDueTime = uint.MaxValue - 1; // Max System.Threading.Timer due time
+
+        public LongTimeoutServerCallDeadlineManager(HttpContextServerCallContext serverCallContext) : base(serverCallContext)
+        {
+        }
+
+        protected override CancellationTokenSource CreateCancellationTokenSource(TimeSpan timeout, ISystemClock clock)
+        {
+            _systemClock = clock;
+            _longDeadlineTimer = new Timer(DeadlineExceededCallback, null, GetTimerDueTime(timeout), Timeout.Infinite);
+
+            return new CancellationTokenSource();
+        }
+
+        private void DeadlineExceededCallback(object? state)
+        {
+            var remaining = Deadline - _systemClock!.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+            {
+                DeadlineExceeded();
+            }
+            else
+            {
+                // Deadline has not been reached because timer maximum due time was smaller than deadline.
+                // Reschedule DeadlineExceeded again until deadline has been exceeded.
+                GrpcServerLog.DeadlineTimerRescheduled(ServerCallContext.Logger, remaining);
+
+                _longDeadlineTimer!.Change(GetTimerDueTime(remaining), Timeout.Infinite);
+            }
+        }
+
+        private long GetTimerDueTime(TimeSpan timeout)
+        {
+            // Timer has a maximum allowed due time.
+            // The called method will rechedule the timer if the deadline time has not passed.
+            var dueTimeMilliseconds = timeout.Ticks / TimeSpan.TicksPerMillisecond;
+            dueTimeMilliseconds = Math.Min(dueTimeMilliseconds, MaxTimerDueTime);
+            // Timer can't have a negative due time
+            dueTimeMilliseconds = Math.Max(dueTimeMilliseconds, 0);
+
+            return dueTimeMilliseconds;
+        }
+    }
+}

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
@@ -57,5 +57,9 @@ namespace Grpc.AspNetCore.Server.Internal
         internal const string X509SubjectAlternativeNameId = "2.5.29.17";
         internal const string X509SubjectAlternativeNameKey = "x509_subject_alternative_name";
         internal const string X509CommonNameKey = "x509_common_name";
+
+        // Maxmimum deadline of 99999999s is consistent with Grpc.Core
+        // https://github.com/grpc/grpc/blob/907a1313a87723774bf59d04ed432602428245c3/src/core/lib/transport/timeout_encoding.h#L32-L34
+        internal const long MaxDeadlineTicks = 99999999 * TimeSpan.TicksPerSecond;
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServerLog.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServerLog.cs
@@ -93,6 +93,12 @@ namespace Grpc.AspNetCore.Server.Internal
         private static readonly Action<ILogger, Exception?> _unhandledCorsPreflightRequest =
            LoggerMessage.Define(LogLevel.Information, new EventId(23, "UnhandledCorsPreflightRequest"), "Unhandled CORS preflight request received. CORS may not be configured correctly in the application.");
 
+        private static readonly Action<ILogger, TimeSpan, Exception?> _deadlineTimeoutTooLong =
+            LoggerMessage.Define<TimeSpan>(LogLevel.Debug, new EventId(24, "DeadlineTimeoutTooLong"), "Deadline timeout {Timeout} is above maximum allowed timeout of 99999999 seconds. Maximum timeout will be used.");
+
+        private static readonly Action<ILogger, TimeSpan, Exception?> _deadlineTimerRescheduled =
+            LoggerMessage.Define<TimeSpan>(LogLevel.Trace, new EventId(25, "DeadlineTimerRescheduled"), "Deadline timer triggered but {Remaining} remaining before deadline exceeded. Deadline timer rescheduled.");
+
         public static void DeadlineExceeded(ILogger logger, TimeSpan timeout)
         {
             _deadlineExceeded(logger, timeout, null);
@@ -206,6 +212,16 @@ namespace Grpc.AspNetCore.Server.Internal
         public static void UnhandledCorsPreflightRequest(ILogger logger)
         {
             _unhandledCorsPreflightRequest(logger, null);
+        }
+
+        public static void DeadlineTimeoutTooLong(ILogger logger, TimeSpan timeout)
+        {
+            _deadlineTimeoutTooLong(logger, timeout, null);
+        }
+
+        public static void DeadlineTimerRescheduled(ILogger logger, TimeSpan remaining)
+        {
+            _deadlineTimerRescheduled(logger, remaining, null);
         }
     }
 }

--- a/test/Grpc.AspNetCore.Server.Tests/Infrastructure/TestSystemClock.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/Infrastructure/TestSystemClock.cs
@@ -1,0 +1,33 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.AspNetCore.Server.Internal;
+
+namespace Grpc.AspNetCore.Server.Tests.Infrastructure
+{
+    public class TestSystemClock : ISystemClock
+    {
+        public TestSystemClock(DateTime utcNow)
+        {
+            UtcNow = utcNow;
+        }
+
+        public DateTime UtcNow { get; set; }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/LongTimeoutServerCallDeadlineManagerTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/LongTimeoutServerCallDeadlineManagerTests.cs
@@ -1,0 +1,120 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.Server.Internal;
+using Grpc.AspNetCore.Server.Tests.Infrastructure;
+using Grpc.Core;
+using Grpc.Tests.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.Server.Tests
+{
+    [TestFixture]
+    public class LongTimeoutServerCallDeadlineManagerTests
+    {
+        [Test]
+        public async Task SmallDeadline_DeadlineExceededWithoutReschedule()
+        {
+            // Arrange
+            var testSink = new TestSink();
+            var testLogger = new TestLogger(string.Empty, testSink, true);
+
+            var testSystemClock = new TestSystemClock(DateTime.UtcNow);
+            var timeout = TimeSpan.FromMilliseconds(100);
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers[GrpcProtocolConstants.TimeoutHeader] = "100m";
+            var context = CreateServerCallContext(httpContext, testLogger);
+
+            var manager = new LongTimeoutServerCallDeadlineManager(context);
+
+            // Act
+            manager.Initialize(testSystemClock, timeout, CancellationToken.None);
+
+            // Assert
+            var assertTask = TestHelpers.AssertIsTrueRetryAsync(
+              () => context.Status.StatusCode == StatusCode.DeadlineExceeded,
+              "StatusCode not set to DeadlineExceeded.");
+
+            testSystemClock.UtcNow = testSystemClock.UtcNow.Add(timeout);
+
+            await assertTask.DefaultTimeout();
+
+            var write = testSink.Writes.Single(w => w.EventId.Name == "DeadlineExceeded");
+            Assert.AreEqual("Request with timeout of 00:00:00.1000000 has exceeded its deadline.", write.Message);
+
+            Assert.IsFalse(testSink.Writes.Any(w => w.EventId.Name == "DeadlineTimerRescheduled"));
+        }
+
+        [Test]
+        public async Task LargeDeadline_DeadlineExceededWithReschedule()
+        {
+            // Arrange
+            var testSink = new TestSink();
+            var testLogger = new TestLogger(string.Empty, testSink, true);
+
+            var testSystemClock = new TestSystemClock(DateTime.UtcNow);
+            var timeout = TimeSpan.FromMilliseconds(100);
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers[GrpcProtocolConstants.TimeoutHeader] = "100m";
+            var context = CreateServerCallContext(httpContext, testLogger);
+
+            var manager = new LongTimeoutServerCallDeadlineManager(context);
+            manager.MaxTimerDueTime = 5;
+
+            // Act
+            manager.Initialize(testSystemClock, timeout, CancellationToken.None);
+
+            // Assert
+            var assertTask = TestHelpers.AssertIsTrueRetryAsync(
+              () => context.Status.StatusCode == StatusCode.DeadlineExceeded,
+              "StatusCode not set to DeadlineExceeded.");
+
+            await Task.Delay(timeout);
+            testSystemClock.UtcNow = testSystemClock.UtcNow.Add(timeout);
+
+            await assertTask.DefaultTimeout();
+
+            var write = testSink.Writes.Single(w => w.EventId.Name == "DeadlineExceeded");
+            Assert.AreEqual("Request with timeout of 00:00:00.1000000 has exceeded its deadline.", write.Message);
+
+            Assert.IsTrue(testSink.Writes.Any(w => w.EventId.Name == "DeadlineTimerRescheduled"));
+        }
+
+        private HttpContextServerCallContext CreateServerCallContext(HttpContext httpContext, ILogger? logger = null)
+        {
+            return HttpContextServerCallContextHelper.CreateServerCallContext(
+                httpContext: httpContext,
+                logger: logger,
+                initialize: false);
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/grpc/grpc-dotnet/issues/751

Before: 24~ day maximum deadline
After: 1050~ day maximum deadline

Supported deadline size is now comparable to ccore