### PR TITLE
Complete activity and log before returning result in client

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -144,7 +144,7 @@ namespace Grpc.Net.Client.Internal
         /// Clean up can be called by:
         /// 1. The user. AsyncUnaryCall.Dispose et al will call this on Dispose
         /// 2. <see cref="ValidateHeaders"/> will call dispose if errors fail validation
-        /// 3. <see cref="FinishResponse"/> will call dispose
+        /// 3. <see cref="FinishResponseAndCleanUp"/> will call dispose
         /// </summary>
         private void Cleanup(Status status)
         {
@@ -194,13 +194,7 @@ namespace Grpc.Net.Client.Internal
             return CreateRpcException(status);
         }
         
-        /// <summary>
-        /// Marks the response as finished, i.e. all response content has been read and trailers are available.
-        /// Can be called by <see cref="GetResponseAsync"/> for unary and client streaming calls, or
-        /// <see cref="HttpContentClientStreamReader{TRequest,TResponse}.MoveNextCore(CancellationToken)"/>
-        /// for server streaming and duplex streaming calls.
-        /// </summary>
-        public void FinishResponse(Status status)
+        private void FinishResponseAndCleanUp(Status status)
         {
             ResponseFinished = true;
 
@@ -208,6 +202,15 @@ namespace Grpc.Net.Client.Internal
             // Call may not be explicitly disposed when used with unary methods
             // e.g. var reply = await client.SayHelloAsync(new HelloRequest());
             Cleanup(status);
+        }
+
+        /// <summary>
+        /// Used by client stream to report it is finished.
+        /// </summary>
+        /// <param name="status">The completed response status code.</param>
+        public void ClientStreamEnded(Status status)
+        {
+            _callTcs.TrySetResult(status);
         }
 
         public Task<Metadata> GetResponseHeadersAsync()
@@ -429,6 +432,9 @@ namespace Grpc.Net.Client.Internal
                     await ReadCredentials(request).ConfigureAwait(false);
                 }
 
+                // Unset variable to check that FinishCall is called in every code path
+                bool finished;
+
                 Status? status = null;
 
                 try
@@ -457,6 +463,7 @@ namespace Grpc.Net.Client.Internal
                             // gRPC status in the header
                             if (status.Value.StatusCode != StatusCode.OK)
                             {
+                                finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
                                 SetFailedResult(status.Value);
                             }
                             else
@@ -464,11 +471,18 @@ namespace Grpc.Net.Client.Internal
                                 // The server should never return StatusCode.OK in the header for a unary call.
                                 // If it does then throw an error that no message was returned from the server.
                                 GrpcCallLog.MessageNotReturned(Logger);
+
+                                finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
                                 _responseTcs.TrySetException(new InvalidOperationException("Call did not return a response message."));
                             }
-                        }
 
-                        FinishResponse(status.Value);
+                            FinishResponseAndCleanUp(status.Value);
+                        }
+                        else
+                        {
+                            finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
+                            FinishResponseAndCleanUp(status.Value);
+                        }
                     }
                     else
                     {
@@ -486,16 +500,20 @@ namespace Grpc.Net.Client.Internal
                                 singleMessage: true,
                                 _callCts.Token).ConfigureAwait(false);
                             status = GrpcProtocolHelpers.GetResponseStatus(HttpResponse);
-                            FinishResponse(status.Value);
+                            FinishResponseAndCleanUp(status.Value);
 
                             if (message == null)
                             {
                                 GrpcCallLog.MessageNotReturned(Logger);
+
+                                finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
                                 SetFailedResult(status.Value);
                             }
                             else
                             {
                                 GrpcEventSource.Log.MessageReceived();
+
+                                finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
 
                                 if (status.Value.StatusCode == StatusCode.OK)
                                 {
@@ -516,6 +534,9 @@ namespace Grpc.Net.Client.Internal
                             // Wait until the response has been read and status read from trailers.
                             // TCS will also be set in Dispose.
                             status = await CallTask.ConfigureAwait(false);
+
+                            finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
+                            FinishResponseAndCleanUp(status.Value);
                         }
                     }
                 }
@@ -524,16 +545,19 @@ namespace Grpc.Net.Client.Internal
                     Exception resolvedException;
                     ResolveException(ex, out status, out resolvedException);
 
+                    finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
                     _responseTcs?.TrySetException(resolvedException);
 
-                    Cleanup(status!.Value);
+                    Cleanup(status.Value);
                 }
 
-                FinishCall(request, diagnosticSourceEnabled, activity, status);
+                // Verify that FinishCall is called in every code path of this method.
+                // Should create an "Unassigned variable" compiler error if not set.
+                Debug.Assert(finished);
             }
         }
 
-        private void ResolveException(Exception ex, out Status? status, out Exception resolvedException)
+        private void ResolveException(Exception ex, [NotNull] out Status? status, out Exception resolvedException)
         {
             if (ex is OperationCanceledException)
             {
@@ -647,7 +671,7 @@ namespace Grpc.Net.Client.Internal
             return (diagnosticSourceEnabled, activity);
         }
 
-        private void FinishCall(HttpRequestMessage request, bool diagnosticSourceEnabled, Activity? activity, Status? status)
+        private bool FinishCall(HttpRequestMessage request, bool diagnosticSourceEnabled, Activity? activity, Status? status)
         {
             if (status!.Value.StatusCode != StatusCode.OK)
             {
@@ -680,6 +704,8 @@ namespace Grpc.Net.Client.Internal
 
                 activity.Stop();
             }
+
+            return true;
         }
 
         private async Task ReadCredentials(HttpRequestMessage request)

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -205,10 +205,10 @@ namespace Grpc.Net.Client.Internal
         }
 
         /// <summary>
-        /// Used by client stream to report it is finished.
+        /// Used by response stream reader to report it is finished.
         /// </summary>
         /// <param name="status">The completed response status code.</param>
-        public void ClientStreamEnded(Status status)
+        public void ResponseStreamEnded(Status status)
         {
             _callTcs.TrySetResult(status);
         }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -170,9 +170,10 @@ namespace Grpc.Net.Client.Internal
                     cancellationToken).ConfigureAwait(false);
                 if (Current == null)
                 {
-                    // No more content in response so mark as finished
+                    // No more content in response so report status to call.
+                    // The call will handle finishing the response.
                     var status = GrpcProtocolHelpers.GetResponseStatus(_httpResponse);
-                    _call.FinishResponse(status);
+                    _call.ClientStreamEnded(status);
                     if (status.StatusCode != StatusCode.OK)
                     {
                         throw _call.CreateFailureStatusException(status);

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -173,7 +173,7 @@ namespace Grpc.Net.Client.Internal
                     // No more content in response so report status to call.
                     // The call will handle finishing the response.
                     var status = GrpcProtocolHelpers.GetResponseStatus(_httpResponse);
-                    _call.ClientStreamEnded(status);
+                    _call.ResponseStreamEnded(status);
                     if (status.StatusCode != StatusCode.OK)
                     {
                         throw _call.CreateFailureStatusException(status);

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -145,8 +145,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                // Kestrel cancellation error message
-                if (writeContext.Exception is IOException &&
+                    // Kestrel cancellation error message
+                    if (writeContext.Exception is IOException &&
                     writeContext.Exception.Message == "The client reset the request stream.")
                 {
                     return true;
@@ -159,8 +159,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                     return true;
                 }
 
-                // Ignore all logging related errors for now
-                return false;
+                    // Ignore all logging related errors for now
+                    return false;
             });
 
             var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingCall);

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -145,9 +145,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             // Arrange
             SetExpectedErrorsFilter(writeContext =>
             {
-                    // Kestrel cancellation error message
-                    if (writeContext.Exception is IOException &&
-                    writeContext.Exception.Message == "The client reset the request stream.")
+                // Kestrel cancellation error message
+                if (writeContext.Exception is IOException &&
+                writeContext.Exception.Message == "The client reset the request stream.")
                 {
                     return true;
                 }
@@ -159,8 +159,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                     return true;
                 }
 
-                    // Ignore all logging related errors for now
-                    return false;
+                // Ignore all logging related errors for now
+                return false;
             });
 
             var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingCall);

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -147,7 +147,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             {
                 // Kestrel cancellation error message
                 if (writeContext.Exception is IOException &&
-                writeContext.Exception.Message == "The client reset the request stream.")
+                    writeContext.Exception.Message == "The client reset the request stream.")
                 {
                     return true;
                 }

--- a/test/FunctionalTests/Client/TrailerMetadataTests.cs
+++ b/test/FunctionalTests/Client/TrailerMetadataTests.cs
@@ -120,5 +120,104 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             AssertHasLogRpcConnectionError(StatusCode.InvalidArgument, "Validation failed");
         }
+
+        [Test]
+        public async Task GetTrailers_ServerStreamingMethodSetStatusWithTrailers_TrailersAvailableInClient()
+        {
+            async Task UnaryDeadlineExceeded(HelloRequest request, IAsyncStreamWriter<HelloReply> writer, ServerCallContext context)
+            {
+                await writer.WriteAsync(new HelloReply());
+
+                context.ResponseTrailers.Add(new Metadata.Entry("Name", "the value was empty"));
+                context.Status = new Status(StatusCode.InvalidArgument, "Validation failed");
+            }
+
+            // Arrange
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                if (writeContext.LoggerName == "Grpc.Net.Client.Internal.GrpcCall" &&
+                    writeContext.EventId.Name == "ErrorReadingMessage" &&
+                    writeContext.Message == "Error reading message.")
+                {
+                    return true;
+                }
+
+                return false;
+            });
+
+            var method = Fixture.DynamicGrpc.AddServerStreamingMethod<HelloRequest, HelloReply>(UnaryDeadlineExceeded);
+
+            var channel = CreateChannel();
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.ServerStreamingCall(new HelloRequest());
+
+            await call.ResponseStream.MoveNext().DefaultTimeout();
+
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
+
+            // Assert
+            var trailers = call.GetTrailers();
+            Assert.AreEqual(1, trailers.Count);
+            Assert.AreEqual("the value was empty", trailers.Single(m => m.Key == "name").Value);
+
+            Assert.AreEqual(StatusCode.InvalidArgument, ex.StatusCode);
+            Assert.AreEqual("Validation failed", ex.Status.Detail);
+            Assert.AreEqual(1, ex.Trailers.Count);
+            Assert.AreEqual("the value was empty", ex.Trailers.Single(m => m.Key == "name").Value);
+        }
+
+        [Test]
+        public async Task GetTrailers_ServerStreamingMethodThrowsExceptionWithTrailers_TrailersAvailableInClient()
+        {
+            async Task UnaryDeadlineExceeded(HelloRequest request, IAsyncStreamWriter<HelloReply> writer, ServerCallContext context)
+            {
+                await writer.WriteAsync(new HelloReply());
+
+                var trailers = new Metadata();
+                trailers.Add(new Metadata.Entry("Name", "the value was empty"));
+                throw new RpcException(new Status(StatusCode.InvalidArgument, "Validation failed"), trailers);
+            }
+
+            // Arrange
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                if (writeContext.LoggerName == "Grpc.Net.Client.Internal.GrpcCall" &&
+                    writeContext.EventId.Name == "ErrorReadingMessage" &&
+                    writeContext.Message == "Error reading message.")
+                {
+                    return true;
+                }
+
+                return false;
+            });
+
+            var method = Fixture.DynamicGrpc.AddServerStreamingMethod<HelloRequest, HelloReply>(UnaryDeadlineExceeded);
+
+            var channel = CreateChannel();
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.ServerStreamingCall(new HelloRequest());
+
+            await call.ResponseStream.MoveNext().DefaultTimeout();
+
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
+
+            // Assert
+            var trailers = call.GetTrailers();
+            Assert.GreaterOrEqual(trailers.Count, 1);
+            Assert.AreEqual("the value was empty", trailers.Single(m => m.Key == "name").Value);
+
+            Assert.AreEqual(StatusCode.InvalidArgument, ex.StatusCode);
+            Assert.AreEqual("Validation failed", ex.Status.Detail);
+            Assert.GreaterOrEqual(ex.Trailers.Count, 1);
+            Assert.AreEqual("the value was empty", ex.Trailers.Single(m => m.Key == "name").Value);
+
+            AssertHasLogRpcConnectionError(StatusCode.InvalidArgument, "Validation failed");
+        }
     }
 }

--- a/test/FunctionalTests/Server/CompressionTests.cs
+++ b/test/FunctionalTests/Server/CompressionTests.cs
@@ -178,12 +178,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             readResult = await pipeReader.ReadAsync();
             Assert.AreEqual(1, readResult.Buffer.FirstSpan[0]); // Message is compressed
             var greeting1 = await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader, "gzip").DefaultTimeout();
-            Assert.AreEqual($"Hello 1", greeting1.Message);
+            Assert.AreEqual($"Hello 1", greeting1!.Message);
 
             readResult = await pipeReader.ReadAsync();
             Assert.AreEqual(0, readResult.Buffer.FirstSpan[0]); // Message is uncompressed
             var greeting2 = await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader, "gzip").DefaultTimeout();
-            Assert.AreEqual($"Hello 2", greeting2.Message);
+            Assert.AreEqual($"Hello 2", greeting2!.Message);
 
             var finishedTask = MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader);
             Assert.IsNull(await finishedTask.DefaultTimeout());

--- a/test/FunctionalTests/Server/DuplexStreamingMethodTests.cs
+++ b/test/FunctionalTests/Server/DuplexStreamingMethodTests.cs
@@ -67,7 +67,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             var message1Task = MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader);
             var message1 = await message1Task.DefaultTimeout();
-            Assert.AreEqual("John", message1.Name);
+            Assert.AreEqual("John", message1!.Name);
             Assert.AreEqual("Hello Jill", message1.Message);
 
             var message2Task = MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader);
@@ -84,7 +84,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             await requestStream.FlushAsync().DefaultTimeout();
 
             var message2 = await message2Task.DefaultTimeout();
-            Assert.AreEqual("Jill", message2.Name);
+            Assert.AreEqual("Jill", message2!.Name);
             Assert.AreEqual("Hello John", message2.Message);
 
             var finishedTask = MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader);
@@ -156,11 +156,11 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             var pipeReader = PipeReader.Create(responseStream);
 
             var message1 = await MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader).DefaultTimeout();
-            Assert.AreEqual("John", message1.Name);
+            Assert.AreEqual("John", message1!.Name);
             Assert.AreEqual("Hello Jill", message1.Message);
 
             var message2 = await MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader).DefaultTimeout();
-            Assert.AreEqual("Jill", message2.Name);
+            Assert.AreEqual("Jill", message2!.Name);
             Assert.AreEqual("Hello John", message2.Message);
 
             Assert.IsNull(await MessageHelpers.AssertReadStreamMessageAsync<ChatMessage>(pipeReader).DefaultTimeout());

--- a/test/FunctionalTests/Server/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Server/ServerStreamingMethodTests.cs
@@ -64,12 +64,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
                 var greeting = await greetingTask.DefaultTimeout();
 
-                Assert.AreEqual($"How are you World? {i}", greeting.Message);
+                Assert.AreEqual($"How are you World? {i}", greeting!.Message);
             }
 
             var goodbyeTask = MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader);
             Assert.False(goodbyeTask.IsCompleted);
-            Assert.AreEqual("Goodbye World!", (await goodbyeTask.DefaultTimeout()).Message);
+            Assert.AreEqual("Goodbye World!", (await goodbyeTask.DefaultTimeout())!.Message);
 
             var finishedTask = MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader);
             Assert.IsNull(await finishedTask.DefaultTimeout());
@@ -109,12 +109,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
                 var greeting = await greetingTask.DefaultTimeout();
 
-                Assert.AreEqual($"How are you World? {i}", greeting.Message);
+                Assert.AreEqual($"How are you World? {i}", greeting!.Message);
             }
 
             var goodbyeTask = MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader);
             Assert.False(goodbyeTask.IsCompleted);
-            Assert.AreEqual("Goodbye World!", (await goodbyeTask.DefaultTimeout()).Message);
+            Assert.AreEqual("Goodbye World!", (await goodbyeTask.DefaultTimeout())!.Message);
 
             var finishedTask = MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader);
             Assert.IsNull(await finishedTask.DefaultTimeout());
@@ -160,11 +160,11 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             {
                 var greeting = await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader).DefaultTimeout();
 
-                Assert.AreEqual($"How are you World? {i}", greeting.Message);
+                Assert.AreEqual($"How are you World? {i}", greeting!.Message);
             }
 
             var goodbye = await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader).DefaultTimeout();
-            Assert.AreEqual("Goodbye World!", goodbye.Message);
+            Assert.AreEqual("Goodbye World!", goodbye!.Message);
 
             Assert.IsNull(await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader).DefaultTimeout());
 

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -106,6 +106,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
             Assert.AreEqual("test", call.ResponseStream.Current.Message);
 
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext(CancellationToken.None));
+
+            Logger.LogInformation("Post MoveNext");
+
             Assert.AreEqual(StatusCode.Aborted, ex.StatusCode);
             Assert.AreEqual("Aborted from server side.", ex.Status.Detail);
 

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -111,6 +111,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
 
             Assert.AreEqual(StatusCode.Aborted, call.GetStatus().StatusCode);
 
+            AssertHasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Aborted', Message: 'Aborted from server side.'.");
             AssertHasLogRpcConnectionError(StatusCode.Aborted, "Aborted from server side.");
         }
 

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -107,12 +107,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
 
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext(CancellationToken.None));
 
-            Logger.LogInformation("Post MoveNext");
-
             Assert.AreEqual(StatusCode.Aborted, ex.StatusCode);
             Assert.AreEqual("Aborted from server side.", ex.Status.Detail);
 
             Assert.AreEqual(StatusCode.Aborted, call.GetStatus().StatusCode);
+
+            // It is possible get into a situation where the response stream finishes slightly before the call.
+            // Small delay to ensure call logging is complete.
+            await Task.Delay(50);
 
             AssertHasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Aborted', Message: 'Aborted from server side.'.");
             AssertHasLogRpcConnectionError(StatusCode.Aborted, "Aborted from server side.");

--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -120,7 +120,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.DefaultCompressionProviders,
                 singleMessage: false,
                 CancellationToken.None).AsTask().DefaultTimeout();
-            Assert.AreEqual("1", requestMessage.Name);
+            Assert.AreEqual("1", requestMessage!.Name);
             requestMessage = await requestContent.ReadMessageAsync(
                 NullLogger.Instance,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
@@ -129,7 +129,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.DefaultCompressionProviders,
                 singleMessage: false,
                 CancellationToken.None).AsTask().DefaultTimeout();
-            Assert.AreEqual("2", requestMessage.Name);
+            Assert.AreEqual("2", requestMessage!.Name);
 
             var responseMessage = await responseTask.DefaultTimeout();
             Assert.AreEqual("Hello world", responseMessage.Message);

--- a/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
@@ -125,7 +125,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.DefaultCompressionProviders,
                 singleMessage: false,
                 CancellationToken.None).AsTask().DefaultTimeout();
-            Assert.AreEqual("1", requestMessage.Name);
+            Assert.AreEqual("1", requestMessage!.Name);
             requestMessage = await requestContent.ReadMessageAsync(
                 NullLogger.Instance,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
@@ -134,7 +134,7 @@ namespace Grpc.Net.Client.Tests
                 GrpcProtocolConstants.DefaultCompressionProviders,
                 singleMessage: false,
                 CancellationToken.None).AsTask().DefaultTimeout();
-            Assert.AreEqual("2", requestMessage.Name);
+            Assert.AreEqual("2", requestMessage!.Name);
 
             Assert.IsNull(responseStream.Current);
 

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -120,7 +120,7 @@ namespace Grpc.Net.Client.Tests
                 singleMessage: true,
                 CancellationToken.None).AsTask().DefaultTimeout();
 
-            Assert.AreEqual("World", requestMessage.Name);
+            Assert.AreEqual("World", requestMessage!.Name);
         }
 
         [Test]


### PR DESCRIPTION
The client is currently returning a result to the caller and then completing the activity and logging in the background. Race condition-y side effects of this:
- Caller could start a new activity when the old calls activity is still going
- Caller could check log for failure status and not see it

PR changes client to always finish the call before setting tasks to report to client.