### PR TITLE
Avoid CancellationToken related allocations

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -180,14 +180,14 @@ namespace Grpc.AspNetCore.Server.Internal
             }
 
             // Don't update trailers if request has exceeded deadline/aborted
-            if (!CancellationToken.IsCancellationRequested)
+            if (DeadlineManager == null || !DeadlineManager.CallComplete)
             {
                 HttpContext.Response.ConsolidateTrailers(this);
             }
 
-            LogCallEnd();
+            DeadlineManager?.SetCallEnded();
 
-            DeadlineManager?.SetCallComplete();
+            LogCallEnd();
         }
 
         // If there is a deadline then we need to have our own cancellation token.
@@ -266,14 +266,14 @@ namespace Grpc.AspNetCore.Server.Internal
         private void EndCallCore()
         {
             // Don't set trailers if deadline exceeded or request aborted
-            if (!CancellationToken.IsCancellationRequested)
+            if (DeadlineManager == null || !DeadlineManager.CallComplete)
             {
                 HttpContext.Response.ConsolidateTrailers(this);
             }
 
-            LogCallEnd();
+            DeadlineManager?.SetCallEnded();
 
-            DeadlineManager?.SetCallComplete();
+            LogCallEnd();
         }
 
         private void LogCallEnd()

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -608,7 +608,7 @@ namespace Grpc.AspNetCore.Server.Tests
                 Assert.Fail($"{methodName} did not wait on lock taken by deadline cancellation.");
             }
 
-            Assert.IsFalse(serverCallContext.DeadlineManager!._callComplete);
+            Assert.IsFalse(serverCallContext.DeadlineManager!.CallComplete);
 
             // Wait for dispose to finish
             syncPoint.Continue();
@@ -616,7 +616,7 @@ namespace Grpc.AspNetCore.Server.Tests
 
             Assert.AreEqual(GrpcProtocolConstants.ResetStreamNoError, httpResetFeature.ErrorCode);
 
-            Assert.IsTrue(serverCallContext.DeadlineManager!._callComplete);
+            Assert.IsTrue(serverCallContext.DeadlineManager!.CallComplete);
         }
 
         [Test]


### PR DESCRIPTION
Accessing `HttpContext.RequestAborted` will allocat a cancellation token source for the request. Use flag in deadline manager instead.