### PR TITLE
Fix to ignore unknown methods

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -113,7 +113,7 @@ namespace Grpc.AspNetCore.Server.Internal
         }
 
         public bool IgnoreUnknownServices => _globalOptions.IgnoreUnknownServices ?? false;
-        public bool IgnoreUnknownMethods => _serviceOptions.IgnoreUnknownServices ?? false;
+        public bool IgnoreUnknownMethods => _serviceOptions.IgnoreUnknownServices ?? _globalOptions.IgnoreUnknownServices  ?? false;
 
         public RequestDelegate CreateUnimplementedService()
         {

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -333,7 +333,9 @@ namespace Grpc.AspNetCore.Server.Tests
                 .ToList();
 
             Assert.IsNull(endpoints.SingleOrDefault(e => e.DisplayName == "gRPC - Unimplemented service"));
-            Assert.IsNull(endpoints.SingleOrDefault(e => e.DisplayName == "gRPC - Unimplemented method for GreeterServiceWithMetadataAttributes"));
+            Assert.IsNull(endpoints.SingleOrDefault(e => e.DisplayName == "gRPC - Unimplemented method for greet.Greeter"));
+
+            Assert.AreEqual(0, endpoints.Count(e => e.Metadata.GetMetadata<GrpcMethodMetadata>() == null));
         }
 
         [Test]


### PR DESCRIPTION
Unknown method route was still being registered when global was ignored.