### PR TITLE
Update Grpc.Core and protobuf dependencies

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <BenchmarkDotNetPackageVersion>0.11.3</BenchmarkDotNetPackageVersion>
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
-    <GoogleProtobufPackageVersion>3.11.2</GoogleProtobufPackageVersion>
+    <GoogleProtobufPackageVersion>3.11.4</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.27.0-pre1</GrpcDotNetPackageVersion>  <!-- Only use for example projects -->
-    <GrpcPackageVersion>2.27.0-pre1</GrpcPackageVersion>
+    <GrpcPackageVersion>2.27.0</GrpcPackageVersion>
     <MicrosoftAspNetCorePackageVersion>3.1.2</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreBlazorPackageVersion>3.2.0-preview1.20073.1</MicrosoftAspNetCoreBlazorPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>


### PR DESCRIPTION
After this gets merged, I'm going to cut a new release branch.

@JamesNK @JunTaoLuo  Is there anything that we will need from the v2.28.0-pre1 release of Grpc.Core?