### PR TITLE
Fix GrpcWebHandler not always resetting HTTP version back to 2.0

### DIFF
--- a/examples/Blazor/Server/Program.cs
+++ b/examples/Blazor/Server/Program.cs
@@ -16,9 +16,8 @@
 
 #endregion
 
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace Server
 {
@@ -26,15 +25,14 @@ namespace Server
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseConfiguration(new ConfigurationBuilder()
-                    .AddCommandLine(args)
-                    .Build())
-                .UseStartup<Startup>()
-                .Build();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/examples/Blazor/Server/appsettings.Development.json
+++ b/examples/Blazor/Server/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Grpc": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/examples/Blazor/Server/appsettings.json
+++ b/examples/Blazor/Server/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/805

Note: @jtattermusch I want to fix this on the 2.28 branch.