### PR TITLE
Change server streaming benchmark to reuse response

### DIFF
--- a/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
+++ b/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
@@ -67,7 +67,10 @@ class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
 
     public override async Task StreamingBothWays(IAsyncStreamReader<SimpleRequest> requestStream, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
     {
-        var messageData = ByteString.CopyFrom(new byte[100]);
+        var response = new SimpleResponse
+        {
+            Payload = new Payload { Body = ByteString.CopyFrom(new byte[100]) }
+        };
         var clientComplete = false;
 
         var readTask = Task.Run(async () =>
@@ -83,10 +86,7 @@ class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
         // Write outgoing messages until client is complete
         while (!clientComplete)
         {
-            await responseStream.WriteAsync(new SimpleResponse
-            {
-                Payload = new Payload { Body = messageData }
-            });
+            await responseStream.WriteAsync(response);
         }
 
         await readTask;

--- a/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
+++ b/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
@@ -42,9 +42,10 @@ class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
 
     public override async Task StreamingFromServer(SimpleRequest request, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
     {
+        var response = CreateResponse(request);
         while (!context.CancellationToken.IsCancellationRequested)
         {
-            await responseStream.WriteAsync(CreateResponse(request));
+            await responseStream.WriteAsync(response);
         }
     }
 


### PR DESCRIPTION
Makes the server streaming benchmark consistent with other implementations.

https://github.com/grpc/grpc-java/blob/ad159cea965f2ebec939dc50521272fe3e26f86e/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java#L289