### PR TITLE
Fix ServerCallContext.Peer with IPv6

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -79,12 +79,25 @@ namespace Grpc.AspNetCore.Server.Internal
         {
             get
             {
+                // Follows the standard at https://github.com/grpc/grpc/blob/master/doc/naming.md
                 if (_peer == null)
                 {
                     var connection = HttpContext.Connection;
                     if (connection.RemoteIpAddress != null)
                     {
-                        _peer = (connection.RemoteIpAddress.AddressFamily == AddressFamily.InterNetwork ? "ipv4:" : "ipv6:") + connection.RemoteIpAddress + ":" + connection.RemotePort;
+                        switch (connection.RemoteIpAddress.AddressFamily)
+                        {
+                            case AddressFamily.InterNetwork:
+                                _peer = "ipv4:" + connection.RemoteIpAddress + ":" + connection.RemotePort;
+                                break;
+                            case AddressFamily.InterNetworkV6:
+                                _peer = "ipv6:[" + connection.RemoteIpAddress + "]:" + connection.RemotePort;
+                                break;
+                            default:
+                                // TODO - test when used with UDS and named pipes
+                                _peer = "unknown:" + connection.RemoteIpAddress + ":" + connection.RemotePort;
+                                break;
+                        }
                     }
                 }
 

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -94,7 +94,7 @@ namespace Grpc.AspNetCore.Server.Internal
                                 _peer = "ipv6:[" + connection.RemoteIpAddress + "]:" + connection.RemotePort;
                                 break;
                             default:
-                                // TODO - test when used with UDS and named pipes
+                                // TODO(JamesNK) - Test what should be output when used with UDS and named pipes
                                 _peer = "unknown:" + connection.RemoteIpAddress + ":" + connection.RemotePort;
                                 break;
                         }

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -42,7 +42,7 @@ namespace Grpc.AspNetCore.Server.Tests
     public class HttpContextServerCallContextTests
     {
         [TestCase("127.0.0.1", 50051, "ipv4:127.0.0.1:50051")]
-        [TestCase("::1", 50051, "ipv6:::1:50051")]
+        [TestCase("::1", 50051, "ipv6:[::1]:50051")]
         public void Peer_FormatsRemoteAddressCorrectly(string ipAddress, int port, string expected)
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/789