### PR TITLE
Update browser sample to not require HTTP/2

### DIFF
--- a/examples/Browser/Server/appsettings.json
+++ b/examples/Browser/Server/appsettings.json
@@ -4,10 +4,5 @@
       "Default": "Information"
     }
   },
-  "AllowedHosts": "*",
-  "Kestrel": {
-    "EndpointDefaults": {
-      "Protocols": "Http2"
-    }
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Replaces https://github.com/grpc/grpc-dotnet/pull/830