### PR TITLE
proposed changes for generalizing client factory to other implementations

### DIFF
--- a/src/Grpc.Net.ClientFactory/GrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientFactory.cs
@@ -17,6 +17,10 @@
 #endregion
 
 using Grpc.Core;
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Grpc.Net.ClientFactory.Internal;
 
 namespace Grpc.Net.ClientFactory
 {
@@ -32,6 +36,29 @@ namespace Grpc.Net.ClientFactory
         /// <typeparam name="TClient">The gRPC client type.</typeparam>
         /// <param name="name">The configuration name.</param>
         /// <returns>A gRPC client instance.</returns>
-        public abstract TClient CreateClient<TClient>(string name) where TClient : ClientBase;
+        public abstract TClient? CreateClient<TClient>(string name) where TClient : class;
+
+        /// <summary>
+        /// Gets a default CallInvoker instance for the specified <typeparamref name="TClient"/> and configuration name.
+        /// </summary>
+        /// <typeparam name="TClient">The gRPC client type.</typeparam>
+        /// <param name="serviceProvider">The service provider.</param>
+        /// <param name="name">The configuration name.</param>
+        /// <returns>A gRPC client instance.</returns>
+        protected static CallInvoker GetCallInvoker<TClient>(IServiceProvider serviceProvider, string name) where TClient : class
+        {
+            var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+            var typedHttpClientFactory = serviceProvider.GetService<INamedTypedHttpClientFactory<TClient>>();
+            if (typedHttpClientFactory is null)
+            {
+                ThrowServiceNotConfigured(name);
+            }
+
+            var httpClient = httpClientFactory.CreateClient(name);
+
+            return typedHttpClientFactory!.GetCallInvoker(httpClient, name);
+        }
+
+        internal static void ThrowServiceNotConfigured(string name) => throw new InvalidOperationException($"No gRPC client configured with name '{name}'.");
     }
 }

--- a/src/Grpc.Net.ClientFactory/Internal/INamedTypedHttpClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/INamedTypedHttpClientFactory.cs
@@ -21,8 +21,11 @@ using Grpc.Core;
 
 namespace Grpc.Net.ClientFactory.Internal
 {
-    interface INamedTypedHttpClientFactory<TClient> where TClient : ClientBase
+    interface INamedTypedHttpClientFactory<TClient> where TClient : class
     {
-        TClient CreateClient(HttpClient httpClient, string name);
+        CallInvoker GetCallInvoker(HttpClient httpClient, string name);
+        TClient CreateClient(CallInvoker callInvoker);
+        public bool CanCreateDefaultClient { get; }
+
     }
 }

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -84,13 +84,12 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Act
-            await client.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
+            await client!.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
 
             // Assert
             Assert.AreEqual(deadline, options.Deadline);
@@ -116,13 +115,12 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Act
-            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => client.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync).DefaultTimeout();
+            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => client!.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync).DefaultTimeout();
 
             // Assert
             Assert.AreEqual("Unable to propagate server context values to the call. Can't find the current HttpContext.", ex.Message);
@@ -151,13 +149,12 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Act
-            await client.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync.DefaultTimeout();
+            await client!.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync.DefaultTimeout();
 
             // Assert
             var log = testSink.Writes.Single(w => w.EventId.Name == "PropagateServerCallContextFailure");
@@ -183,13 +180,12 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Act
-            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => client.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync).DefaultTimeout();
+            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(() => client!.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync).DefaultTimeout();
 
             // Assert
             Assert.AreEqual("Unable to propagate server context values to the call. Can't find the gRPC ServerCallContext on the current HttpContext.", ex.Message);
@@ -218,13 +214,12 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Act
-            await client.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync.DefaultTimeout();
+            await client!.SayHelloAsync(new HelloRequest(), new CallOptions()).ResponseAsync.DefaultTimeout();
 
             // Assert
             var log = testSink.Writes.Single(w => w.EventId.Name == "PropagateServerCallContextFailure");

--- a/test/Grpc.Net.ClientFactory.Tests/CustomClientFactoryTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/CustomClientFactoryTests.cs
@@ -1,0 +1,110 @@
+﻿using Grpc.Core;
+using Grpc.Net.ClientFactory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Grpc.AspNetCore.Server.ClientFactory.Tests
+{
+    [TestFixture]
+    public class CustomClientFactoryTests
+    {
+        private static IServiceProvider SharedRegistraction(bool registerCustomProvider)
+        {
+            var services = new ServiceCollection();
+            services.AddGrpcClient<DefaultLookingClient>(o =>
+            {
+                o.Address = new Uri("https://nowhere.com/");
+            });
+            // doing this twice to check that we don't end up with multiple factory instances
+            services.AddGrpcClient<AnotherDefaultLookingClient>(o =>
+            {
+                o.Address = new Uri("https://nowhere.com/");
+            });
+            services.AddGrpcClient<IMyCustomService>(o =>
+            {
+                o.Address = new Uri("https://nowhere.com/");
+            });
+            services.AddHttpClient("TestClient");
+
+            // this would be via a custom extension method or similar
+            if (registerCustomProvider)
+            {
+                // doing this twice to check that we don't end up with multiple factory instances
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<GrpcClientFactory, CustomGrpcClientFactory>());
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<GrpcClientFactory, CustomGrpcClientFactory>());
+            }
+
+            var provider = services.BuildServiceProvider();
+            var factoryCount = provider.GetServices<GrpcClientFactory>().Count();
+            Assert.AreEqual(registerCustomProvider ? 2 : 1, factoryCount);
+            return provider;
+        }
+
+        [Theory]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void StandardServiceWorksWithOrWithoutCustomProvider(bool registerCustomProvider)
+        {
+            var services = SharedRegistraction(registerCustomProvider);
+            var client = services.GetRequiredService<DefaultLookingClient>();
+            Assert.NotNull(client);
+        }
+
+        [Test]
+        public void CustomServiceFailsWithoutCustomProvider()
+        {
+            var services = SharedRegistraction(false);
+            Assert.Throws<InvalidOperationException>(() => services.GetRequiredService<IMyCustomService>());
+        }
+
+        [Test]
+        public void CustomServiceWorksWithCustomProvider()
+        {
+            var services = SharedRegistraction(true);
+            var client = services.GetRequiredService<IMyCustomService>();
+            Assert.NotNull(client);
+        }
+
+        public class DefaultLookingClient : ClientBase
+        {
+            public DefaultLookingClient(CallInvoker callInvoker) : base(callInvoker) { }
+        }
+        public class AnotherDefaultLookingClient : ClientBase
+        {
+            public AnotherDefaultLookingClient(CallInvoker callInvoker) : base(callInvoker) { }
+        }
+
+        interface IMyCustomService
+        {
+            public ValueTask<MyResponse> MyMethodAsync(MyRequest request);
+        }
+        class MyRequest { }
+        class MyResponse { }
+        class MyService : IMyCustomService
+        {
+            public CallInvoker CallInvoker { get; }
+            public MyService(CallInvoker callInvoker) => CallInvoker = callInvoker ?? throw new ArgumentNullException(nameof(callInvoker));
+            public ValueTask<MyResponse> MyMethodAsync(MyRequest request) => new ValueTask<MyResponse>(new MyResponse());
+        }
+
+        public class CustomGrpcClientFactory : GrpcClientFactory
+        {
+            private readonly IServiceProvider _serviceProvider;
+            public CustomGrpcClientFactory(IServiceProvider serviceProvider) => _serviceProvider = serviceProvider;
+            public override TClient? CreateClient<TClient>(string name) where TClient : class
+            {
+                // only knows how to create one thing
+                if (typeof(TClient) == typeof(IMyCustomService))
+                {
+                    var callInvoker = GetCallInvoker<TClient>(_serviceProvider, name);
+                    return (TClient)(object)new MyService(callInvoker);
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -52,15 +52,14 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
 
             // Act
             var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Assert
-            Assert.AreEqual(Timeout.InfiniteTimeSpan, client.CallInvoker.Channel.HttpClient.Timeout);
+            Assert.AreEqual(Timeout.InfiniteTimeSpan, client!.CallInvoker.Channel.HttpClient.Timeout);
         }
 
         [Test]
@@ -77,16 +76,15 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
 
             // Act
             var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Assert
             Assert.IsNotNull(client);
-            Assert.AreEqual(address, client.CallInvoker.Channel.Address);
+            Assert.AreEqual(address, client!.CallInvoker.Channel.Address);
         }
 
         [Test]
@@ -103,16 +101,15 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
 
             // Act
             var client = clientFactory.CreateClient<TestGreeterClient>("Custom");
+            Assert.NotNull(client, "no client returned");
 
             // Assert
             Assert.IsNotNull(client);
-            Assert.AreEqual(address, client.CallInvoker.Channel.Address);
+            Assert.AreEqual(address, client!.CallInvoker.Channel.Address);
         }
 
         [Test]
@@ -127,9 +124,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(() => clientFactory.CreateClient<Greeter.GreeterClient>("Test"));
@@ -148,9 +143,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
 
             // Act
             var ex = Assert.Throws<InvalidOperationException>(() => clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient)));
@@ -170,15 +163,14 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
 
-            var clientFactory = new DefaultGrpcClientFactory(
-                serviceProvider,
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+            var clientFactory = new DefaultGrpcClientFactory(serviceProvider);
 
             // Act
             var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Assert
-            Assert.AreEqual("http://contoso", client.CallInvoker.Channel.Address.OriginalString);
+            Assert.AreEqual("http://contoso", client!.CallInvoker.Channel.Address.OriginalString);
         }
 
         [Test]
@@ -203,8 +195,9 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             var clientFactory = provider.GetRequiredService<GrpcClientFactory>();
 
             var contosoClient = clientFactory.CreateClient<TestGreeterClient>("contoso");
+            Assert.NotNull(contosoClient, "no client returned");
 
-            var response = await contosoClient.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
+            var response = await contosoClient!.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
 
             // Assert
             Assert.AreEqual("http://contoso", contosoClient.CallInvoker.Channel.Address.OriginalString);
@@ -237,10 +230,12 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
 
             var contosoClient = clientFactory.CreateClient<TestGreeterClient>("contoso");
             var adventureworksClient = clientFactory.CreateClient<TestGreeterClient>("adventureworks");
+            Assert.NotNull(contosoClient, "no contosoClient returned");
+            Assert.NotNull(adventureworksClient, "no adventureworksClient returned");
 
             // Assert
-            Assert.AreEqual("http://contoso", contosoClient.CallInvoker.Channel.Address.OriginalString);
-            Assert.AreEqual("http://adventureworks", adventureworksClient.CallInvoker.Channel.Address.OriginalString);
+            Assert.AreEqual("http://contoso", contosoClient!.CallInvoker.Channel.Address.OriginalString);
+            Assert.AreEqual("http://adventureworks", adventureworksClient!.CallInvoker.Channel.Address.OriginalString);
         }
 
         internal class TestGreeterClient : Greeter.GreeterClient

--- a/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
@@ -67,9 +67,10 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             // Act
             var clientFactory = serviceProvider.GetRequiredService<GrpcClientFactory>();
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
             // Handle bad response
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => client.SayHelloAsync(request).ResponseAsync).DefaultTimeout();
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => client!.SayHelloAsync(request).ResponseAsync).DefaultTimeout();
 
             // Assert
             Assert.AreEqual(StatusCode.ResourceExhausted, ex.StatusCode);
@@ -111,8 +112,9 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             // Act
             var clientFactory = serviceProvider.GetRequiredService<GrpcClientFactory>();
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
-            var response = await client.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
+            var response = await client!.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
 
             // Assert
             Assert.IsNotNull(response);
@@ -200,8 +202,9 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             // Act
             var clientFactory = serviceProvider.GetRequiredService<GrpcClientFactory>();
             var client = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+            Assert.NotNull(client, "no client returned");
 
-            var response = await client.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
+            var response = await client!.SayHelloAsync(new HelloRequest()).ResponseAsync.DefaultTimeout();
 
             // Assert
             Assert.IsNotNull(response);


### PR DESCRIPTION
 (for example: protobuf-net.Grpc)

This PR is largely a discussion document intended to discuss (with code) some problems in the current `ClientFactory` implementation that make it hard to generalize.

Problem statements:

1. there is an unnecessary `where T : ClientBase` constraint; this precludes usage with implementations that don't start from that assumption; this could be non-`ClientBase` classes, or naked interfaces
2. the client factory is a unary registration; this makes it impossible to *add* a custom factory without breaking code that relies on the *old* factory; and the old default factory is not directly available
3. a lot of complex nuanced code around http-client and GRPC configuration is hidden in `internal` implementations without any mechanism to control them; any custom client would have to essentially copy *most* of the `ClientFactory` code base; this is undesirable and will invariably lead to code drift

Proposed solutions:

1. replace `where T : ClientBase` with `where T : class`; this is presumably a helper guide for callers, but notably, the implementation does not *use* the `ClientBase` knowledge in any useful constraint, and it doesn't actually enforce the requirements needed by the activator/constructor API in use (i.e. even with the constraint a client can be constructed that does not work)
2. use an enumerable service descriptor rather than a unary service descriptor; each service may *try* and create a client, returning `null` if it cannot do so; the first to do so: wins; make the default descriptor more aware of what it can / cannot create
3. make all of the default configuration bits available behind a reusable API that just returns a fully configured `CallInvoker`

Example usage of this is shown in `CustomClientFactoryTests`, but the key impact here can be summarized in a few lines of code:

``` c#
// service registration
services.AddGrpcClient<IMyCustomService>(o =>
{
    o.Address = new Uri("https://nowhere.com/");
});
// factory registration (this would usually be hidden in a library-specific helper method)
services.TryAddEnumerable(
    ServiceDescriptor.Singleton<GrpcClientFactory, CustomGrpcClientFactory>()
);
```

with the custom factory (very simple here, for test purposes; real implementations would be library specific - it is not expected that end consumers would ever need to touch this):

``` c#
public class CustomGrpcClientFactory : GrpcClientFactory
{
    private readonly IServiceProvider _serviceProvider;
    public CustomGrpcClientFactory(IServiceProvider serviceProvider)
        => _serviceProvider = serviceProvider;
    public override TClient? CreateClient<TClient>(string name) where TClient : class
    {
        // only knows how to create one thing
        if (typeof(TClient) == typeof(IMyCustomService))
        {
            var callInvoker = GetCallInvoker<TClient>(_serviceProvider, name);
            return (TClient)(object)new MyService(callInvoker);
        }
        return null;
    }
}
```
