### PR TITLE
Update exposed CORS headers in tests and samples

### DIFF
--- a/examples/Spar/Server/Startup.cs
+++ b/examples/Spar/Server/Startup.cs
@@ -41,7 +41,7 @@ namespace Server
                 builder.AllowAnyOrigin()
                        .AllowAnyMethod()
                        .AllowAnyHeader()
-                       .WithExposedHeaders("Grpc-Status", "Grpc-Message");
+                       .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding");
             }));
         }
 

--- a/examples/Spar/Server/Startup.cs
+++ b/examples/Spar/Server/Startup.cs
@@ -41,7 +41,7 @@ namespace Server
                 builder.AllowAnyOrigin()
                        .AllowAnyMethod()
                        .AllowAnyHeader()
-                       .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding");
+                       .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding");
             }));
         }
 

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -89,7 +89,7 @@ namespace FunctionalTestsWebsite
                     builder.AllowAnyOrigin();
                     builder.AllowAnyMethod();
                     builder.AllowAnyHeader();
-                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding");
+                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding");
                 });
             });
 

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -89,7 +89,7 @@ namespace FunctionalTestsWebsite
                     builder.AllowAnyOrigin();
                     builder.AllowAnyMethod();
                     builder.AllowAnyHeader();
-                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message");
+                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding");
                 });
             });
 

--- a/testassets/InteropTestsWebsite/Startup.cs
+++ b/testassets/InteropTestsWebsite/Startup.cs
@@ -36,7 +36,7 @@ namespace InteropTestsWebsite
                     builder.AllowAnyOrigin();
                     builder.AllowAnyMethod();
                     builder.AllowAnyHeader();
-                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding");
+                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding");
                 });
             });
         }

--- a/testassets/InteropTestsWebsite/Startup.cs
+++ b/testassets/InteropTestsWebsite/Startup.cs
@@ -36,7 +36,7 @@ namespace InteropTestsWebsite
                     builder.AllowAnyOrigin();
                     builder.AllowAnyMethod();
                     builder.AllowAnyHeader();
-                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message");
+                    builder.WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding");
                 });
             });
         }


### PR DESCRIPTION
These headers can also be returned by gRPC so need to be configured as exposed.