### PR TITLE
Fix flaky client cancellation tests

### DIFF
--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -185,7 +185,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
             await serverCompleteTcs.Task.DefaultTimeout();
 
-            AssertHasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Cancelled', Message: 'Call canceled by the client.'.");
+            await TestHelpers.AssertIsTrueRetryAsync(
+                () => HasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Cancelled', Message: 'Call canceled by the client.'."),
+                "Missing client cancellation log.").DefaultTimeout();
         }
 
         [Test]
@@ -251,10 +253,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext(CancellationToken.None)).DefaultTimeout();
             Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
 
-            // 4. Check that the cancellation was sent to the server. This will 
+            // 4. Check that the cancellation was sent to the server.
             await serverCompleteTcs.Task.DefaultTimeout();
 
-            AssertHasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Cancelled', Message: 'Call canceled by the client.'.");
+            await TestHelpers.AssertIsTrueRetryAsync(
+                () => HasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Cancelled', Message: 'Call canceled by the client.'."),
+                "Missing client cancellation log.").DefaultTimeout();
         }
     }
 }

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -85,6 +85,8 @@ namespace Grpc.AspNetCore.FunctionalTests
 
         public IList<LogRecord> Logs => _testContext!.Scope.Logs;
 
+        public void ClearLogs() => _testContext!.Scope.ClearLogs();
+
         protected void AssertHasLogRpcConnectionError(StatusCode statusCode, string detail)
         {
             AssertHasLog(LogLevel.Information, "RpcConnectionError", $"Error status code '{statusCode}' raised.", e => GetRpcExceptionDetail(e) == detail);
@@ -92,7 +94,17 @@ namespace Grpc.AspNetCore.FunctionalTests
 
         protected void AssertHasLog(LogLevel logLevel, string name, string message, Func<Exception, bool>? exceptionMatch = null)
         {
-            if (Logs.Any(r =>
+            if (HasLog(logLevel, name, message, exceptionMatch))
+            {
+                return;
+            }
+
+            Assert.Fail($"No match. Log level = {logLevel}, name = {name}, message = '{message}'.");
+        }
+
+        protected bool HasLog(LogLevel logLevel, string name, string message, Func<Exception, bool>? exceptionMatch = null)
+        {
+            return Logs.Any(r =>
             {
                 var match = r.LogLevel == logLevel && r.EventId.Name == name && r.Message == message;
                 if (exceptionMatch != null)
@@ -100,12 +112,7 @@ namespace Grpc.AspNetCore.FunctionalTests
                     match = match && r.Exception != null && exceptionMatch(r.Exception);
                 }
                 return match;
-            }))
-            {
-                return;
-            }
-
-            Assert.Fail($"No match. Log level = {logLevel}, name = {name}, message = '{message}'.");
+            });
         }
 
         protected void SetExpectedErrorsFilter(Func<LogRecord, bool> expectedErrorsFilter)

--- a/test/FunctionalTests/Infrastructure/LogSinkProvider.cs
+++ b/test/FunctionalTests/Infrastructure/LogSinkProvider.cs
@@ -43,6 +43,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 
         public IList<LogRecord> GetLogs() => _logs.ToList();
 
+        public void ClearLogs() => _logs.Clear();
+
         public void Log<TState>(string categoryName, LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             var record = new LogRecord(DateTime.Now, logLevel, eventId, state!, exception, (o, e) => formatter((TState)o, e), categoryName);

--- a/test/FunctionalTests/Infrastructure/VerifyNoErrorsScope.cs
+++ b/test/FunctionalTests/Infrastructure/VerifyNoErrorsScope.cs
@@ -47,6 +47,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 
         public IList<LogRecord> Logs => _sink.GetLogs();
 
+        public void ClearLogs() => _sink.ClearLogs();
+
         public void Dispose()
         {
             _wrappedDisposable?.Dispose();


### PR DESCRIPTION
Logging is not sync and there is no easy hook to await so put test in a helper that will retry a couple of times.