### PR TITLE
Add GrpcChannelOptions.HttpHandler and channel default to invoker

### DIFF
--- a/perf/Grpc.AspNetCore.Microbenchmarks/Client/UnaryClientBenchmarkBase.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Client/UnaryClientBenchmarkBase.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Greet;
@@ -64,11 +65,9 @@ namespace Grpc.AspNetCore.Microbenchmarks.Client
                 return ResponseUtils.CreateResponse(HttpStatusCode.OK, content, grpcEncoding: ResponseCompressionAlgorithm);
             });
 
-            var httpClient = new HttpClient(handler);
-
             var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
             {
-                HttpClient = httpClient,
+                HttpHandler = handler,
                 CompressionProviders = CompressionProviders
             });
 

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Client/UnaryClientBenchmarkBase.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Client/UnaryClientBenchmarkBase.cs
@@ -23,7 +23,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Greet;

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -40,9 +40,11 @@ namespace Grpc.Net.Client
 
         private readonly ConcurrentDictionary<IMethod, GrpcMethodInfo> _methodInfoCache;
         private readonly Func<IMethod, GrpcMethodInfo> _createMethodInfoFunc;
+        // Internal for testing
+        internal readonly HashSet<IDisposable> ActiveCalls;
 
         internal Uri Address { get; }
-        internal HttpClient HttpClient { get; }
+        internal HttpMessageInvoker HttpInvoker { get; }
         internal int? SendMaxMessageSize { get; }
         internal int? ReceiveMaxMessageSize { get; }
         internal ILoggerFactory LoggerFactory { get; }
@@ -64,12 +66,13 @@ namespace Grpc.Net.Client
             _methodInfoCache = new ConcurrentDictionary<IMethod, GrpcMethodInfo>();
 
             // Dispose the HttpClient if...
-            //   1. No client was specified and so the channel created the HttpClient itself
-            //   2. User has specified a client and set DisposeHttpClient to true
-            _shouldDisposeHttpClient = channelOptions.HttpClient == null || channelOptions.DisposeHttpClient;
+            //   1. No client/handler was specified and so the channel created the client itself
+            //   2. User has specified a client/handler and set DisposeHttpClient to true
+            _shouldDisposeHttpClient = (channelOptions.HttpClient == null && channelOptions.HttpHandler == null)
+                || channelOptions.DisposeHttpClient;
 
             Address = address;
-            HttpClient = channelOptions.HttpClient ?? CreateInternalHttpClient();
+            HttpInvoker = channelOptions.HttpClient ?? CreateInternalHttpInvoker(channelOptions.HttpHandler);
             SendMaxMessageSize = channelOptions.MaxSendMessageSize;
             ReceiveMaxMessageSize = channelOptions.MaxReceiveMessageSize;
             CompressionProviders = ResolveCompressionProviders(channelOptions.CompressionProviders);
@@ -77,6 +80,7 @@ namespace Grpc.Net.Client
             LoggerFactory = channelOptions.LoggerFactory ?? NullLoggerFactory.Instance;
             ThrowOperationCanceledOnCancellation = channelOptions.ThrowOperationCanceledOnCancellation;
             _createMethodInfoFunc = CreateMethodInfo;
+            ActiveCalls = new HashSet<IDisposable>();
 
             if (channelOptions.Credentials != null)
             {
@@ -90,21 +94,29 @@ namespace Grpc.Net.Client
             }
         }
 
-        private static HttpClient CreateInternalHttpClient()
+        private static HttpMessageInvoker CreateInternalHttpInvoker(HttpMessageHandler? handler)
         {
-            var httpClient = new HttpClient();
+            // HttpMessageInvoker should always dispose handler if Disposed is called on it.
+            // Decision to dispose invoker is controlled by _shouldDisposeHttpClient.
+            var httpInvoker = new HttpMessageInvoker(handler ?? new HttpClientHandler(), disposeHandler: true);
 
-            // Long running server and duplex streaming gRPC requests may not
-            // return any messages for over 100 seconds, triggering a cancellation
-            // of HttpClient.SendAsync. Disable timeout in internally created
-            // HttpClient for channel.
-            //
-            // gRPC deadline should be the recommended way to timeout gRPC calls.
-            //
-            // https://github.com/dotnet/corefx/issues/41650
-            httpClient.Timeout = Timeout.InfiniteTimeSpan;
+            return httpInvoker;
+        }
 
-            return httpClient;
+        internal void RegisterActiveCall(IDisposable grpcCall)
+        {
+            lock (ActiveCalls)
+            {
+                ActiveCalls.Add(grpcCall);
+            }
+        }
+
+        internal void FinishActiveCall(IDisposable grpcCall)
+        {
+            lock (ActiveCalls)
+            {
+                ActiveCalls.Remove(grpcCall);
+            }
         }
 
         internal GrpcMethodInfo GetCachedGrpcMethodInfo(IMethod method)
@@ -261,6 +273,12 @@ namespace Grpc.Net.Client
                 throw new ArgumentNullException(nameof(channelOptions));
             }
 
+            if (channelOptions.HttpClient != null && channelOptions.HttpHandler != null)
+            {
+                throw new ArgumentException($"{nameof(GrpcChannelOptions.HttpClient)} and {nameof(GrpcChannelOptions.HttpHandler)} have been configured. " +
+                    $"Only one HTTP caller can be specified.");
+            }
+
             return new GrpcChannel(address, channelOptions);
         }
 
@@ -275,9 +293,18 @@ namespace Grpc.Net.Client
                 return;
             }
 
+            lock (ActiveCalls)
+            {
+                // Disposing calls will remove them from ActiveCalls
+                foreach (var activeCall in ActiveCalls)
+                {
+                    activeCall.Dispose();
+                }
+            }
+
             if (_shouldDisposeHttpClient)
             {
-                HttpClient.Dispose();
+                HttpInvoker.Dispose();
             }
             Disposed = true;
         }

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -68,23 +68,46 @@ namespace Grpc.Net.Client
         public ILoggerFactory? LoggerFactory { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="HttpClient"/> used by the channel.
+        /// Gets or sets the <see cref="System.Net.Http.HttpClient"/> used by the channel to make HTTP calls.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// By default a <see cref="System.Net.Http.HttpClient"/> specified here will not be disposed with the channel.
         /// To dispose the <see cref="System.Net.Http.HttpClient"/> with the channel you must set <see cref="DisposeHttpClient"/>
         /// to <c>true</c>.
+        /// </para>
+        /// <para>
+        /// Only one HTTP caller can be specified for a channel. An error will be thrown if this is configured
+        /// together with <see cref="HttpHandler"/>.
+        /// </para>
         /// </remarks>
         public HttpClient? HttpClient { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the underlying <see cref="System.Net.Http.HttpClient"/> should be disposed
-        /// when the <see cref="GrpcChannel"/> instance is disposed. The default value is <c>false</c>.
+        /// Gets or sets the <see cref="HttpMessageHandler"/> used by the channel to make HTTP calls.
         /// </summary>
         /// <remarks>
-        /// This setting is used when a <see cref="HttpClient"/> value is specified. If no <see cref="HttpClient"/> value is provided
-        /// then the channel will create an <see cref="System.Net.Http.HttpClient"/> instance that is always disposed when
-        /// the channel is disposed.
+        /// <para>
+        /// By default a <see cref="HttpMessageHandler"/> specified here will not be disposed with the channel.
+        /// To dispose the <see cref="HttpMessageHandler"/> with the channel you must set <see cref="DisposeHttpClient"/>
+        /// to <c>true</c>.
+        /// </para>
+        /// <para>
+        /// Only one HTTP caller can be specified for a channel. An error will be thrown if this is configured
+        /// together with <see cref="HttpClient"/>.
+        /// </para>
+        /// </remarks>
+        public HttpMessageHandler? HttpHandler { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the underlying <see cref="System.Net.Http.HttpClient"/> or 
+        /// <see cref="HttpMessageHandler"/> should be disposed when the <see cref="GrpcChannel"/> instance is disposed.
+        /// The default value is <c>false</c>.
+        /// </summary>
+        /// <remarks>
+        /// This setting is used when a <see cref="HttpClient"/> or <see cref="HttpHandler"/> value is specified.
+        /// If they are not specified then the channel will create an internal HTTP caller that is always disposed
+        /// when the channel is disposed.
         /// </remarks>
         public bool DisposeHttpClient { get; set; }
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -75,6 +75,8 @@ namespace Grpc.Net.Client.Internal
             Channel = channel;
             Logger = channel.LoggerFactory.CreateLogger(LoggerName);
             _deadline = options.Deadline ?? DateTime.MaxValue;
+
+            Channel.RegisterActiveCall(this);
         }
 
         private void ValidateDeadline(DateTime? deadline)
@@ -459,7 +461,12 @@ namespace Grpc.Net.Client.Internal
 
                     try
                     {
-                        _httpResponseTask = Channel.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token);
+                        // If a HttpClient has been specified then we need to call it with ResponseHeadersRead
+                        // so that the response message is available for streaming
+                        _httpResponseTask = (Channel.HttpInvoker is HttpClient httpClient)
+                            ? httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _callCts.Token)
+                            : Channel.HttpInvoker.SendAsync(request, _callCts.Token);
+
                         HttpResponse = await _httpResponseTask.ConfigureAwait(false);
                     }
                     catch (Exception ex)
@@ -768,11 +775,11 @@ namespace Grpc.Net.Client.Internal
             var headers = message.Headers;
 
             // User agent is optional but recommended.
-            headers.Add(GrpcProtocolConstants.UserAgentHeader, GrpcProtocolConstants.UserAgentHeaderValue);
+            headers.TryAddWithoutValidation(GrpcProtocolConstants.UserAgentHeader, GrpcProtocolConstants.UserAgentHeaderValue);
             // TE is required by some servers, e.g. C Core.
             // A missing TE header results in servers aborting the gRPC call.
-            headers.Add(GrpcProtocolConstants.TEHeader, GrpcProtocolConstants.TEHeaderValue);
-            headers.Add(GrpcProtocolConstants.MessageAcceptEncodingHeader, Channel.MessageAcceptEncoding);
+            headers.TryAddWithoutValidation(GrpcProtocolConstants.TEHeader, GrpcProtocolConstants.TEHeaderValue);
+            headers.TryAddWithoutValidation(GrpcProtocolConstants.MessageAcceptEncodingHeader, Channel.MessageAcceptEncoding);
 
             if (Options.Headers != null && Options.Headers.Count > 0)
             {
@@ -788,7 +795,7 @@ namespace Grpc.Net.Client.Internal
                         // grpc-internal-encoding-request is used in the client to set message compression.
                         // 'grpc-encoding' is sent even if WriteOptions.Flags = NoCompress. In that situation
                         // individual messages will not be written with compression.
-                        headers.Add(GrpcProtocolConstants.MessageEncodingHeader, entry.Value);
+                        headers.TryAddWithoutValidation(GrpcProtocolConstants.MessageEncodingHeader, entry.Value);
                     }
                     else
                     {
@@ -799,7 +806,7 @@ namespace Grpc.Net.Client.Internal
 
             if (timeout != null)
             {
-                headers.Add(GrpcProtocolConstants.TimeoutHeader, GrpcProtocolHelpers.EncodeTimeout(timeout.Value.Ticks / TimeSpan.TicksPerMillisecond));
+                headers.TryAddWithoutValidation(GrpcProtocolConstants.TimeoutHeader, GrpcProtocolHelpers.EncodeTimeout(timeout.Value.Ticks / TimeSpan.TicksPerMillisecond));
             }
 
             return message;

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -170,6 +170,8 @@ namespace Grpc.Net.Client.Internal
                 ClientStreamReader?.HttpResponseTcs.TrySetCanceled();
             }
 
+            Channel.FinishActiveCall(this);
+
             _ctsRegistration?.Dispose();
             _deadlineTimer?.Dispose();
             HttpResponse?.Dispose();

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -269,7 +269,7 @@ namespace Grpc.Net.Client.Internal
         public static void AddHeader(HttpRequestHeaders headers, Metadata.Entry entry)
         {
             var value = entry.IsBinary ? Convert.ToBase64String(entry.ValueBytes) : entry.Value;
-            headers.Add(entry.Key, value);
+            headers.TryAddWithoutValidation(entry.Key, value);
         }
 
         public static string? GetHeaderValue(HttpHeaders? headers, string name)

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -41,13 +41,21 @@ namespace Grpc.AspNetCore.FunctionalTests
 
         protected GrpcChannel Channel => _channel ??= CreateChannel();
 
-        protected GrpcChannel CreateChannel()
+        protected GrpcChannel CreateChannel(bool useHandler = false)
         {
-            return GrpcChannel.ForAddress(Fixture.Client.BaseAddress, new GrpcChannelOptions
+            var options = new GrpcChannelOptions
             {
-                LoggerFactory = LoggerFactory,
-                HttpClient = Fixture.Client
-            });
+                LoggerFactory = LoggerFactory
+            };
+            if (useHandler)
+            {
+                options.HttpHandler = Fixture.Handler;
+            }
+            else
+            {
+                options.HttpClient = Fixture.Client;
+            }
+            return GrpcChannel.ForAddress(Fixture.Client.BaseAddress, options);
         }
 
         protected virtual void ConfigureServices(IServiceCollection services) { }

--- a/test/FunctionalTests/Infrastructure/LogRecord.cs
+++ b/test/FunctionalTests/Infrastructure/LogRecord.cs
@@ -17,10 +17,12 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 {
+    [DebuggerDisplay("{Message,nq}")]
     public class LogRecord
     {
         public LogRecord(DateTime timestamp, LogLevel logLevel, EventId eventId, object state, Exception? exception, Func<object, Exception?, string> formatter, string loggerName)

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -20,6 +20,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Greet;
 using Grpc.Core;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
@@ -40,16 +41,6 @@ namespace Grpc.Net.Client.Tests
 
             // Assert
             Assert.IsTrue(channel.IsSecure);
-        }
-
-        [Test]
-        public void Build_NoHttpClient_InternalHttpClientHasInfiniteTimeout()
-        {
-            // Arrange & Act
-            var channel = GrpcChannel.ForAddress("https://localhost");
-
-            // Assert
-            Assert.AreEqual(Timeout.InfiniteTimeSpan, channel.HttpClient.Timeout);
         }
 
         [Test]
@@ -108,6 +99,20 @@ namespace Grpc.Net.Client.Tests
         }
 
         [Test]
+        public void Build_HttpClientAndHttpHandler_ThrowsError()
+        {
+            // Arrange & Act
+            var ex = Assert.Throws<ArgumentException>(() => GrpcChannel.ForAddress("https://localhost", new GrpcChannelOptions
+            {
+                HttpClient = new HttpClient(),
+                HttpHandler = new HttpClientHandler()
+            }));
+
+            // Assert
+            Assert.AreEqual("HttpClient and HttpHandler have been configured. Only one HTTP caller can be specified.", ex.Message);
+        }
+
+        [Test]
         public void Dispose_NotCalled_NotDisposed()
         {
             // Arrange
@@ -130,7 +135,7 @@ namespace Grpc.Net.Client.Tests
 
             // Assert
             Assert.IsTrue(channel.Disposed);
-            Assert.Throws<ObjectDisposedException>(() => channel.HttpClient.CancelPendingRequests());
+            Assert.Throws<ObjectDisposedException>(() => channel.HttpInvoker.SendAsync(new HttpRequestMessage(), CancellationToken.None));
         }
 
         [Test]
@@ -174,21 +179,6 @@ namespace Grpc.Net.Client.Tests
             await ExceptionAssert.ThrowsAsync<ObjectDisposedException>(() => client.SayHelloAsync(new Greet.HelloRequest()).ResponseAsync);
         }
 
-        public class TestHttpMessageHandler : HttpMessageHandler
-        {
-            public bool Disposed { get; private set; }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                Disposed = true;
-            }
-        }
-
         [Test]
         public void Dispose_CalledWhenHttpClientSpecified_HttpClientNotDisposed()
         {
@@ -226,6 +216,69 @@ namespace Grpc.Net.Client.Tests
             // Assert
             Assert.IsTrue(channel.Disposed);
             Assert.IsTrue(handler.Disposed);
+        }
+
+        [Test]
+        public void Dispose_CalledWhenHttpMessageHandlerSpecifiedAndHttpClientDisposedTrue_HttpClientDisposed()
+        {
+            // Arrange
+            var handler = new TestHttpMessageHandler();
+            var channel = GrpcChannel.ForAddress("https://localhost", new GrpcChannelOptions
+            {
+                HttpHandler = handler,
+                DisposeHttpClient = true
+            });
+
+            // Act
+            channel.Dispose();
+
+            // Assert
+            Assert.IsTrue(channel.Disposed);
+            Assert.IsTrue(handler.Disposed);
+        }
+
+        [Test]
+        public async Task Dispose_CalledWhileActiveCalls_ActiveCallsDisposed()
+        {
+            // Arrange
+            var handler = new TestHttpMessageHandler();
+            var channel = GrpcChannel.ForAddress("https://localhost", new GrpcChannelOptions
+            {
+                HttpHandler = handler
+            });
+
+            var client = new Greeter.GreeterClient(channel);
+            var call = client.SayHelloAsync(new HelloRequest());
+
+            var exTask = ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync);
+            Assert.IsFalse(exTask.IsCompleted);
+
+            // Act
+            channel.Dispose();
+
+            // Assert
+            var ex = await exTask.DefaultTimeout();
+            Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
+            Assert.AreEqual("gRPC call disposed.", ex.Status.Detail);
+
+            Assert.IsTrue(channel.Disposed);
+        }
+
+        public class TestHttpMessageHandler : HttpMessageHandler
+        {
+            public bool Disposed { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var tcs = new TaskCompletionSource<HttpResponseMessage>();
+                cancellationToken.Register(s => ((TaskCompletionSource<HttpResponseMessage>)s!).SetException(new OperationCanceledException()), tcs);
+                return await tcs.Task;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                Disposed = true;
+            }
         }
     }
 }

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -252,6 +252,7 @@ namespace Grpc.Net.Client.Tests
 
             var exTask = ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync);
             Assert.IsFalse(exTask.IsCompleted);
+            Assert.AreEqual(1, channel.ActiveCalls.Count);
 
             // Act
             channel.Dispose();
@@ -262,6 +263,7 @@ namespace Grpc.Net.Client.Tests
             Assert.AreEqual("gRPC call disposed.", ex.Status.Detail);
 
             Assert.IsTrue(channel.Disposed);
+            Assert.AreEqual(0, channel.ActiveCalls.Count);
         }
 
         public class TestHttpMessageHandler : HttpMessageHandler

--- a/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -56,7 +56,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
 
             // Assert
-            Assert.AreEqual(Timeout.InfiniteTimeSpan, client.CallInvoker.Channel.HttpClient.Timeout);
+            Assert.AreEqual(Timeout.InfiniteTimeSpan, ((HttpClient)client.CallInvoker.Channel.HttpInvoker).Timeout);
         }
 
         [Test]

--- a/testassets/Shared/InteropClient.cs
+++ b/testassets/Shared/InteropClient.cs
@@ -196,12 +196,10 @@ namespace Grpc.Shared.TestAssets
                 httpMessageHandler = httpClientHandler;
             }
 
-            var httpClient = new HttpClient(httpMessageHandler);
-
             var channel = GrpcChannel.ForAddress($"{scheme}://{options.ServerHost}:{options.ServerPort}", new GrpcChannelOptions
             {
                 Credentials = credentials,
-                HttpClient = httpClient,
+                HttpHandler = httpMessageHandler,
                 LoggerFactory = loggerFactory
             });
 


### PR DESCRIPTION
* Add GrpcChannelOptions.HttpHandler
* Change channel to default to using HttpMessageInvoker instead of HttpClient
* Channel will dispose active calls when it is disposed
* Minor perf improvements (headers Add to TryAddWithoutValidation)

@stephentoub this applies some of your perf changes from https://github.com/JamesNK/Http2Perf/pull/1

After:
```
        Method |     Mean |     Error |    StdDev |      Op/s | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
-------------- |---------:|----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
 SayHelloAsync | 9.730 us | 0.1655 us | 0.1382 us | 102,776.2 |      0.0763 |           - |           - |             6.05 KB |
```

Before:
```
        Method |     Mean |     Error |    StdDev |      Op/s | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
-------------- |---------:|----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
 SayHelloAsync | 7.860 us | 0.1571 us | 0.1746 us | 127,222.9 |      0.0610 |           - |           - |             5.25 KB |
```