### PR TITLE
Add test for ResponseStream.MoveNext cancellation

### DIFF
--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -303,6 +303,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext(CancellationToken.None)).DefaultTimeout();
             Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
 
+            await syncPoint.WaitForSyncPoint();
             syncPoint.Continue();
 
             // 4. Check that the cancellation was sent to the server.

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -260,5 +260,59 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 () => HasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Cancelled', Message: 'Call canceled by the client.'."),
                 "Missing client cancellation log.").DefaultTimeout();
         }
+
+        [Test]
+        public async Task ServerStreaming_CancellationOnClientWhileMoveNext_CancellationSentToServer()
+        {
+            var serverCompleteTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var syncPoint = new SyncPoint();
+            var serverCancellationRequested = false;
+
+            async Task ServerStreamingCall(DataMessage request, IServerStreamWriter<DataMessage> streamWriter, ServerCallContext context)
+            {
+                await streamWriter.WriteAsync(new DataMessage());
+                await streamWriter.WriteAsync(new DataMessage());
+
+                await syncPoint.WaitToContinue();
+
+                serverCancellationRequested = context.CancellationToken.IsCancellationRequested;
+
+                serverCompleteTcs.TrySetResult(null);
+            }
+
+            var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingCall);
+
+            var channel = CreateChannel();
+            var cts = new CancellationTokenSource();
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.ServerStreamingCall(new DataMessage(), new CallOptions(cancellationToken: cts.Token));
+
+            // Assert
+
+            // 1. Lets read some messages
+            Assert.IsTrue(await call.ResponseStream.MoveNext(CancellationToken.None).DefaultTimeout());
+            Assert.IsTrue(await call.ResponseStream.MoveNext(CancellationToken.None).DefaultTimeout());
+
+            // 2. Cancel the token that was passed to the gRPC call. This should dispose HttpResponseMessage
+            cts.CancelAfter(TimeSpan.FromSeconds(0.2));
+
+            // 3. Read from the response stream. This will throw a cancellation exception locally
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext(CancellationToken.None)).DefaultTimeout();
+            Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
+
+            syncPoint.Continue();
+
+            // 4. Check that the cancellation was sent to the server.
+            await serverCompleteTcs.Task.DefaultTimeout();
+
+            Assert.AreEqual(true, serverCancellationRequested);
+
+            await TestHelpers.AssertIsTrueRetryAsync(
+                () => HasLog(LogLevel.Information, "GrpcStatusError", "Call failed with gRPC error status. Status code: 'Cancelled', Message: 'Call canceled by the client.'."),
+                "Missing client cancellation log.").DefaultTimeout();
+        }
     }
 }

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -311,7 +311,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             // 4. Check that the cancellation was sent to the server.
             pauseServerTcs.TrySetResult(null);
 
-            await callEndSyncPoint.WaitForSyncPoint();
+            await callEndSyncPoint.WaitForSyncPoint().DefaultTimeout();
             callEndSyncPoint.Continue();
 
             Assert.AreEqual(true, serverCancellationRequested);


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/894