### PR TITLE
Add extension methods for configuring all gRPC clients

### DIFF
--- a/src/Grpc.AspNetCore.Server.ClientFactory/GrpcServerServiceExtensions.cs
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/GrpcServerServiceExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Grpc.AspNetCore.ClientFactory;
+using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Grpc.AspNetCore.Server.ClientFactory
+{
+    /// <summary>
+    /// Extension methods for <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class GrpcServerServiceExtensions
+    {
+        /// <summary>
+        /// Configures the server to propagate values from a call's <see cref="ServerCallContext"/>
+        /// onto all gRPC clients.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddGrpcCallContextPropagation(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.TryAddSingleton<ContextPropagationInterceptor>();
+            services.AddHttpContextAccessor();
+            services.ConfigureAllGrpcClients((services, options) =>
+            {
+                options.Interceptors.Add(services.GetRequiredService<ContextPropagationInterceptor>());
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -379,5 +379,43 @@ namespace Microsoft.Extensions.DependencyInjection
 
             registry.NamedClientRegistrations[name] = type;
         }
+
+        /// <summary>
+        /// Registers an action used to configure all gRPC clients registered with <see cref="AddGrpcClient{TClient}(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configureClient">A delegate that is used to configure the gRPC clients.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection ConfigureAllGrpcClients(this IServiceCollection services, Action<GrpcClientFactoryOptions> configureClient)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            return services.ConfigureAll(configureClient);
+        }
+
+        /// <summary>
+        /// Registers an action used to configure all gRPC clients registered with <see cref="AddGrpcClient{TClient}(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configureClient">A delegate that is used to configure the gRPC clients.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection ConfigureAllGrpcClients(this IServiceCollection services, Action<IServiceProvider, GrpcClientFactoryOptions> configureClient)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            return services.AddTransient<IConfigureOptions<GrpcClientFactoryOptions>>(services =>
+            {
+                return new ConfigureNamedOptions<GrpcClientFactoryOptions>(null, options =>
+                {
+                    configureClient(services, options);
+                });
+            });
+        }
     }
 }


### PR DESCRIPTION
- Add `.ConfigureAllGrpcClients` extension method.
  This is useful e.g. for globally registering gRPC client interceptors.
- Add `AddGrpcCallContextPropagation` extension method. This is an alternative to `EnableCallContextPropagation` that applies to call gRPC clients instead of a specific one.