### PR TITLE
Write unary content with single Stream.WriteAsync

### DIFF
--- a/src/Grpc.Net.Client.Web/Internal/Base64RequestStream.cs
+++ b/src/Grpc.Net.Client.Web/Internal/Base64RequestStream.cs
@@ -119,15 +119,19 @@ namespace Grpc.Net.Client.Web.Internal
 
         public override async Task FlushAsync(CancellationToken cancellationToken)
         {
+            await WriteRemainderAsync(cancellationToken).ConfigureAwait(false);
+            await _inner.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        internal async Task WriteRemainderAsync(CancellationToken cancellationToken)
+        {
             if (_remainder > 0)
             {
                 EnsureSuccess(Base64.EncodeToUtf8InPlace(_buffer, _remainder, out var bytesWritten));
 
-                await _inner.WriteAsync(_buffer.AsMemory(0, bytesWritten), cancellationToken);
+                await _inner.WriteAsync(_buffer.AsMemory(0, bytesWritten), cancellationToken).ConfigureAwait(false);
                 _remainder = 0;
             }
-
-            await _inner.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
@@ -35,7 +35,7 @@ namespace Grpc.Net.Client.Web.Internal
             _mode = mode;
             foreach (var header in inner.Headers)
             {
-                Headers.Add(header.Key, header.Value);
+                Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 
             Headers.ContentType = (mode == GrpcWebMode.GrpcWebText)
@@ -43,30 +43,20 @@ namespace Grpc.Net.Client.Web.Internal
                 : GrpcWebProtocolConstants.GrpcWebHeader;
         }
 
-        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>
+            _mode == GrpcWebMode.GrpcWebText
+                ? SerializeTextToStreamAsync(stream)
+                : _inner.CopyToAsync(stream);
+
+        private async Task SerializeTextToStreamAsync(Stream stream)
         {
-            Base64RequestStream? base64RequestStream = null;
+            using var base64RequestStream = new Base64RequestStream(stream);
+            await _inner.CopyToAsync(base64RequestStream).ConfigureAwait(false);
 
-            try
-            {
-                if (_mode == GrpcWebMode.GrpcWebText)
-                {
-                    base64RequestStream = new Base64RequestStream(stream);
-                    stream = base64RequestStream;
-                }
-
-                await _inner.CopyToAsync(stream).ConfigureAwait(false);
-
-                if (base64RequestStream != null)
-                {
-                    // Flush any remaining base64 content
-                    await base64RequestStream.FlushAsync().ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                base64RequestStream?.Dispose();
-            }
+            // Any remaining content needs to be written when SerializeToStreamAsync finishes.
+            // We want to avoid unnecessary flush calls so a custom method is used to write
+            // ramining content rather than calling FlushAsync.
+            await base64RequestStream.WriteRemainderAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override bool TryComputeLength(out long length)

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
@@ -56,6 +56,12 @@ namespace Grpc.Net.Client.Web.Internal
                 }
 
                 await _inner.CopyToAsync(stream).ConfigureAwait(false);
+
+                if (base64RequestStream != null)
+                {
+                    // Flush any remaining base64 content
+                    await base64RequestStream.FlushAsync().ConfigureAwait(false);
+                }
             }
             finally
             {

--- a/src/Grpc.Net.Client/Internal/DefaultSerializationContext.cs
+++ b/src/Grpc.Net.Client/Internal/DefaultSerializationContext.cs
@@ -136,20 +136,13 @@ namespace Grpc.Net.Client.Internal
             }
         }
 
-        public Memory<byte> GetHeader(bool isCompressed, int length)
+        public void WriteHeader(Span<byte> headerData, bool isCompressed, int length)
         {
-            // TODO(JamesNK): We can optimize header allocation when IBufferWriter is being used.
-            // IBufferWriter can be used to provide a buffer, either before or after message content.
-            // https://github.com/grpc/grpc-dotnet/issues/784
-            var buffer = new byte[GrpcProtocolConstants.HeaderSize];
-
             // Compression flag
-            buffer[0] = isCompressed ? (byte)1 : (byte)0;
+            headerData[0] = isCompressed ? (byte)1 : (byte)0;
 
             // Message length
-            EncodeMessageLength(length, buffer.AsSpan(1, 4));
-
-            return buffer;
+            EncodeMessageLength(length, headerData.Slice(1, 4));
         }
 
         private static void EncodeMessageLength(int messageLength, Span<byte> destination)

--- a/src/Grpc.Net.Client/Internal/DefaultSerializationContext.cs
+++ b/src/Grpc.Net.Client/Internal/DefaultSerializationContext.cs
@@ -135,21 +135,5 @@ namespace Grpc.Net.Client.Internal
                     break;
             }
         }
-
-        public void WriteHeader(Span<byte> headerData, bool isCompressed, int length)
-        {
-            // Compression flag
-            headerData[0] = isCompressed ? (byte)1 : (byte)0;
-
-            // Message length
-            EncodeMessageLength(length, headerData.Slice(1, 4));
-        }
-
-        private static void EncodeMessageLength(int messageLength, Span<byte> destination)
-        {
-            Debug.Assert(destination.Length >= GrpcProtocolConstants.MessageDelimiterSize, "Buffer too small to encode message length.");
-
-            BinaryPrimitives.WriteUInt32BigEndian(destination, (uint)messageLength);
-        }
     }
 }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -163,7 +163,10 @@ namespace Grpc.Net.Client.Internal
                     callOptions = callOptions.WithWriteOptions(WriteOptions);
                 }
 
-                await _call.WriteMessageAsync(writeStream, message, _grpcEncoding, callOptions);
+                await _call.WriteMessageAsync(writeStream, message, _grpcEncoding, callOptions).ConfigureAwait(false);
+
+                // Flush stream to ensure messages are sent immediately
+                await writeStream.FlushAsync(callOptions.CancellationToken).ConfigureAwait(false);
 
                 GrpcEventSource.Log.MessageSent();
             }

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -294,9 +294,23 @@ namespace Grpc.Net.Client
                         data);
                 }
 
-                await stream.WriteAsync(serializationContext.GetHeader(isCompressed, data.Length), callOptions.CancellationToken).ConfigureAwait(false);
-                await stream.WriteAsync(data, callOptions.CancellationToken).ConfigureAwait(false);
-                await stream.FlushAsync(callOptions.CancellationToken).ConfigureAwait(false);
+                var totalSize = data.Length + GrpcProtocolConstants.HeaderSize;
+                var completeData = ArrayPool<byte>.Shared.Rent(totalSize);
+                try
+                {
+                    var buffer = completeData.AsMemory(0, totalSize);
+
+                    serializationContext.WriteHeader(buffer.Span.Slice(0, GrpcProtocolConstants.HeaderSize), isCompressed, data.Length);
+                    data.CopyTo(buffer.Slice(GrpcProtocolConstants.HeaderSize));
+
+                    // Sending the header+content in a single WriteAsync call has significant performance benefits
+                    // https://github.com/dotnet/runtime/issues/35184#issuecomment-626304981
+                    await stream.WriteAsync(buffer, callOptions.CancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(completeData);
+                }
 
                 GrpcCallLog.MessageSent(logger);
             }

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -300,7 +300,7 @@ namespace Grpc.Net.Client
                 {
                     var buffer = completeData.AsMemory(0, totalSize);
 
-                    serializationContext.WriteHeader(buffer.Span.Slice(0, GrpcProtocolConstants.HeaderSize), isCompressed, data.Length);
+                    WriteHeader(buffer.Span.Slice(0, GrpcProtocolConstants.HeaderSize), isCompressed, data.Length);
                     data.CopyTo(buffer.Slice(GrpcProtocolConstants.HeaderSize));
 
                     // Sending the header+content in a single WriteAsync call has significant performance benefits
@@ -341,6 +341,22 @@ namespace Grpc.Net.Client
 
             // Should never reach here
             throw new InvalidOperationException($"Could not find compression provider for '{compressionEncoding}'.");
+        }
+
+        private static void WriteHeader(Span<byte> headerData, bool isCompressed, int length)
+        {
+            // Compression flag
+            headerData[0] = isCompressed ? (byte)1 : (byte)0;
+
+            // Message length
+            EncodeMessageLength(length, headerData.Slice(1, 4));
+        }
+
+        private static void EncodeMessageLength(int messageLength, Span<byte> destination)
+        {
+            Debug.Assert(destination.Length >= GrpcProtocolConstants.MessageDelimiterSize, "Buffer too small to encode message length.");
+
+            BinaryPrimitives.WriteUInt32BigEndian(destination, (uint)messageLength);
         }
     }
 }


### PR DESCRIPTION
Large performance improvement in unary RPS.

https://github.com/dotnet/runtime/issues/35184#issuecomment-626304981

Before
```
Successfully processed 100373; RPS 27299; Errors 0; Last elapsed 3.9209ms
Successfully processed 127896; RPS 27496; Errors 0; Last elapsed 3.6429ms
Successfully processed 155281; RPS 27374; Errors 0; Last elapsed 3.6593ms
Successfully processed 182801; RPS 27520; Errors 0; Last elapsed 3.546ms
Successfully processed 209917; RPS 27112; Errors 0; Last elapsed 3.6468ms
```
After
```
Successfully processed 228755; RPS 52340; Errors 0; Last elapsed 2.1993ms
Successfully processed 282848; RPS 53993; Errors 0; Last elapsed 2.1865ms
Successfully processed 336652; RPS 53802; Errors 0; Last elapsed 1.5827ms
Successfully processed 390310; RPS 53628; Errors 0; Last elapsed 0.9105ms
Successfully processed 443199; RPS 52889; Errors 0; Last elapsed 2.2438ms
```

When Google.Protobuf supports writing to `IBufferWriter<byte>` this can be improved to write message data directly to the buffer array.

@stephentoub 