### PR TITLE
Check for in-progress write in ServerStreamWriter

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -62,9 +62,11 @@ namespace Grpc.AspNetCore.Server.Internal
                 {
                     return Task.FromException(new InvalidOperationException("Can't write the message because the previous write is in progress."));
                 }
+
+                // Save write task to track whether it is complete. Must be set inside lock.
+                _writeTask = _context.HttpContext.Response.BodyWriter.WriteMessageAsync(message, _context, _serializer, canFlush: true);
             }
 
-            _writeTask = _context.HttpContext.Response.BodyWriter.WriteMessageAsync(message, _context, _serializer, canFlush: true);
             return _writeTask;
         }
 

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -27,11 +27,14 @@ namespace Grpc.AspNetCore.Server.Internal
     {
         private readonly HttpContextServerCallContext _context;
         private readonly Action<TResponse, SerializationContext> _serializer;
+        private readonly object _writeLock;
+        private Task? _writeTask;
 
         public HttpContextStreamWriter(HttpContextServerCallContext context, Action<TResponse, SerializationContext> serializer)
         {
             _context = context;
             _serializer = serializer;
+            _writeLock = new object();
         }
 
         public WriteOptions WriteOptions
@@ -44,15 +47,38 @@ namespace Grpc.AspNetCore.Server.Internal
         {
             if (message == null)
             {
-                throw new ArgumentNullException(nameof(message));
+                return Task.FromException(new ArgumentNullException(nameof(message)));
             }
 
             if (_context.CancellationToken.IsCancellationRequested)
             {
-                throw new InvalidOperationException("Cannot write message after request is complete.");
+                return Task.FromException(new InvalidOperationException("Cannot write message after request is complete."));
             }
 
-            return _context.HttpContext.Response.BodyWriter.WriteMessageAsync(message, _context, _serializer, canFlush: true);
+            lock (_writeLock)
+            {
+                // Pending writes need to be awaited first
+                if (IsWriteInProgressUnsynchronized)
+                {
+                    return Task.FromException(new InvalidOperationException("Can't write the message because the previous write is in progress."));
+                }
+            }
+
+            _writeTask = _context.HttpContext.Response.BodyWriter.WriteMessageAsync(message, _context, _serializer, canFlush: true);
+            return _writeTask;
+        }
+
+        /// <summary>
+        /// A value indicating whether there is an async write already in progress.
+        /// Should only check this property when holding the write lock.
+        /// </summary>
+        private bool IsWriteInProgressUnsynchronized
+        {
+            get
+            {
+                var writeTask = _writeTask;
+                return writeTask != null && !writeTask.IsCompleted;
+            }
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -129,7 +129,7 @@ namespace Grpc.Net.Client.Internal
                         return CreateErrorTask("Can't write the message because the previous write is in progress.");
                     }
 
-                    // Save write task to track whether it is complete
+                    // Save write task to track whether it is complete. Must be set inside lock.
                     _writeTask = WriteAsyncCore(message);
                 }
             }

--- a/test/Shared/TestResponseBodyFeature.cs
+++ b/test/Shared/TestResponseBodyFeature.cs
@@ -27,9 +27,12 @@ namespace Grpc.Tests.Shared
 {
     public class TestResponseBodyFeature : IHttpResponseBodyFeature
     {
-        public TestResponseBodyFeature(PipeWriter writer)
+        private readonly Task _startAsyncTask;
+
+        public TestResponseBodyFeature(PipeWriter writer, Task? startAsyncTask = null)
         {
             Writer = writer;
+            _startAsyncTask = startAsyncTask ?? Task.CompletedTask;
         }
 
         public PipeWriter Writer { get; }
@@ -52,7 +55,7 @@ namespace Grpc.Tests.Shared
 
         public Task StartAsync(CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return _startAsyncTask;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/902

Gives a friendly user error when attempting to write to server stream writer without awaiting.