### PR TITLE
Remove Google.ProtoBuf from AspNetCore server csproj

### DIFF
--- a/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
@@ -24,6 +24,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
+++ b/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Reflection" Version="$(GrpcPackageVersion)" />
 
     <ProjectReference Include="..\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />

--- a/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
+++ b/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
@@ -22,7 +22,6 @@
     <!-- PrivateAssets set to None to ensure the build targets/props are propagated to parent project -->
     <ProjectReference Include="..\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" PrivateAssets="None" />
 
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <!-- PrivateAssets set to None to ensure the build targets/props are propagated to parent project -->
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="None" />
   </ItemGroup>

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
@@ -18,6 +18,8 @@
     <Protobuf Include="grpc\testing\payloads.proto" GrpcServices="None" />
 
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
+
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageVersion)" />

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -19,6 +19,8 @@
 
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
+
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As far as I can tell there is no dependency on ProtoBuf as there shouldn't be anyway since gRPC is data format agnostic.