### PR TITLE
Fixed AsyncStreamReaderExtensions.ReadAllAsync argument validation

### DIFF
--- a/src/Grpc.Net.Common/AsyncStreamReaderExtensions.cs
+++ b/src/Grpc.Net.Common/AsyncStreamReaderExtensions.cs
@@ -34,13 +34,18 @@ namespace Grpc.Core
         /// <param name="streamReader">The stream reader.</param>
         /// <param name="cancellationToken">The cancellation token to use to cancel the enumeration.</param>
         /// <returns>The created async enumerable.</returns>
-        public async static IAsyncEnumerable<T> ReadAllAsync<T>(this IAsyncStreamReader<T> streamReader, [EnumeratorCancellation]CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<T> ReadAllAsync<T>(this IAsyncStreamReader<T> streamReader, CancellationToken cancellationToken = default)
         {
             if (streamReader == null)
             {
                 throw new System.ArgumentNullException(nameof(streamReader));
             }
 
+            return ReadAllAsyncCore(streamReader, cancellationToken);
+        }
+
+        private static async IAsyncEnumerable<T> ReadAllAsyncCore<T>(IAsyncStreamReader<T> streamReader, [EnumeratorCancellation]CancellationToken cancellationToken)
+        {
             while (await streamReader.MoveNext(cancellationToken).ConfigureAwait(false))
             {
                 yield return streamReader.Current;


### PR DESCRIPTION
The check for `streamReader == null` was performed on iterating. With this change the check is performed when getting the `IAsyncEnumerable` (eager), i.e. when `ReadAllAsync` is called.

It's an extension method, so it's rather unlikely to be called as `null.ReadAllAsync()`, but to be on the safe side an fail early I believe this should get in :wink: