### PR TITLE
Fix sending and receiving duplicate header names

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -364,11 +364,11 @@ namespace Grpc.AspNetCore.Server.Internal
                     {
                         if (entry.IsBinary)
                         {
-                            HttpContext.Response.Headers[entry.Key] = Convert.ToBase64String(entry.ValueBytes);
+                            HttpContext.Response.Headers.Append(entry.Key, Convert.ToBase64String(entry.ValueBytes));
                         }
                         else
                         {
-                            HttpContext.Response.Headers[entry.Key] = entry.Value;
+                            HttpContext.Response.Headers.Append(entry.Key, entry.Value);
                         }
                     }
                 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -362,14 +362,8 @@ namespace Grpc.AspNetCore.Server.Internal
                     }
                     else
                     {
-                        if (entry.IsBinary)
-                        {
-                            HttpContext.Response.Headers.Append(entry.Key, Convert.ToBase64String(entry.ValueBytes));
-                        }
-                        else
-                        {
-                            HttpContext.Response.Headers.Append(entry.Key, entry.Value);
-                        }
+                        var encodedValue = entry.IsBinary ? Convert.ToBase64String(entry.ValueBytes) : entry.Value;
+                        HttpContext.Response.Headers.Append(entry.Key, encodedValue);
                     }
                 }
             }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -74,13 +74,17 @@ namespace Grpc.Net.Client.Internal
                 {
                     continue;
                 }
-                else if (header.Key.EndsWith(Metadata.BinaryHeaderSuffix, StringComparison.OrdinalIgnoreCase))
+
+                foreach (var value in header.Value)
                 {
-                    headers.Add(header.Key, GrpcProtocolHelpers.ParseBinaryHeader(string.Join(",", header.Value)));
-                }
-                else
-                {
-                    headers.Add(header.Key, string.Join(",", header.Value));
+                    if (header.Key.EndsWith(Metadata.BinaryHeaderSuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        headers.Add(header.Key, ParseBinaryHeader(value));
+                    }
+                    else
+                    {
+                        headers.Add(header.Key, value);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/915

PR fixes concatenated values. I also noticed the server wasn't sending duplicate response headers.

I couldn't replicate having no headers. If might be fixed in 2.29.0-pre1.

@mgravell 