### PR TITLE
Fix MaxReceiveMessageSize/MaxSendMessageSize null issues

### DIFF
--- a/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
@@ -28,7 +28,10 @@ namespace Grpc.AspNetCore.Server
     public class GrpcServiceOptions
     {
         internal IList<ICompressionProvider>? _compressionProviders;
-
+        internal bool _maxReceiveMessageSizeConfigured;
+        
+        private int? _maxReceiveMessageSize;
+        
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be sent from the server.
         /// </summary>
@@ -37,7 +40,15 @@ namespace Grpc.AspNetCore.Server
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be received by the server.
         /// </summary>
-        public int? MaxReceiveMessageSize { get; set; }
+        public int? MaxReceiveMessageSize
+        {
+            get => _maxReceiveMessageSize;
+            set
+            {
+                _maxReceiveMessageSize = value;
+                _maxReceiveMessageSizeConfigured = true;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether detailed error messages are sent to the peer.

--- a/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
@@ -29,13 +29,22 @@ namespace Grpc.AspNetCore.Server
     {
         internal IList<ICompressionProvider>? _compressionProviders;
         internal bool _maxReceiveMessageSizeConfigured;
-        
-        private int? _maxReceiveMessageSize;
-        
+        internal int? _maxReceiveMessageSize;
+        internal bool _maxSendMessageSizeConfigured;
+        internal int? _maxSendMessageSize;
+
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be sent from the server.
         /// </summary>
-        public int? MaxSendMessageSize { get; set; }
+        public int? MaxSendMessageSize
+        {
+            get => _maxSendMessageSize;
+            set
+            {
+                _maxSendMessageSize = value;
+                _maxSendMessageSizeConfigured = true;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be received by the server.

--- a/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcServiceOptions.cs
@@ -35,6 +35,10 @@ namespace Grpc.AspNetCore.Server
 
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be sent from the server.
+        /// Attempting to send a message that exceeds the configured maximum message size results in an exception.
+        /// <para>
+        /// A <c>null</c> value removes the maximum message size limit. Defaults to <c>null</c>.
+        /// </para>
         /// </summary>
         public int? MaxSendMessageSize
         {
@@ -48,6 +52,10 @@ namespace Grpc.AspNetCore.Server
 
         /// <summary>
         /// Gets or sets the maximum message size in bytes that can be received by the server.
+        /// If the server receives a message that exceeds this limit, it throws an exception.
+        /// <para>
+        /// A <c>null</c> value removes the maximum message size limit. Defaults to 4,194,304 (4 MB).
+        /// </para>
         /// </summary>
         public int? MaxReceiveMessageSize
         {

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
@@ -27,12 +27,13 @@ namespace Grpc.AspNetCore.Server.Internal
         // Default to no send limit and 4mb receive limit.
         // Matches the gRPC C impl defaults
         // https://github.com/grpc/grpc/blob/977df7208a6e3f9a62a6369af5cd6e4b69b4fdec/include/grpc/impl/codegen/grpc_types.h#L413-L416
-        private const int DefaultReceiveMaxMessageSize = 4 * 1024 * 1024;
+        internal const int DefaultReceiveMaxMessageSize = 4 * 1024 * 1024;
 
         public void Configure(GrpcServiceOptions options)
         {
-            if (options.MaxReceiveMessageSize == null)
+            if (!options._maxReceiveMessageSizeConfigured)
             {
+                // Only default MaxReceiveMessageSize if it was not configured
                 options.MaxReceiveMessageSize = DefaultReceiveMaxMessageSize;
             }
             if (options._compressionProviders == null || options._compressionProviders.Count == 0)

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
@@ -34,7 +34,7 @@ namespace Grpc.AspNetCore.Server.Internal
             if (!options._maxReceiveMessageSizeConfigured)
             {
                 // Only default MaxReceiveMessageSize if it was not configured
-                options.MaxReceiveMessageSize = DefaultReceiveMaxMessageSize;
+                options._maxReceiveMessageSize = DefaultReceiveMaxMessageSize;
             }
             if (options._compressionProviders == null || options._compressionProviders.Count == 0)
             {

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -50,7 +50,8 @@ namespace Grpc.AspNetCore.Server.Internal
             _globalOptions = globalOptions.Value;
         }
 
-        private MethodOptions CreateMethodOptions()
+        // Internal for testing
+        internal MethodOptions CreateMethodOptions()
         {
             return MethodOptions.Create(new[] { _globalOptions, _serviceOptions });
         }

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -48,12 +48,20 @@ namespace Grpc.Net.Client
         public ChannelCredentials? Credentials { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum message size in bytes that can be sent from the client.
+        /// Gets or sets the maximum message size in bytes that can be sent from the client. Attempting to send a message
+        /// that exceeds the configured maximum message size results in an exception.
+        /// <para>
+        /// A <c>null</c> value removes the maximum message size limit. Defaults to <c>null</c>.
+        /// </para>
         /// </summary>
         public int? MaxSendMessageSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum message size in bytes that can be received by the client.
+        /// Gets or sets the maximum message size in bytes that can be received by the client. If the client receives a
+        /// message that exceeds this limit, it throws an exception.
+        /// <para>
+        /// A <c>null</c> value removes the maximum message size limit. Defaults to 4,194,304 (4 MB).
+        /// </para>
         /// </summary>
         public int? MaxReceiveMessageSize { get; set; }
 

--- a/src/Shared/Server/MethodOptions.cs
+++ b/src/Shared/Server/MethodOptions.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
 using Grpc.AspNetCore.Server;
+using Grpc.AspNetCore.Server.Internal;
 using Grpc.Net.Compression;
 
 namespace Grpc.Shared.Server
@@ -113,7 +114,9 @@ namespace Grpc.Shared.Server
             var resolvedCompressionProviders = new Dictionary<string, ICompressionProvider>(StringComparer.Ordinal);
             var tempInterceptors = new List<InterceptorRegistration>();
             int? maxSendMessageSize = null;
-            int? maxReceiveMessageSize = null;
+            var maxSendMessageSizeConfigured = false;
+            int? maxReceiveMessageSize = GrpcServiceOptionsSetup.DefaultReceiveMaxMessageSize;
+            var maxReceiveMessageSizeConfigured = false;
             bool? enableDetailedErrors = null;
             string? responseCompressionAlgorithm = null;
             CompressionLevel? responseCompressionLevel = null;
@@ -122,8 +125,16 @@ namespace Grpc.Shared.Server
             {
                 AddCompressionProviders(resolvedCompressionProviders, options.CompressionProviders);
                 tempInterceptors.InsertRange(0, options.Interceptors);
-                maxSendMessageSize ??= options.MaxSendMessageSize;
-                maxReceiveMessageSize ??= options.MaxReceiveMessageSize;
+                if (!maxSendMessageSizeConfigured && options._maxSendMessageSizeConfigured)
+                {
+                    maxSendMessageSize = options.MaxSendMessageSize;
+                    maxSendMessageSizeConfigured = true;
+                }
+                if (!maxReceiveMessageSizeConfigured && options._maxReceiveMessageSizeConfigured)
+                {
+                    maxReceiveMessageSize = options.MaxReceiveMessageSize;
+                    maxReceiveMessageSizeConfigured = true;
+                }
                 enableDetailedErrors ??= options.EnableDetailedErrors;
                 responseCompressionAlgorithm ??= options.ResponseCompressionAlgorithm;
                 responseCompressionLevel ??= options.ResponseCompressionLevel;

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcServicesExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcServicesExtensionsTests.cs
@@ -98,5 +98,26 @@ namespace Grpc.AspNetCore.Server.Tests
             // Assert
             Assert.AreEqual(null, options.MaxReceiveMessageSize);
         }
+
+        [Test]
+        public void AddServiceOptions_MaxReceiveMessageSizeNull_NullOverrideGlobalOptions()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services
+                .AddGrpc()
+                .AddServiceOptions<object>(o =>
+                {
+                    o.MaxReceiveMessageSize = null;
+                });
+
+            var serviceProvider = services.BuildServiceProvider(validateScopes: true);
+
+            // Act
+            var options = serviceProvider.GetRequiredService<IOptions<GrpcServiceOptions<object>>>().Value;
+
+            // Assert
+            Assert.AreEqual(null, options.MaxReceiveMessageSize);
+        }
     }
 }

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcServicesExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcServicesExtensionsTests.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using Grpc.AspNetCore.Server.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
@@ -34,7 +35,6 @@ namespace Grpc.AspNetCore.Server.Tests
                 .AddGrpc(o =>
                 {
                     o.EnableDetailedErrors = true;
-                    o.MaxReceiveMessageSize = 1;
                     o.MaxSendMessageSize = 1;
                 });
 
@@ -45,8 +45,10 @@ namespace Grpc.AspNetCore.Server.Tests
 
             // Assert
             Assert.AreEqual(true, options.EnableDetailedErrors);
-            Assert.AreEqual(1, options.MaxReceiveMessageSize);
+            Assert.AreEqual(GrpcServiceOptionsSetup.DefaultReceiveMaxMessageSize, options.MaxReceiveMessageSize);
             Assert.AreEqual(1, options.MaxSendMessageSize);
+            Assert.AreEqual(1, options.CompressionProviders.Count);
+            Assert.AreEqual("gzip", options.CompressionProviders[0].EncodingName);
         }
 
         [Test]
@@ -58,12 +60,12 @@ namespace Grpc.AspNetCore.Server.Tests
                 .AddGrpc(o =>
                 {
                     o.EnableDetailedErrors = true;
-                    o.MaxReceiveMessageSize = 1;
                     o.MaxSendMessageSize = 1;
                 })
                 .AddServiceOptions<object>(o =>
                 {
                     o.MaxSendMessageSize = 2;
+                    o.MaxReceiveMessageSize = 1;
                 });
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
@@ -75,6 +77,26 @@ namespace Grpc.AspNetCore.Server.Tests
             Assert.AreEqual(true, options.EnableDetailedErrors);
             Assert.AreEqual(1, options.MaxReceiveMessageSize);
             Assert.AreEqual(2, options.MaxSendMessageSize);
+        }
+
+        [Test]
+        public void AddGrpc_MaxReceiveMessageSizeNull_RemainsNull()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services
+                .AddGrpc(o =>
+                {
+                    o.MaxReceiveMessageSize = null;
+                });
+
+            var serviceProvider = services.BuildServiceProvider(validateScopes: true);
+
+            // Act
+            var options = serviceProvider.GetRequiredService<IOptions<GrpcServiceOptions>>().Value;
+
+            // Assert
+            Assert.AreEqual(null, options.MaxReceiveMessageSize);
         }
     }
 }

--- a/test/Grpc.AspNetCore.Server.Tests/ServerCallHandlerFactoryTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/ServerCallHandlerFactoryTests.cs
@@ -81,6 +81,21 @@ namespace Grpc.AspNetCore.Server.Tests
         }
 
         [Test]
+        public void CreateMethodOptions_MaxReceiveMessageSizeGlobalNullWithOverride_UseOverride()
+        {
+            // Arrange
+            var factory = CreateServerCallHandlerFactory(
+                o => o.MaxReceiveMessageSize = null,
+                o => o.MaxReceiveMessageSize = 1);
+
+            // Act
+            var options = factory.CreateMethodOptions();
+
+            // Assert
+            Assert.AreEqual(1, options.MaxReceiveMessageSize);
+        }
+
+        [Test]
         public void CreateMethodOptions_MaxSendMessageSizeServiceNull_NullValue()
         {
             // Arrange
@@ -93,6 +108,21 @@ namespace Grpc.AspNetCore.Server.Tests
 
             // Assert
             Assert.AreEqual(null, options.MaxSendMessageSize);
+        }
+
+        [Test]
+        public void CreateMethodOptions_MaxSendMessageSizeGlobalNullWithOverride_UseOverride()
+        {
+            // Arrange
+            var factory = CreateServerCallHandlerFactory(
+                o => o.MaxSendMessageSize = null,
+                o => o.MaxSendMessageSize = 1);
+
+            // Act
+            var options = factory.CreateMethodOptions();
+
+            // Assert
+            Assert.AreEqual(1, options.MaxSendMessageSize);
         }
 
         private static ServerCallHandlerFactory<object> CreateServerCallHandlerFactory(

--- a/test/Grpc.AspNetCore.Server.Tests/ServerCallHandlerFactoryTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/ServerCallHandlerFactoryTests.cs
@@ -1,0 +1,110 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Greet;
+using Grpc.AspNetCore.Server.Internal;
+using Grpc.AspNetCore.Server.Model;
+using Grpc.AspNetCore.Server.Model.Internal;
+using Grpc.AspNetCore.Server.Tests.TestObjects;
+using Grpc.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.Server.Tests
+{
+    [TestFixture]
+    public class ServerCallHandlerFactoryTests
+    {
+        [Test]
+        public void CreateMethodOptions_MaxReceiveMessageSizeUnset_DefaultValue()
+        {
+            // Arrange
+            var factory = CreateServerCallHandlerFactory(
+                o => { },
+                o => { });
+
+            // Act
+            var options = factory.CreateMethodOptions();
+
+            // Assert
+            Assert.AreEqual(GrpcServiceOptionsSetup.DefaultReceiveMaxMessageSize, options.MaxReceiveMessageSize);
+        }
+
+        [Test]
+        public void CreateMethodOptions_MaxReceiveMessageSizeGlobalNull_NullValue()
+        {
+            // Arrange
+            var factory = CreateServerCallHandlerFactory(
+                o => o.MaxReceiveMessageSize = null,
+                o => { });
+
+            // Act
+            var options = factory.CreateMethodOptions();
+
+            // Assert
+            Assert.AreEqual(null, options.MaxReceiveMessageSize);
+        }
+
+        [Test]
+        public void CreateMethodOptions_MaxReceiveMessageSizeServiceNull_NullValue()
+        {
+            // Arrange
+            var factory = CreateServerCallHandlerFactory(
+                o => { },
+                o => o.MaxReceiveMessageSize = null);
+
+            // Act
+            var options = factory.CreateMethodOptions();
+
+            // Assert
+            Assert.AreEqual(null, options.MaxReceiveMessageSize);
+        }
+
+        [Test]
+        public void CreateMethodOptions_MaxSendMessageSizeServiceNull_NullValue()
+        {
+            // Arrange
+            var factory = CreateServerCallHandlerFactory(
+                o => o.MaxSendMessageSize = 1,
+                o => o.MaxSendMessageSize = null);
+
+            // Act
+            var options = factory.CreateMethodOptions();
+
+            // Assert
+            Assert.AreEqual(null, options.MaxSendMessageSize);
+        }
+
+        private static ServerCallHandlerFactory<object> CreateServerCallHandlerFactory(
+            Action<GrpcServiceOptions> globalOptions,
+            Action<GrpcServiceOptions<object>> serviceOptions)
+        {
+            var services = new ServiceCollection();
+            services.AddGrpc(globalOptions).AddServiceOptions<object>(serviceOptions);
+            services.AddLogging();
+            var serviceProvider = services.BuildServiceProvider();
+
+            return serviceProvider.GetRequiredService<ServerCallHandlerFactory<object>>();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/966

Ensure that setting max size values to null on server overrides previous values.