### PR TITLE
Rename variables and args related to client certificate benchmark

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <GoogleProtobufPackageVersion>3.12.2</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.29.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.30.0-pre1</GrpcPackageVersion>
-    <MicrosoftAspNetCorePackageAppVersion>3.1.3</MicrosoftAspNetCorePackageAppVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>3.1.3</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreBlazorPackageVersion>3.2.0</MicrosoftAspNetCoreBlazorPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <GoogleProtobufPackageVersion>3.12.2</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.29.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.30.0-pre1</GrpcPackageVersion>
-    <MicrosoftAspNetCorePackageVersion>3.1.3</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftAspNetCorePackageAppVersion>3.1.3</MicrosoftAspNetCorePackageAppVersion>
     <MicrosoftAspNetCoreBlazorPackageVersion>3.2.0</MicrosoftAspNetCoreBlazorPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>

--- a/examples/Blazor/Server/Server.csproj
+++ b/examples/Blazor/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\weather.proto" GrpcServices="Server" Link="Protos\weather.proto" />
     <Protobuf Include="..\Proto\count.proto" GrpcServices="Server" Link="Protos\count.proto" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreBlazorPackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="$(GrpcDotNetPackageVersion)" />

--- a/examples/Blazor/Server/Server.csproj
+++ b/examples/Blazor/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\weather.proto" GrpcServices="Server" Link="Protos\weather.proto" />
     <Protobuf Include="..\Proto\count.proto" GrpcServices="Server" Link="Protos\count.proto" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreBlazorPackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="$(GrpcDotNetPackageVersion)" />

--- a/examples/Certifier/Server/Server.csproj
+++ b/examples/Certifier/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\certify.proto" GrpcServices="Server" Link="Protos\certify.proto" />
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/examples/Certifier/Server/Server.csproj
+++ b/examples/Certifier/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\certify.proto" GrpcServices="Server" Link="Protos\certify.proto" />
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
   </ItemGroup>
 
 </Project>

--- a/examples/Tester/Tests/Tests.csproj
+++ b/examples/Tester/Tests/Tests.csproj
@@ -8,7 +8,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="NUnit" Version="$(NunitPackageVersion)" />

--- a/examples/Tester/Tests/Tests.csproj
+++ b/examples/Tester/Tests/Tests.csproj
@@ -8,7 +8,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="NUnit" Version="$(NunitPackageVersion)" />

--- a/examples/Ticketer/Server/Server.csproj
+++ b/examples/Ticketer/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\ticket.proto" GrpcServices="Server" Link="Protos\ticket.proto" />
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
   </ItemGroup>
 
 </Project>

--- a/examples/Ticketer/Server/Server.csproj
+++ b/examples/Ticketer/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\ticket.proto" GrpcServices="Server" Link="Protos\ticket.proto" />
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -40,6 +40,6 @@
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
   </ItemGroup>
 </Project>

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -40,6 +40,6 @@
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/perf/benchmarkapps/GrpcClient/ClientOptions.cs
+++ b/perf/benchmarkapps/GrpcClient/ClientOptions.cs
@@ -29,7 +29,7 @@ namespace GrpcClient
         public string? Scenario { get; set; }
         public bool Latency { get; set; }
         public string? Protocol { get; set; }
-        public bool ClientCertificate { get; set; }
+        public bool EnableCertAuth { get; set; }
         public LogLevel LogLevel { get; set; }
         public int RequestSize { get; set; }
         public int ResponseSize { get; set; }

--- a/perf/benchmarkapps/GrpcClient/Program.cs
+++ b/perf/benchmarkapps/GrpcClient/Program.cs
@@ -73,7 +73,7 @@ namespace GrpcClient
             rootCommand.AddOption(new Option<int>(new string[] { "--responseSize" }, "Response payload size"));
             rootCommand.AddOption(new Option<GrpcClientType>(new string[] { "--grpcClientType" }, () => GrpcClientType.GrpcNetClient, "Whether to use Grpc.NetClient or Grpc.Core client"));
             rootCommand.AddOption(new Option<int>(new string[] { "--streams" }, () => 1, "Maximum concurrent streams per connection"));
-            rootCommand.AddOption(new Option<bool>(new string[] { "--clientCertificate" }, () => false, "Flag indicating whether client sends a client certificate"));
+            rootCommand.AddOption(new Option<bool>(new string[] { "--enableCertAuth" }, () => false, "Flag indicating whether client sends a client certificate"));
 
             rootCommand.Handler = CommandHandler.Create<ClientOptions>(async (options) =>
             {
@@ -366,7 +366,7 @@ namespace GrpcClient
             {
                 default:
                 case GrpcClientType.GrpcCore:
-                    if (_options.ClientCertificate)
+                    if (_options.EnableCertAuth)
                     {
                         throw new Exception("Client certificate not implemented for Grpc.Core");
                     }
@@ -386,7 +386,7 @@ namespace GrpcClient
                     var httpClientHandler = new HttpClientHandler();
                     httpClientHandler.UseProxy = false;
                     httpClientHandler.AllowAutoRedirect = false;
-                    if (_options.ClientCertificate)
+                    if (_options.EnableCertAuth)
                     {
                         var basePath = Path.GetDirectoryName(typeof(Program).Assembly.Location);
                         var certPath = Path.Combine(basePath!, "Certs", "client.pfx");

--- a/perf/benchmarkapps/GrpcClient/Program.cs
+++ b/perf/benchmarkapps/GrpcClient/Program.cs
@@ -262,7 +262,9 @@ namespace GrpcClient
                     _latencyPerConnection[i].Sort();
                 }
 
-                BenchmarksEventSource.Measure("grpc/latency/mean", totalSum / totalCount);
+                var mean = (totalCount != 0) ? totalSum / totalCount : totalSum;
+
+                BenchmarksEventSource.Measure("grpc/latency/mean", mean);
 
                 var allConnections = new List<double>();
                 foreach (var connectionLatency in _latencyPerConnection)
@@ -280,6 +282,13 @@ namespace GrpcClient
                 BenchmarksEventSource.Measure("grpc/latency/90", GetPercentile(90, allConnections));
                 BenchmarksEventSource.Measure("grpc/latency/99", GetPercentile(99, allConnections));
                 BenchmarksEventSource.Measure("grpc/latency/max", GetPercentile(100, allConnections));
+
+                Log($"Mean latency: {mean:0.###}ms");
+                Log($"Max latency: {GetPercentile(100, allConnections):0.###}ms");
+                Log($"50 percentile latency: {GetPercentile(50, allConnections):0.###}ms");
+                Log($"75 percentile latency: {GetPercentile(75, allConnections):0.###}ms");
+                Log($"90 percentile latency: {GetPercentile(90, allConnections):0.###}ms");
+                Log($"99 percentile latency: {GetPercentile(99, allConnections):0.###}ms");
             }
             else
             {
@@ -291,12 +300,9 @@ namespace GrpcClient
                     totalCount += average.count;
                 }
 
-                if (totalCount != 0)
-                {
-                    totalSum /= totalCount;
-                }
+                var mean = (totalCount != 0) ? totalSum / totalCount : totalSum;
 
-                BenchmarksEventSource.Measure("grpc/latency/mean", totalSum);
+                BenchmarksEventSource.Measure("grpc/latency/mean", mean);
                 BenchmarksEventSource.Measure("grpc/latency/max", _maxLatency);
 
                 Log($"Mean latency: {totalSum:0.###}ms");

--- a/perf/benchmarkapps/GrpcClient/Program.cs
+++ b/perf/benchmarkapps/GrpcClient/Program.cs
@@ -305,7 +305,7 @@ namespace GrpcClient
                 BenchmarksEventSource.Measure("grpc/latency/mean", mean);
                 BenchmarksEventSource.Measure("grpc/latency/max", _maxLatency);
 
-                Log($"Mean latency: {totalSum:0.###}ms");
+                Log($"Mean latency: {mean:0.###}ms");
                 Log($"Max latency: {_maxLatency:0.###}ms");
             }
         }

--- a/perf/benchmarkapps/GrpcClient/grpc-client.yml
+++ b/perf/benchmarkapps/GrpcClient/grpc-client.yml
@@ -16,5 +16,5 @@
       grpcClientType: GrpcNetClient
       requestSize: 0
       responseSize: 0
-      clientCertificate: false
-    arguments: "-c {{connections}} --streams {{streams}} -d {{duration}} -p {{protocol}} -s {{scenario}} -u {{serverUri}}:{{serverPort}}{{path}} -w {{warmup}} --grpcClientType {{grpcClientType}} --requestSize {{requestSize}} --responseSize {{responseSize}} --clientCertificate {{clientCertificate}} {% if logLevel != 'none' %} --logLevel {{ logLevel }} {% endif %}"
+      enableCertAuth: false
+    arguments: "-c {{connections}} --streams {{streams}} -d {{duration}} -p {{protocol}} -s {{scenario}} -u {{serverUri}}:{{serverPort}}{{path}} -w {{warmup}} --grpcClientType {{grpcClientType}} --requestSize {{requestSize}} --responseSize {{responseSize}} --enableCertAuth {{enableCertAuth}} {% if logLevel != 'none' %} --logLevel {{ logLevel }} {% endif %}"

--- a/perf/benchmarkapps/GrpcClient/grpc-client.yml
+++ b/perf/benchmarkapps/GrpcClient/grpc-client.yml
@@ -17,4 +17,5 @@
       requestSize: 0
       responseSize: 0
       enableCertAuth: false
-    arguments: "-c {{connections}} --streams {{streams}} -d {{duration}} -p {{protocol}} -s {{scenario}} -u {{serverUri}}:{{serverPort}}{{path}} -w {{warmup}} --grpcClientType {{grpcClientType}} --requestSize {{requestSize}} --responseSize {{responseSize}} --enableCertAuth {{enableCertAuth}} {% if logLevel != 'none' %} --logLevel {{ logLevel }} {% endif %}"
+      latency: false
+    arguments: "-c {{connections}} --streams {{streams}} -d {{duration}} -p {{protocol}} -s {{scenario}} -u {{serverUri}}:{{serverPort}}{{path}} -w {{warmup}} --grpcClientType {{grpcClientType}} --requestSize {{requestSize}} --responseSize {{responseSize}} --enableCertAuth {{enableCertAuth}} --latency {{latency}} {% if logLevel != 'none' %} --logLevel {{ logLevel }} {% endif %}"

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -23,7 +23,7 @@
 
     <ProjectReference Include="..\..\testassets\FunctionalTestsWebsite\FunctionalTestsWebsite.csproj" />
 
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
 
     <None Update="server1.pfx">

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -23,7 +23,7 @@
 
     <ProjectReference Include="..\..\testassets\FunctionalTestsWebsite\FunctionalTestsWebsite.csproj" />
 
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
 
     <None Update="server1.pfx">

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     
     <Protobuf Include="..\Proto\any.proto" Link="Protos\any.proto" />
     <Protobuf Include="..\Proto\authorize.proto" Link="Protos\authorize.proto" />

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
     
     <Protobuf Include="..\Proto\any.proto" Link="Protos\any.proto" />
     <Protobuf Include="..\Proto\authorize.proto" Link="Protos\authorize.proto" />

--- a/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
+++ b/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreBlazorPackageVersion)" />
   </ItemGroup>
 

--- a/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
+++ b/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCorePackageAppVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreBlazorPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Change dependencies.prop's `MicrosoftAspNetCorePackageVersion` to `MicrosoftAspNetCoreAppPackageVersion` so it matches the benchmark environment name for this variable

Change gRPC benchmark client's `ClientCertificate` variable to `EnableCertAuth` so it matches the server variable.