### PR TITLE
Use latest version of OpenTelemetry with gRPC in sample

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -19,7 +19,7 @@
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
     <NunitPackageVersion>3.12.0</NunitPackageVersion>
     <Nunit3TestAdapterPackageVersion>3.16.1</Nunit3TestAdapterPackageVersion>
-    <OpenTelemetryPackageVersion>0.2.0-alpha.100</OpenTelemetryPackageVersion>
+    <OpenTelemetryPackageVersion>0.4.0-beta.2</OpenTelemetryPackageVersion>
     <SystemCommandLinePackageVersion>2.0.0-beta1.20214.1</SystemCommandLinePackageVersion>
     <SystemCommandLineRenderingPackageVersion>0.3.0-alpha.20214.1</SystemCommandLineRenderingPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.1</SystemDiagnosticsDiagnosticSourcePackageVersion>

--- a/examples/Aggregator/Server/Server.csproj
+++ b/examples/Aggregator/Server/Server.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryPackageVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryPackageVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Grpc" Version="$(OpenTelemetryPackageVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/examples/Aggregator/Server/Server.csproj
+++ b/examples/Aggregator/Server/Server.csproj
@@ -11,10 +11,10 @@
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
 
-    <PackageReference Include="OpenTelemetry.Hosting" Version="$(OpenTelemetryPackageVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryPackageVersion)" />
-    <PackageReference Include="OpenTelemetry.Collector.Dependencies" Version="$(OpenTelemetryPackageVersion)" />
-    <PackageReference Include="OpenTelemetry.Collector.AspNetCore" Version="$(OpenTelemetryPackageVersion)" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryPackageVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryPackageVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Grpc" Version="$(OpenTelemetryPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/examples/Aggregator/Server/Startup.cs
+++ b/examples/Aggregator/Server/Startup.cs
@@ -50,6 +50,7 @@ namespace Server
                 {
                     telemetry.UseZipkinExporter(o => o.ServiceName = "aggregator");
                     telemetry.AddGrpcClientInstrumentation();
+                    telemetry.AddHttpClientInstrumentation();
                     telemetry.AddAspNetCoreInstrumentation();
                 });
             }

--- a/examples/Aggregator/Server/Startup.cs
+++ b/examples/Aggregator/Server/Startup.cs
@@ -17,7 +17,6 @@
 #endregion
 
 using System;
-using System.Diagnostics;
 using Count;
 using Greet;
 using Microsoft.AspNetCore.Builder;
@@ -26,8 +25,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Trace;
 
 namespace Server
 {
@@ -50,9 +48,9 @@ namespace Server
             {
                 services.AddOpenTelemetry(telemetry =>
                 {
-                    telemetry.UseZipkin(o => o.ServiceName = "aggregator");
-                    telemetry.AddDependencyCollector();
-                    telemetry.AddRequestCollector();
+                    telemetry.UseZipkinExporter(o => o.ServiceName = "aggregator");
+                    telemetry.AddGrpcClientInstrumentation();
+                    telemetry.AddAspNetCoreInstrumentation();
                 });
             }
 


### PR DESCRIPTION
Updated packages, startup API, and use new gRPC instrumentation.