### PR TITLE
Fix benchmarks app on net5.0

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -112,10 +112,10 @@ namespace GrpcAspNetCoreServer
                         Console.WriteLine($"Console Logging enabled with level '{logLevel}'");
 
                         loggerFactory
-#if NETCOREAPP3_1
-                            .AddConsole(o => o.TimestampFormat = "ss.ffff ")
-#else
+#if NET5_0
                             .AddSimpleConsole(o => o.TimestampFormat = "ss.ffff ")
+#else
+                            .AddConsole(o => o.TimestampFormat = "ss.ffff ")
 #endif
                             .SetMinimumLevel(logLevel);
                     }


### PR DESCRIPTION
AddConsole + TimestampFormat is obsolete.