### PR TITLE
Fix repeatedly decoding base64 with large grpc-web-text request

### DIFF
--- a/src/Grpc.AspNetCore.Web/Internal/MemorySegment.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/MemorySegment.cs
@@ -1,0 +1,43 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Buffers;
+
+namespace Grpc.AspNetCore.Web.Internal
+{
+    internal class MemorySegment<T> : ReadOnlySequenceSegment<T>
+    {
+        public MemorySegment(ReadOnlyMemory<T> memory)
+        {
+            Memory = memory;
+        }
+
+        public MemorySegment<T> Append(ReadOnlyMemory<T> memory)
+        {
+            var segment = new MemorySegment<T>(memory)
+            {
+                RunningIndex = RunningIndex + Memory.Length
+            };
+
+            Next = segment;
+
+            return segment;
+        }
+    }
+}

--- a/test/FunctionalTests/TestServer/TesterServiceTests.cs
+++ b/test/FunctionalTests/TestServer/TesterServiceTests.cs
@@ -91,20 +91,17 @@ namespace Grpc.AspNetCore.FunctionalTests.TestServer
             // Act
             using var call = client.SayHelloClientStreamingError();
 
-            var ex = await ExceptionAssert.ThrowsAsync<InvalidOperationException>(async () =>
+            var ex = await ExceptionAssert.ThrowsAsync<Exception>(async () =>
             {
-                var names = new[] { "James", "Jo", "Lee" };
-
+                while (true)
                 {
-                    foreach (var name in names)
-                    {
-                        await call.RequestStream.WriteAsync(new HelloRequest { Name = name }).DefaultTimeout();
-                        await Task.Delay(50);
-                    }
+                    await call.RequestStream.WriteAsync(new HelloRequest { Name = "Name!" }).DefaultTimeout();
+                    await Task.Delay(50);
                 }
             }).DefaultTimeout();
 
             // Assert
+            Assert.IsTrue(ex is InvalidOperationException || ex is RpcException);
             Assert.AreEqual(StatusCode.NotFound, call.GetStatus().StatusCode);
         }
 

--- a/test/Grpc.AspNetCore.Server.Tests/Web/Base64PipeReaderTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/Web/Base64PipeReaderTests.cs
@@ -20,6 +20,7 @@ using System;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.AspNetCore.Web.Internal;
 using Grpc.Tests.Shared;
@@ -75,6 +76,47 @@ namespace Grpc.AspNetCore.Server.Tests.Web
         }
 
         [Test]
+        public async Task ReadAsync_MultipleSuccesfulReadsAndWrites_Success()
+        {
+            // Arrange
+            var initialData = Encoding.UTF8.GetBytes("Hello world");
+            var base64Data = Encoding.UTF8.GetBytes(Convert.ToBase64String(initialData));
+            var testPipe = new Pipe();
+            var r = new Base64PipeReader(testPipe.Reader);
+
+            // Act 1
+            await testPipe.Writer.WriteAsync(base64Data.AsMemory(0, 5));
+            var result1 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 1
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hel"), result1.Buffer.ToArray());
+
+            // Act 2
+            r.AdvanceTo(result1.Buffer.Start, result1.Buffer.End);
+            await testPipe.Writer.WriteAsync(base64Data.AsMemory(5, 5));
+            var result2 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 2
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello "), result2.Buffer.ToArray());
+
+            // Act 3
+            r.AdvanceTo(result2.Buffer.Start, result2.Buffer.End);
+            await testPipe.Writer.WriteAsync(base64Data.AsMemory(10));
+            var result3 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 3
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), result3.Buffer.ToArray());
+
+            // Act 4
+            r.AdvanceTo(result3.Buffer.End, result3.Buffer.End);
+            await testPipe.Writer.WriteAsync(base64Data);
+            var result4 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 4
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), result4.Buffer.ToArray());
+        }
+
+        [Test]
         public async Task ReadAsync_ByteAtATime_Success()
         {
             // Arrange
@@ -104,6 +146,114 @@ namespace Grpc.AspNetCore.Server.Tests.Web
             result = await r.ReadAsync().AsTask().DefaultTimeout();
 
             CollectionAssert.AreEqual(initialData, result.Buffer.ToArray());
+        }
+
+        private class OnAdvancePipeReader : PipeReader
+        {
+            private readonly Pipe _pipe;
+            private ReadOnlyMemory<byte> _data;
+            private bool _writeToPipe;
+
+            public OnAdvancePipeReader(Pipe pipe, byte[] data)
+            {
+                _pipe = pipe;
+                _data = data;
+                _writeToPipe = true;
+            }
+
+            public override void AdvanceTo(SequencePosition consumed)
+            {
+                _pipe.Reader.AdvanceTo(consumed);
+                _writeToPipe = true;
+            }
+
+            public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+            {
+                _pipe.Reader.AdvanceTo(consumed, examined);
+                _writeToPipe = true;
+            }
+
+            public override void CancelPendingRead()
+            {
+                _pipe.Reader.CancelPendingRead();
+            }
+
+            public override void Complete(Exception? exception = null)
+            {
+                _pipe.Reader.Complete(exception);
+            }
+
+            public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+            {
+                // Write to the pipe when ReadAsync is called after Advance.
+                if (_writeToPipe)
+                {
+                    if (!_data.IsEmpty)
+                    {
+                        await _pipe.Writer.WriteAsync(_data.Slice(0, 1), cancellationToken);
+                        _data = _data.Slice(1);
+                    }
+                    else
+                    {
+                        _pipe.Writer.Complete();
+                    }
+
+                    _writeToPipe = false;
+                }
+
+                return await _pipe.Reader.ReadAsync(cancellationToken);
+            }
+
+            public override bool TryRead(out ReadResult result)
+            {
+                return _pipe.Reader.TryRead(out result);
+            }
+        }
+
+        [Test]
+        public async Task ReadAsync_ByteAtATimeOnAdvance_Success()
+        {
+            // Arrange
+            var initialData = Encoding.UTF8.GetBytes("Hello world");
+            var base64Data = Encoding.UTF8.GetBytes(Convert.ToBase64String(initialData));
+            var testPipe = new Pipe();
+            var onAdvancePipeReader = new OnAdvancePipeReader(testPipe, base64Data);
+            var r = new Base64PipeReader(onAdvancePipeReader);
+
+            // Act 1
+            var result1 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 1
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hel"), result1.Buffer.ToArray());
+
+            // Act 2
+            r.AdvanceTo(result1.Buffer.Start, result1.Buffer.End);
+            var result2 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 2
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello "), result2.Buffer.ToArray());
+
+            // Act 3
+            r.AdvanceTo(result2.Buffer.Start, result2.Buffer.End);
+            var result3 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 3
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello wor"), result3.Buffer.ToArray());
+
+            // Act 4
+            r.AdvanceTo(result3.Buffer.Start, result3.Buffer.End);
+            var result4 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 4
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("Hello world"), result4.Buffer.ToArray());
+            Assert.IsFalse(result4.IsCompleted);
+
+            // Act 4
+            r.AdvanceTo(result4.Buffer.End, result4.Buffer.End);
+            var result5 = await r.ReadAsync().AsTask().DefaultTimeout();
+
+            // Assert 4
+            Assert.IsTrue(result5.IsCompleted);
         }
 
         [TestCase("")]


### PR DESCRIPTION
Large base64 encoded messages are slow to decode. Each time ReadAsync is called all the buffered data is re-decoded.

This PR changes base64 decoding to be incremental. Only new data is decoded and it is appended to a sequence of decoded data.

3 megabyte message, IIS host:
* Before - 6000 ms
* After - 100 ms