### PR TITLE
Skip server header in benchmark website

### DIFF
--- a/testassets/InteropTestsWebsite/Program.cs
+++ b/testassets/InteropTestsWebsite/Program.cs
@@ -53,6 +53,7 @@ namespace InteropTestsWebsite
                         var http1Port = context.Configuration.GetValue<int>("port_http1", -1);
                         var useTls = context.Configuration.GetValue<bool>("use_tls", false);
 
+                        options.AddServerHeader = false;
                         options.Limits.MinRequestBodyDataRate = null;
                         options.ListenAnyIP(http2Port, o => ConfigureEndpoint(o, useTls, HttpProtocols.Http2));
                         if (http1Port != -1)


### PR DESCRIPTION
I noticed that other servers don't include "server". Lets not write it to be consistent and for the minor perf boost.