### PR TITLE
Extra metadata filtering in client and server

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
@@ -77,6 +77,7 @@ namespace Grpc.AspNetCore.Server.Internal
             MessageEncodingHeader,
             MessageAcceptEncodingHeader,
             TimeoutHeader,
+            HeaderNames.ContentEncoding,
             HeaderNames.ContentType,
             HeaderNames.TE,
             HeaderNames.Host,

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -231,5 +231,10 @@ namespace Grpc.AspNetCore.Server.Internal
 
             return canCompress;
         }
+
+        internal static bool ShouldSkipHeader(string name)
+        {
+            return name.StartsWith(':') || GrpcProtocolConstants.FilteredHeaders.Contains(name);
+        }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -117,13 +117,12 @@ namespace Grpc.AspNetCore.Server.Internal
 
                     foreach (var header in HttpContext.Request.Headers)
                     {
-                        // gRPC metadata contains a subset of the request headers
-                        // Filter out pseudo headers (start with :) and other known headers
-                        if (header.Key.StartsWith(':') || GrpcProtocolConstants.FilteredHeaders.Contains(header.Key))
+                        if (GrpcProtocolHelpers.ShouldSkipHeader(header.Key))
                         {
                             continue;
                         }
-                        else if (header.Key.EndsWith(Metadata.BinaryHeaderSuffix, StringComparison.OrdinalIgnoreCase))
+
+                        if (header.Key.EndsWith(Metadata.BinaryHeaderSuffix, StringComparison.OrdinalIgnoreCase))
                         {
                             _requestHeaders.Add(header.Key, GrpcProtocolHelpers.ParseBinaryHeader(header.Value));
                         }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -109,10 +109,6 @@ namespace Grpc.Net.Client.Internal
                     // Exclude known HTTP headers. This matches Grpc.Core client behavior.
                     return string.Equals(name, "content-encoding", StringComparison.OrdinalIgnoreCase)
                         || string.Equals(name, "content-type", StringComparison.OrdinalIgnoreCase);
-                //case 'a':
-                //case 'A':
-                //    // Exclude known grpc headers. This matches Grpc.Core client behavior.
-                //    return string.Equals(name, "accept-encoding", StringComparison.OrdinalIgnoreCase);
                 default:
                     return false;
             }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -104,6 +104,15 @@ namespace Grpc.Net.Client.Internal
                         || string.Equals(name, GrpcProtocolConstants.MessageTrailer, StringComparison.OrdinalIgnoreCase)
                         || string.Equals(name, GrpcProtocolConstants.MessageEncodingHeader, StringComparison.OrdinalIgnoreCase)
                         || string.Equals(name, GrpcProtocolConstants.MessageAcceptEncodingHeader, StringComparison.OrdinalIgnoreCase);
+                case 'c':
+                case 'C':
+                    // Exclude known HTTP headers. This matches Grpc.Core client behavior.
+                    return string.Equals(name, "content-encoding", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(name, "content-type", StringComparison.OrdinalIgnoreCase);
+                //case 'a':
+                //case 'A':
+                //    // Exclude known grpc headers. This matches Grpc.Core client behavior.
+                //    return string.Equals(name, "accept-encoding", StringComparison.OrdinalIgnoreCase);
                 default:
                     return false;
             }

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -570,7 +570,11 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             // Arrange
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers[headerName] = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
+
+            // A base64 valid value is required for -bin headers
+            var value = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
+            httpContext.Request.Headers[headerName] = value;
+
             var serverCallContext = CreateServerCallContext(httpContext);
 
             // Act

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -546,13 +546,25 @@ namespace Grpc.AspNetCore.Server.Tests
         }
 
         [TestCase("grpc-accept-encoding", false)]
+        [TestCase("GRPC-ACCEPT-ENCODING", false)]
         [TestCase("grpc-encoding", false)]
+        [TestCase("GRPC-ENCODING", false)]
         [TestCase("grpc-timeout", false)]
+        [TestCase("GRPC-TIMEOUT", false)]
         [TestCase("content-type", false)]
+        [TestCase("CONTENT-TYPE", false)]
+        [TestCase("content-encoding", false)]
+        [TestCase("CONTENT-ENCODING", false)]
         [TestCase("te", false)]
+        [TestCase("TE", false)]
         [TestCase("host", false)]
+        [TestCase("HOST", false)]
         [TestCase("accept-encoding", false)]
+        [TestCase("ACCEPT-ENCODING", false)]
         [TestCase("user-agent", true)]
+        [TestCase("USER-AGENT", true)]
+        [TestCase("grpc-status-details-bin", true)]
+        [TestCase("GRPC-STATUS-DETAILS-BIN", true)]
         public void RequestHeaders_ManyHttpRequestHeaders_HeadersFiltered(string headerName, bool addedToRequestHeaders)
         {
             // Arrange

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -24,6 +24,7 @@ using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.AspNetCore.Server.Internal;
@@ -569,7 +570,7 @@ namespace Grpc.AspNetCore.Server.Tests
         {
             // Arrange
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers[headerName] = "value";
+            httpContext.Request.Headers[headerName] = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
             var serverCallContext = CreateServerCallContext(httpContext);
 
             // Act

--- a/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
@@ -66,6 +66,10 @@ namespace Grpc.Net.Client.Tests
         [TestCase("custom", false)]
         [TestCase("grpc-status-details-bin", false)]
         [TestCase("GRPC-STATUS-DETAILS-BIN", false)]
+        [TestCase("content-encoding", true)]
+        [TestCase("CONTENT-ENCODING", true)]
+        [TestCase("content-type", true)]
+        [TestCase("CONTENT-TYPE", true)]
         public void ShouldSkipHeader(string header, bool skipped)
         {
             var result = GrpcProtocolHelpers.ShouldSkipHeader(header);


### PR DESCRIPTION
Follow up to https://github.com/grpc/grpc-dotnet/pull/1046

Filter a couple of extra headers when creating metadata collections.