### PR TITLE
[2.32.0] Don't write response grpc-encoding header when identity

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
@@ -34,8 +34,8 @@ namespace Grpc.AspNetCore.Server.Internal
         internal static readonly string Http2Protocol = HttpProtocol.Http2;
 #else
         internal const string Http2Protocol = "HTTP/2";
-#endif
         internal const string Http20Protocol = "HTTP/2.0"; // This is what IIS sets
+#endif
 
 #if NET5_0
         internal static readonly string TimeoutHeader = HeaderNames.GrpcTimeout;

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextSerializationContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextSerializationContext.cs
@@ -70,20 +70,11 @@ namespace Grpc.AspNetCore.Server.Internal
 
         private ICompressionProvider? ResolveCompressionProvider()
         {
-            Debug.Assert(
-                _serverCallContext.ResponseGrpcEncoding != null,
-                "Response encoding should have been calculated at this point.");
-
-            var canCompress =
+            if (_serverCallContext.ResponseGrpcEncoding != null &&
                 GrpcProtocolHelpers.CanWriteCompressed(_serverCallContext.WriteOptions) &&
-                !GrpcProtocolConstants.IsGrpcEncodingIdentity(_serverCallContext.ResponseGrpcEncoding);
-
-            if (canCompress)
+                _serverCallContext.Options.CompressionProviders.TryGetValue(_serverCallContext.ResponseGrpcEncoding, out var compressionProvider))
             {
-                if (_serverCallContext.Options.CompressionProviders.TryGetValue(_serverCallContext.ResponseGrpcEncoding, out var compressionProvider))
-                {
-                    return compressionProvider;
-                }
+                return compressionProvider;
             }
 
             return null;

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -382,12 +382,13 @@ namespace Grpc.AspNetCore.Server.Internal
             {
                 ResponseGrpcEncoding = serviceDefaultCompression;
             }
-            else
-            {
-                ResponseGrpcEncoding = GrpcProtocolConstants.IdentityGrpcEncoding;
-            }
 
-            HttpContext.Response.Headers[GrpcProtocolConstants.MessageEncodingHeader] = ResponseGrpcEncoding;
+            // grpc-encoding response header is optional and is inferred as 'identity' when not present.
+            // Only write a non-identity value for performance.
+            if (ResponseGrpcEncoding != null)
+            {
+                HttpContext.Response.Headers[GrpcProtocolConstants.MessageEncodingHeader] = ResponseGrpcEncoding;
+            }
         }
 
         private Activity? GetHostActivity()
@@ -530,11 +531,11 @@ namespace Grpc.AspNetCore.Server.Internal
 
         internal void ValidateAcceptEncodingContainsResponseEncoding()
         {
-            Debug.Assert(ResponseGrpcEncoding != null);
+            var resolvedResponseGrpcEncoding = ResponseGrpcEncoding ?? GrpcProtocolConstants.IdentityGrpcEncoding;
 
-            if (!IsEncodingInRequestAcceptEncoding(ResponseGrpcEncoding))
+            if (!IsEncodingInRequestAcceptEncoding(resolvedResponseGrpcEncoding))
             {
-                GrpcServerLog.EncodingNotInAcceptEncoding(Logger, ResponseGrpcEncoding);
+                GrpcServerLog.EncodingNotInAcceptEncoding(Logger, resolvedResponseGrpcEncoding);
             }
         }
     }

--- a/test/FunctionalTests/Server/CompressionTests.cs
+++ b/test/FunctionalTests/Server/CompressionTests.cs
@@ -210,7 +210,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues(GrpcProtocolConstants.MessageEncodingHeader).Single());
+            Assert.IsFalse(response.Headers.Contains(GrpcProtocolConstants.MessageEncodingHeader));
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);
@@ -490,7 +490,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual("identity", response.Headers.GetValues(GrpcProtocolConstants.MessageEncodingHeader).Single());
+            Assert.IsFalse(response.Headers.Contains(GrpcProtocolConstants.MessageEncodingHeader));
 
             var responseMessage = MessageHelpers.AssertReadMessage<HelloReply>(await response.Content.ReadAsByteArrayAsync().DefaultTimeout());
             Assert.AreEqual("Hello World", responseMessage.Message);


### PR DESCRIPTION
Cherry pick commit from https://github.com/grpc/grpc-dotnet/pull/1047