### PR TITLE
[2.32.0] Fix client to only filter known gRPC headers

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
@@ -77,6 +77,7 @@ namespace Grpc.AspNetCore.Server.Internal
             MessageEncodingHeader,
             MessageAcceptEncodingHeader,
             TimeoutHeader,
+            HeaderNames.ContentEncoding,
             HeaderNames.ContentType,
             HeaderNames.TE,
             HeaderNames.Host,

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -231,5 +231,10 @@ namespace Grpc.AspNetCore.Server.Internal
 
             return canCompress;
         }
+
+        internal static bool ShouldSkipHeader(string name)
+        {
+            return name.StartsWith(':') || GrpcProtocolConstants.FilteredHeaders.Contains(name);
+        }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -117,13 +117,12 @@ namespace Grpc.AspNetCore.Server.Internal
 
                     foreach (var header in HttpContext.Request.Headers)
                     {
-                        // gRPC metadata contains a subset of the request headers
-                        // Filter out pseudo headers (start with :) and other known headers
-                        if (header.Key.StartsWith(':') || GrpcProtocolConstants.FilteredHeaders.Contains(header.Key))
+                        if (GrpcProtocolHelpers.ShouldSkipHeader(header.Key))
                         {
                             continue;
                         }
-                        else if (header.Key.EndsWith(Metadata.BinaryHeaderSuffix, StringComparison.OrdinalIgnoreCase))
+
+                        if (header.Key.EndsWith(Metadata.BinaryHeaderSuffix, StringComparison.OrdinalIgnoreCase))
                         {
                             _requestHeaders.Add(header.Key, GrpcProtocolHelpers.ParseBinaryHeader(header.Value));
                         }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -104,6 +104,11 @@ namespace Grpc.Net.Client.Internal
                         || string.Equals(name, GrpcProtocolConstants.MessageTrailer, StringComparison.OrdinalIgnoreCase)
                         || string.Equals(name, GrpcProtocolConstants.MessageEncodingHeader, StringComparison.OrdinalIgnoreCase)
                         || string.Equals(name, GrpcProtocolConstants.MessageAcceptEncodingHeader, StringComparison.OrdinalIgnoreCase);
+                case 'c':
+                case 'C':
+                    // Exclude known HTTP headers. This matches Grpc.Core client behavior.
+                    return string.Equals(name, "content-encoding", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(name, "content-type", StringComparison.OrdinalIgnoreCase);
                 default:
                     return false;
             }

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -24,6 +24,7 @@ using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.AspNetCore.Server.Internal;
@@ -546,18 +547,34 @@ namespace Grpc.AspNetCore.Server.Tests
         }
 
         [TestCase("grpc-accept-encoding", false)]
+        [TestCase("GRPC-ACCEPT-ENCODING", false)]
         [TestCase("grpc-encoding", false)]
+        [TestCase("GRPC-ENCODING", false)]
         [TestCase("grpc-timeout", false)]
+        [TestCase("GRPC-TIMEOUT", false)]
         [TestCase("content-type", false)]
+        [TestCase("CONTENT-TYPE", false)]
+        [TestCase("content-encoding", false)]
+        [TestCase("CONTENT-ENCODING", false)]
         [TestCase("te", false)]
+        [TestCase("TE", false)]
         [TestCase("host", false)]
+        [TestCase("HOST", false)]
         [TestCase("accept-encoding", false)]
+        [TestCase("ACCEPT-ENCODING", false)]
         [TestCase("user-agent", true)]
+        [TestCase("USER-AGENT", true)]
+        [TestCase("grpc-status-details-bin", true)]
+        [TestCase("GRPC-STATUS-DETAILS-BIN", true)]
         public void RequestHeaders_ManyHttpRequestHeaders_HeadersFiltered(string headerName, bool addedToRequestHeaders)
         {
             // Arrange
             var httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers[headerName] = "value";
+
+            // A base64 valid value is required for -bin headers
+            var value = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
+            httpContext.Request.Headers[headerName] = value;
+
             var serverCallContext = CreateServerCallContext(httpContext);
 
             // Act

--- a/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
@@ -66,6 +66,10 @@ namespace Grpc.Net.Client.Tests
         [TestCase("custom", false)]
         [TestCase("grpc-status-details-bin", false)]
         [TestCase("GRPC-STATUS-DETAILS-BIN", false)]
+        [TestCase("content-encoding", true)]
+        [TestCase("CONTENT-ENCODING", true)]
+        [TestCase("content-type", true)]
+        [TestCase("CONTENT-TYPE", true)]
         public void ShouldSkipHeader(string header, bool skipped)
         {
             var result = GrpcProtocolHelpers.ShouldSkipHeader(header);

--- a/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcProtocolHelpersTests.cs
@@ -16,9 +16,7 @@
 
 #endregion
 
-using System.Net.Http.Headers;
 using Grpc.Net.Client.Internal;
-using Grpc.Shared;
 using NUnit.Framework;
 
 namespace Grpc.Net.Client.Tests
@@ -53,6 +51,25 @@ namespace Grpc.Net.Client.Tests
         {
             var encoded = GrpcProtocolHelpers.EncodeTimeout(milliseconds);
             Assert.AreEqual(expected, encoded);
+        }
+
+        [TestCase(":status", true)]
+        [TestCase(":STATUS", true)]
+        [TestCase("grpc-status", true)]
+        [TestCase("GRPC-STATUS", true)]
+        [TestCase("grpc-message", true)]
+        [TestCase("GRPC-MESSAGE", true)]
+        [TestCase("grpc-encoding", true)]
+        [TestCase("GRPC-ENCODING", true)]
+        [TestCase("grpc-accept-encoding", true)]
+        [TestCase("GRPC-ACCEPT-ENCODING", true)]
+        [TestCase("custom", false)]
+        [TestCase("grpc-status-details-bin", false)]
+        [TestCase("GRPC-STATUS-DETAILS-BIN", false)]
+        public void ShouldSkipHeader(string header, bool skipped)
+        {
+            var result = GrpcProtocolHelpers.ShouldSkipHeader(header);
+            Assert.AreEqual(skipped, result);
         }
     }
 }


### PR DESCRIPTION
Cherry pick changes from https://github.com/grpc/grpc-dotnet/pull/1046 and https://github.com/grpc/grpc-dotnet/pull/1052