### PR TITLE
Don't include server header in benchmarks for real this time

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -88,6 +88,9 @@ namespace GrpcAspNetCoreServer
                                 ConfigureListenOptions(listenOptions, config, endPoint);
                             });
                         }
+
+                        // Other gRPC servers don't include a server header
+                        options.AddServerHeader = false;
                     });
                 })
                 .ConfigureLogging(loggerFactory =>

--- a/testassets/InteropTestsWebsite/Program.cs
+++ b/testassets/InteropTestsWebsite/Program.cs
@@ -53,7 +53,6 @@ namespace InteropTestsWebsite
                         var http1Port = context.Configuration.GetValue<int>("port_http1", -1);
                         var useTls = context.Configuration.GetValue<bool>("use_tls", false);
 
-                        options.AddServerHeader = false;
                         options.Limits.MinRequestBodyDataRate = null;
                         options.ListenAnyIP(http2Port, o => ConfigureEndpoint(o, useTls, HttpProtocols.Http2));
                         if (http1Port != -1)


### PR DESCRIPTION
Opps, previous PR removed the header from the interop tests.