### PR TITLE
Client response MoveNext cancellation cancels call

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -388,6 +388,14 @@ namespace Grpc.Net.Client.Internal
                 GrpcProtocolConstants.GrpcContentTypeHeaderValue);
         }
 
+        public void CancelCallFromCancellationToken()
+        {
+            using (StartScope())
+            {
+                CancelCall(new Status(StatusCode.Cancelled, "Call canceled by the client."));
+            }
+        }
+
         private void CancelCall(Status status)
         {
             // Set overall call status first. Status can be used in throw RpcException from cancellation.
@@ -690,13 +698,7 @@ namespace Grpc.Net.Client.Internal
                 // The cancellation token will cancel the call CTS.
                 // This must be registered after the client writer has been created
                 // so that cancellation will always complete the writer.
-                _ctsRegistration = Options.CancellationToken.Register(() =>
-                {
-                    using (StartScope())
-                    {
-                        CancelCall(new Status(StatusCode.Cancelled, "Call canceled by the client."));
-                    }
-                });
+                _ctsRegistration = Options.CancellationToken.Register(CancelCallFromCancellationToken);
             }
 
             return (diagnosticSourceEnabled, activity);

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -119,21 +119,16 @@ namespace Grpc.Net.Client.Internal
 
         private async Task<bool> MoveNextCore(CancellationToken cancellationToken)
         {
-            CancellationTokenSource? cts = null;
+            CancellationTokenRegistration? ctsRegistration = null;
             try
             {
-                // Linking tokens is expensive. Only create a linked token if the token passed in requires it
                 if (cancellationToken.CanBeCanceled)
                 {
-                    cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _call.CancellationToken);
-                    cancellationToken = cts.Token;
-                }
-                else
-                {
-                    cancellationToken = _call.CancellationToken;
+                    // The cancellation token will cancel the call CTS.
+                    ctsRegistration = cancellationToken.Register(_call.CancelCallFromCancellationToken);
                 }
 
-                cancellationToken.ThrowIfCancellationRequested();
+                _call.CancellationToken.ThrowIfCancellationRequested();
 
                 if (_httpResponse == null)
                 {
@@ -167,7 +162,7 @@ namespace Grpc.Net.Client.Internal
                     _responseStream,
                     _grpcEncoding,
                     singleMessage: false,
-                    cancellationToken).ConfigureAwait(false);
+                    _call.CancellationToken).ConfigureAwait(false);
                 if (Current == null)
                 {
                     // No more content in response so report status to call.
@@ -202,7 +197,7 @@ namespace Grpc.Net.Client.Internal
             }
             finally
             {
-                cts?.Dispose();
+                ctsRegistration?.Dispose();
             }
         }
 

--- a/test/FunctionalTests/Web/Server/DeadlineTests.cs
+++ b/test/FunctionalTests/Web/Server/DeadlineTests.cs
@@ -86,28 +86,24 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Server
 
             var grpcWebClient = CreateGrpcWebClient();
 
-            // TODO(JamesNK): This test is/was flaky. Remove loop if this test is no longer a problem
-            for (int i = 0; i < 20; i++)
+            var requestMessage = new HelloRequest
             {
-                var requestMessage = new HelloRequest
-                {
-                    Name = "World"
-                };
+                Name = "World"
+            };
 
-                var requestStream = new MemoryStream();
-                MessageHelpers.WriteMessage(requestStream, requestMessage);
+            var requestStream = new MemoryStream();
+            MessageHelpers.WriteMessage(requestStream, requestMessage);
 
-                var httpRequest = GrpcHttpHelper.Create(method.FullName);
-                httpRequest.Headers.Add(GrpcProtocolConstants.TimeoutHeader, "50m");
-                httpRequest.Content = new GrpcStreamContent(requestStream);
+            var httpRequest = GrpcHttpHelper.Create(method.FullName);
+            httpRequest.Headers.Add(GrpcProtocolConstants.TimeoutHeader, "50m");
+            httpRequest.Content = new GrpcStreamContent(requestStream);
 
-                // Act
-                var response = await grpcWebClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
+            // Act
+            var response = await grpcWebClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead).DefaultTimeout();
 
-                // Assert
-                response.AssertIsSuccessfulGrpcRequest();
-                response.AssertTrailerStatus(StatusCode.DeadlineExceeded, "Deadline Exceeded");
-            }
+            // Assert
+            response.AssertIsSuccessfulGrpcRequest();
+            response.AssertTrailerStatus(StatusCode.DeadlineExceeded, "Deadline Exceeded");
         }
 
         [Test]


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1048

Canceling ResponseStream.MoveNext would cancel locally but not send cancellation to the server. Grpc.Core does send cancellation to the server so this makes grpc-dotnet consistent.