### PR TITLE
Remove TestServer workaround handler

### DIFF
--- a/examples/Tester/Tests/FunctionalTests/Helpers/GrpcTestFixture.cs
+++ b/examples/Tester/Tests/FunctionalTests/Helpers/GrpcTestFixture.cs
@@ -18,8 +18,6 @@
 
 using System;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;

--- a/examples/Tester/Tests/FunctionalTests/Helpers/GrpcTestFixture.cs
+++ b/examples/Tester/Tests/FunctionalTests/Helpers/GrpcTestFixture.cs
@@ -62,12 +62,7 @@ namespace Tests.FunctionalTests.Helpers
             _host = builder.Start();
             _server = _host.GetTestServer();
 
-            // Need to set the response version to 2.0.
-            // Required because of this TestServer issue - https://github.com/aspnet/AspNetCore/issues/16940
-            var responseVersionHandler = new ResponseVersionHandler();
-            responseVersionHandler.InnerHandler = _server.CreateHandler();
-
-            Handler = responseVersionHandler;
+            Handler = _server.CreateHandler();
         }
 
         public LoggerFactory LoggerFactory { get; }
@@ -79,17 +74,6 @@ namespace Tests.FunctionalTests.Helpers
             Handler.Dispose();
             _host.Dispose();
             _server.Dispose();
-        }
-
-        private class ResponseVersionHandler : DelegatingHandler
-        {
-            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                var response = await base.SendAsync(request, cancellationToken);
-                response.Version = request.Version;
-
-                return response;
-            }
         }
 
         public IDisposable GetTestContext()

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -24,12 +24,18 @@
 
     <ProjectReference Include="..\..\testassets\FunctionalTestsWebsite\FunctionalTestsWebsite.csproj" />
 
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreApp31PackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
 
     <None Update="server1.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreApp31PackageVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/FunctionalTests/TestServer/Helpers/GrpcTestFixture.cs
+++ b/test/FunctionalTests/TestServer/Helpers/GrpcTestFixture.cs
@@ -18,13 +18,7 @@
 
 using System;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Grpc.AspNetCore.Server;
-using Grpc.Core;
-using Grpc.Core.Interceptors;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -66,12 +60,7 @@ namespace Tests.FunctionalTests.Helpers
             _host = builder.Start();
             _server = _host.GetTestServer();
 
-            // Need to set the response version to 2.0.
-            // Required because of this TestServer issue - https://github.com/aspnet/AspNetCore/issues/16940
-            var responseVersionHandler = new ResponseVersionHandler();
-            responseVersionHandler.InnerHandler = _server.CreateHandler();
-
-            var client = new HttpClient(responseVersionHandler);
+            var client = new HttpClient(_server.CreateHandler());
             client.BaseAddress = new Uri("http://localhost");
 
             Client = client;
@@ -86,17 +75,6 @@ namespace Tests.FunctionalTests.Helpers
             Client.Dispose();
             _host.Dispose();
             _server.Dispose();
-        }
-
-        private class ResponseVersionHandler : DelegatingHandler
-        {
-            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                var response = await base.SendAsync(request, cancellationToken);
-                response.Version = request.Version;
-
-                return response;
-            }
         }
 
         public IDisposable GetTestContext()

--- a/test/FunctionalTests/TestServer/Helpers/GrpcTestFixture.cs
+++ b/test/FunctionalTests/TestServer/Helpers/GrpcTestFixture.cs
@@ -66,13 +66,13 @@ namespace Tests.FunctionalTests.Helpers
             _host = builder.Start();
             _server = _host.GetTestServer();
 
-#if NET5_0
-            var handler = _server.CreateHandler();
-#else
+#if !NET5_0
             // Need to set the response version to 2.0.
             // Required because of this TestServer issue - https://github.com/aspnet/AspNetCore/issues/16940
             var handler = new ResponseVersionHandler();
             handler.InnerHandler = _server.CreateHandler();
+#else
+            var handler = _server.CreateHandler();
 #endif
 
             var client = new HttpClient(handler);
@@ -92,6 +92,7 @@ namespace Tests.FunctionalTests.Helpers
             _server.Dispose();
         }
 
+#if !NET5_0
         private class ResponseVersionHandler : DelegatingHandler
         {
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -102,6 +103,7 @@ namespace Tests.FunctionalTests.Helpers
                 return response;
             }
         }
+#endif
 
         public IDisposable GetTestContext()
         {


### PR DESCRIPTION
No longer needed in 5.0 because of fixes in ASP.NET Core test host.