### PR TITLE
Support netcoreapp3.1 in benchmark apps and call count limit

### DIFF
--- a/build/sources.props
+++ b/build/sources.props
@@ -18,5 +18,12 @@
       $(RestoreSources);
       https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev;
     </RestoreSources>
+    <!-- The following is a temporary change so 5.0 build works during transition from rc to rtm -->
+    <RestoreSources>
+      $(RestoreSources);
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-b928f03f/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-efcore-ab94ac91/nuget/v3/index.json;
+    </RestoreSources>
   </PropertyGroup>
 </Project>
+

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -5,7 +5,7 @@
     <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Uncomment line below to enable gRPC-Web on the server -->
-    <!--<DefineConstants>$(DefineConstants);GRPC_WEB</DefineConstants>-->
+    <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
 
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <!-- Uncomment line below to automatically compile .proto files in the project directory -->
@@ -34,12 +34,25 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
-    <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableGrpcWeb)' == 'true'">
     <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.23.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.9.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.23.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
@@ -21,7 +21,9 @@ using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Grpc.Testing;
+#if NET5_0
 using Microsoft.AspNetCore.Authentication.Certificate;
+#endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -45,8 +47,10 @@ namespace GrpcAspNetCoreServer
         {
             services.AddGrpc(o =>
             {
+#if NET5_0
                 // Small performance benefit to not add catch-all routes to handle UNIMPLEMENTED for unknown services
                 o.IgnoreUnknownServices = true;
+#endif
             });
             services.Configure<RouteOptions>(c =>
             {
@@ -56,6 +60,7 @@ namespace GrpcAspNetCoreServer
             services.AddSingleton<BenchmarkServiceImpl>();
             services.AddControllers();
 
+#if NET5_0
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {
@@ -68,6 +73,7 @@ namespace GrpcAspNetCoreServer
                         options.AllowedCertificateTypes = CertificateTypes.All;
                     });
             }
+#endif
         }
 
         public void Configure(IApplicationBuilder app, IHostApplicationLifetime applicationLifetime)
@@ -77,19 +83,23 @@ namespace GrpcAspNetCoreServer
 
             app.UseRouting();
 
+#if NET5_0
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {
                 app.UseAuthentication();
                 app.UseAuthorization();
             }
+#endif
 
+#if GRPC_WEB
             bool.TryParse(_config["enableGrpcWeb"], out var enableGrpcWeb);
 
             if (enableGrpcWeb)
             {
                 app.UseGrpcWeb(new GrpcWebOptions { DefaultEnabled = true });
             }
+#endif
 
             app.UseMiddleware<ServiceProvidersMiddleware>();
 
@@ -129,11 +139,13 @@ namespace GrpcAspNetCoreServer
 
         private void ConfigureAuthorization(IEndpointConventionBuilder builder)
         {
+#if NET5_0
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {
                 builder.RequireAuthorization();
             }
+#endif
         }
     }
 }

--- a/perf/benchmarkapps/GrpcClient/ClientOptions.cs
+++ b/perf/benchmarkapps/GrpcClient/ClientOptions.cs
@@ -23,10 +23,13 @@ namespace GrpcClient
     public class ClientOptions
     {
         public string? Url { get; set; }
+#if NET5_0
         public string? UdsFileName { get; set; }
+#endif
         public int Connections { get; set; }
         public int Warmup { get; set; }
         public int Duration { get; set; }
+        public int? CallCount { get; set; }
         public string? Scenario { get; set; }
         public bool Latency { get; set; }
         public string? Protocol { get; set; }

--- a/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
+++ b/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
+    <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
     <!-- Enable server GC to more closely simulate a microservice app making calls -->
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
@@ -22,12 +23,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <ProjectReference Include="..\..\..\src\Grpc.Net.Client.Web\Grpc.Net.Client.Web.csproj" />
-    <ProjectReference Include="..\..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
-
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
-    <PackageReference Include="Grpc.Core" Version="$(GrpcPackageVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
@@ -44,6 +39,25 @@
     <None Update="Certs\client.key">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableGrpcWeb)' == 'true'">
+    <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <ProjectReference Include="..\..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
+
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <PackageReference Include="Grpc.Core" Version="$(GrpcPackageVersion)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Grpc.Net.Client" Version="2.23.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.9.1" />
+    <PackageReference Include="Grpc.Core" Version="2.23.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.23.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/perf/benchmarkapps/GrpcClient/UnixDomainSocketConnectionFactory.cs
+++ b/perf/benchmarkapps/GrpcClient/UnixDomainSocketConnectionFactory.cs
@@ -23,6 +23,8 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
+#if NET5_0
+
 namespace GrpcClient
 {
     public class UnixDomainSocketConnectionFactory
@@ -51,3 +53,5 @@ namespace GrpcClient
         }
     }
 }
+
+#endif


### PR DESCRIPTION
* Support running benchmark apps on netcoreapp3.1 for comparison
* Support client running until a certain call count instead of duration