### PR TITLE
Update Microservicer sample to net5.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -13,7 +13,7 @@
     <MicrosoftExtensionsPackageVersion>3.0.3</MicrosoftExtensionsPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>16.6.1</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>1.0.0</MicrosoftSourceLinkGitHubPackageVersion>
-    <MicrosoftTyePackageVersion>0.3.0-alpha.20319.3</MicrosoftTyePackageVersion>
+    <MicrosoftTyePackageVersion>0.4.0-alpha.20371.1</MicrosoftTyePackageVersion>
     <MicrosoftWin32RegistryLinePackageVersion>4.6.0</MicrosoftWin32RegistryLinePackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.3</NewtonsoftJsonPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -13,7 +13,7 @@
     <MicrosoftExtensionsPackageVersion>3.0.3</MicrosoftExtensionsPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>16.6.1</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>1.0.0</MicrosoftSourceLinkGitHubPackageVersion>
-    <MicrosoftTyePackageVersion>0.4.0-alpha.20371.1</MicrosoftTyePackageVersion>
+    <MicrosoftTyePackageVersion>0.5.0-alpha.20555.1</MicrosoftTyePackageVersion>
     <MicrosoftWin32RegistryLinePackageVersion>4.6.0</MicrosoftWin32RegistryLinePackageVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.3</NewtonsoftJsonPackageVersion>

--- a/examples/Microservicer/Backend/Backend.csproj
+++ b/examples/Microservicer/Backend/Backend.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Microservicer/Frontend/Frontend.csproj
+++ b/examples/Microservicer/Frontend/Frontend.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Only works with 0.5 preview that hasn't been published yet. Wait until 0.5 is on NuGet.org before merging.