### PR TITLE
Clean up RpcException logic in client

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
@@ -225,7 +225,7 @@ namespace Grpc.Net.Client.Internal
         {
             if (payloadLength > _call.Channel.SendMaxMessageSize)
             {
-                throw new RpcException(SendingMessageExceedsLimitStatus);
+                throw _call.CreateRpcException(SendingMessageExceedsLimitStatus);
             }
         }
 

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -195,10 +195,9 @@ namespace Grpc.Net.Client.Internal
 
                 throw _call.CreateCanceledStatusException();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (_call.ResolveException("Error reading next message.", ex, out _, out var resolvedException))
             {
                 // Throw RpcException from MoveNext. Consistent with Grpc.Core.
-                _call.ResolveException("Error reading next message.", ex, out _, out var resolvedException);
                 throw resolvedException;
             }
             finally

--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -113,9 +113,8 @@ namespace Grpc.Net.Client.Tests
             await call.RequestStream.CompleteAsync().DefaultTimeout();
 
             var requestContent = await streamTask.DefaultTimeout();
-            var requestMessage = await requestContent.ReadMessageAsync(
-                new DefaultDeserializationContext(),
-                NullLogger.Instance,
+            var requestMessage = await StreamSerializationHelper.ReadMessageAsync(
+                requestContent,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,
@@ -123,9 +122,8 @@ namespace Grpc.Net.Client.Tests
                 singleMessage: false,
                 CancellationToken.None).AsTask().DefaultTimeout();
             Assert.AreEqual("1", requestMessage!.Name);
-            requestMessage = await requestContent.ReadMessageAsync(
-                new DefaultDeserializationContext(),
-                NullLogger.Instance,
+            requestMessage = await StreamSerializationHelper.ReadMessageAsync(
+                requestContent,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,

--- a/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
@@ -120,9 +120,8 @@ namespace Grpc.Net.Client.Tests
 
             Assert.IsNotNull(content);
             var requestContent = await content!.ReadAsStreamAsync().DefaultTimeout();
-            var requestMessage = await requestContent.ReadMessageAsync(
-                deserializationContext,
-                NullLogger.Instance,
+            var requestMessage = await StreamSerializationHelper.ReadMessageAsync(
+                requestContent,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,
@@ -130,9 +129,8 @@ namespace Grpc.Net.Client.Tests
                 singleMessage: false,
                 CancellationToken.None).AsTask().DefaultTimeout();
             Assert.AreEqual("1", requestMessage!.Name);
-            requestMessage = await requestContent.ReadMessageAsync(
-                deserializationContext,
-                NullLogger.Instance,
+            requestMessage = await StreamSerializationHelper.ReadMessageAsync(
+                requestContent,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -112,9 +112,8 @@ namespace Grpc.Net.Client.Tests
             Assert.IsNotNull(content);
 
             var requestContent = await content!.ReadAsStreamAsync().DefaultTimeout();
-            var requestMessage = await requestContent.ReadMessageAsync(
-                new DefaultDeserializationContext(),
-                NullLogger.Instance,
+            var requestMessage = await StreamSerializationHelper.ReadMessageAsync(
+                requestContent,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                 GrpcProtocolConstants.IdentityGrpcEncoding,
                 maximumMessageSize: null,

--- a/test/Grpc.Net.Client.Tests/CompressionTests.cs
+++ b/test/Grpc.Net.Client.Tests/CompressionTests.cs
@@ -53,10 +53,8 @@ namespace Grpc.Net.Client.Tests
 
                 var requestStream = await request.Content!.ReadAsStreamAsync().DefaultTimeout();
 
-                helloRequest = await StreamExtensions.ReadMessageAsync(
+                helloRequest = await StreamSerializationHelper.ReadMessageAsync(
                     requestStream,
-                    new DefaultDeserializationContext(),
-                    NullLogger.Instance,
                     ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                     "gzip",
                     maximumMessageSize: null,
@@ -105,10 +103,8 @@ namespace Grpc.Net.Client.Tests
                 var requestData = await request.Content!.ReadAsByteArrayAsync().DefaultTimeout();
                 isRequestNotCompressed = requestData[0] == 0;
 
-                helloRequest = await StreamExtensions.ReadMessageAsync(
+                helloRequest = await StreamSerializationHelper.ReadMessageAsync(
                     new MemoryStream(requestData),
-                    new DefaultDeserializationContext(),
-                    NullLogger.Instance,
                     ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                     "gzip",
                     maximumMessageSize: null,
@@ -173,10 +169,8 @@ namespace Grpc.Net.Client.Tests
 
                 var requestStream = await request.Content!.ReadAsStreamAsync().DefaultTimeout();
 
-                helloRequest = await StreamExtensions.ReadMessageAsync(
+                helloRequest = await StreamSerializationHelper.ReadMessageAsync(
                     requestStream,
-                    new DefaultDeserializationContext(),
-                    NullLogger.Instance,
                     ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                     "gzip",
                     maximumMessageSize: null,
@@ -221,10 +215,8 @@ namespace Grpc.Net.Client.Tests
 
                 var requestStream = await request.Content!.ReadAsStreamAsync().DefaultTimeout();
 
-                helloRequest = await StreamExtensions.ReadMessageAsync(
+                helloRequest = await StreamSerializationHelper.ReadMessageAsync(
                     requestStream,
-                    new DefaultDeserializationContext(),
-                    NullLogger.Instance,
                     ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                     "gzip",
                     maximumMessageSize: null,
@@ -274,10 +266,8 @@ namespace Grpc.Net.Client.Tests
                 var requestStream = new MemoryStream(requestData);
 
                 isRequestCompressed1 = requestData[0] == 1;
-                helloRequest1 = await StreamExtensions.ReadMessageAsync(
+                helloRequest1 = await StreamSerializationHelper.ReadMessageAsync(
                     requestStream,
-                    new DefaultDeserializationContext(),
-                    NullLogger.Instance,
                     ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                     "gzip",
                     maximumMessageSize: null,
@@ -286,10 +276,8 @@ namespace Grpc.Net.Client.Tests
                     CancellationToken.None);
 
                 isRequestCompressed2 = requestData[requestStream.Position] == 1;
-                helloRequest2 = await StreamExtensions.ReadMessageAsync(
+                helloRequest2 = await StreamSerializationHelper.ReadMessageAsync(
                     requestStream,
-                    new DefaultDeserializationContext(),
-                    NullLogger.Instance,
                     ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                     "gzip",
                     maximumMessageSize: null,

--- a/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Net.Client.Internal;
+using Grpc.Net.Compression;
+using Grpc.Shared;
+using Microsoft.Extensions.Logging;
+
+namespace Grpc.Net.Client.Tests.Infrastructure
+{
+    internal static class StreamSerializationHelper
+    {
+        public static ValueTask<TResponse?> ReadMessageAsync<TResponse>(
+            Stream responseStream,
+            //ILogger logger,
+            Func<DeserializationContext, TResponse> deserializer,
+            string grpcEncoding,
+            int? maximumMessageSize,
+            Dictionary<string, ICompressionProvider> compressionProviders,
+            bool singleMessage,
+            CancellationToken cancellationToken)
+            where TResponse : class
+        {
+            var tempChannel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+            {
+                MaxReceiveMessageSize = maximumMessageSize,
+                CompressionProviders = compressionProviders?.Values.ToList()
+            });
+
+            var tempCall = new TestGrpcCall(new CallOptions(), tempChannel, typeof(TResponse));
+
+            return responseStream.ReadMessageAsync(tempCall, deserializer, grpcEncoding, singleMessage, cancellationToken);
+        }
+
+        private class TestGrpcCall : GrpcCall
+        {
+            private readonly Type _type;
+
+            public TestGrpcCall(CallOptions options, GrpcChannel channel, Type type) : base(options, channel)
+            {
+                _type = type;
+            }
+
+            public override Type RequestType => _type;
+            public override Type ResponseType => _type;
+        }
+    }
+}

--- a/test/Grpc.Net.Client.Tests/MaximumMessageSizeTests.cs
+++ b/test/Grpc.Net.Client.Tests/MaximumMessageSizeTests.cs
@@ -38,10 +38,8 @@ namespace Grpc.Net.Client.Tests
         {
             var requestStream = await request.Content!.ReadAsStreamAsync().DefaultTimeout();
 
-            var helloRequest = await StreamExtensions.ReadMessageAsync(
+            var helloRequest = await StreamSerializationHelper.ReadMessageAsync(
                 requestStream,
-                new DefaultDeserializationContext(),
-                NullLogger.Instance,
                 ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
                 "gzip",
                 maximumMessageSize: null,


### PR DESCRIPTION
Don't wrap RpcException when not needed to preserve the original stack trace