### PR TITLE
Fix GrpcWebHandler with TLS+HTTP/1.1 endpoints in .NET 5

### DIFF
--- a/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
+++ b/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
@@ -135,6 +135,15 @@ namespace Grpc.Net.Client.Web
                 // uses what the browser has negotiated.
                 request.Version = HttpVersion;
             }
+#if NET5_0
+            else if (request.RequestUri?.Scheme == Uri.UriSchemeHttps)
+            {
+                // If no explicit HttpVersion is set and the request is using TLS then default to HTTP/1.1.
+                // HTTP/1.1 together with HttpVersionPolicy.RequestVersionOrHigher it will be compatible
+                // with all endpoints.
+                request.Version = System.Net.HttpVersion.Version11;
+            }
+#endif
 
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -106,10 +106,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
             switch (endpointName)
             {
                 case TestServerEndpointName.Http1:
-                    return new Uri(_server.GetUrl(endpointName.Value));
                 case TestServerEndpointName.Http2:
-                    return new Uri(_server.GetUrl(endpointName.Value));
                 case TestServerEndpointName.Http1WithTls:
+                case TestServerEndpointName.Http2WithTls:
                     return new Uri(_server.GetUrl(endpointName.Value));
                 default:
                     throw new ArgumentException("Unexpected value: " + endpointName, nameof(endpointName));

--- a/test/FunctionalTests/Infrastructure/InProcessTestServer.cs
+++ b/test/FunctionalTests/Infrastructure/InProcessTestServer.cs
@@ -104,6 +104,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
                     });
                     options.ListenLocalhost(50030, listenOptions =>
                     {
+                        listenOptions.Protocols = HttpProtocols.Http2;
+
+                        var basePath = Path.GetDirectoryName(typeof(InProcessTestServer).Assembly.Location);
+                        var certPath = Path.Combine(basePath!, "server1.pfx");
+                        listenOptions.UseHttps(certPath, "1111");
+                    });
+                    options.ListenLocalhost(50020, listenOptions =>
+                    {
                         listenOptions.Protocols = HttpProtocols.Http1;
 
                         var basePath = Path.GetDirectoryName(typeof(InProcessTestServer).Assembly.Location);
@@ -137,7 +145,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
             {
                 [TestServerEndpointName.Http2] = "http://127.0.0.1:50050",
                 [TestServerEndpointName.Http1] = "http://127.0.0.1:50040",
-                [TestServerEndpointName.Http1WithTls] = "https://127.0.0.1:50030"
+                [TestServerEndpointName.Http2WithTls] = "https://127.0.0.1:50030",
+                [TestServerEndpointName.Http1WithTls] = "https://127.0.0.1:50020"
             };
 
             _lifetime.ApplicationStopped.Register(() =>

--- a/test/FunctionalTests/Infrastructure/TestServerEndpointName.cs
+++ b/test/FunctionalTests/Infrastructure/TestServerEndpointName.cs
@@ -22,6 +22,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
     {
         Http2,
         Http1,
+        Http2WithTls,
         Http1WithTls
     }
 }

--- a/test/FunctionalTests/Web/Client/ConnectionTests.cs
+++ b/test/FunctionalTests/Web/Client/ConnectionTests.cs
@@ -1,0 +1,105 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
+using Grpc.Core;
+using Grpc.Gateway.Testing;
+using Grpc.Net.Client;
+using Grpc.Net.Client.Web;
+using Grpc.Tests.Shared;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.FunctionalTests.Web.Client
+{
+    public class ConnectionTests : FunctionalTestBase
+    {
+        private HttpClient CreateGrpcWebClient(TestServerEndpointName endpointName, Version? version)
+        {
+            GrpcWebHandler grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb);
+            grpcWebHandler.HttpVersion = version;
+
+            return Fixture.CreateClient(endpointName, grpcWebHandler);
+        }
+
+        private GrpcChannel CreateGrpcWebChannel(TestServerEndpointName endpointName, Version? version)
+        {
+            var httpClient = CreateGrpcWebClient(endpointName, version);
+            var channel = GrpcChannel.ForAddress(httpClient.BaseAddress!, new GrpcChannelOptions
+            {
+                HttpClient = httpClient,
+                LoggerFactory = LoggerFactory
+            });
+
+            return channel;
+        }
+
+        [TestCase(TestServerEndpointName.Http1, "2.0", false)]
+        [TestCase(TestServerEndpointName.Http1, "1.1", true)]
+        [TestCase(TestServerEndpointName.Http1, null, false)]
+        [TestCase(TestServerEndpointName.Http2, "2.0", true)]
+        [TestCase(TestServerEndpointName.Http2, "1.1", false)]
+        [TestCase(TestServerEndpointName.Http2, null, true)]
+#if NET5_0
+        // Specifing HTTP/2 doesn't work when the server is using TLS with HTTP/1.1
+        // Caused by using HttpVersionPolicy.RequestVersionOrHigher setting
+        [TestCase(TestServerEndpointName.Http1WithTls, "2.0", false)]
+#else
+        [TestCase(TestServerEndpointName.Http1WithTls, "2.0", true)]
+#endif
+        [TestCase(TestServerEndpointName.Http1WithTls, "1.1", true)]
+        [TestCase(TestServerEndpointName.Http1WithTls, null, true)]
+        [TestCase(TestServerEndpointName.Http2WithTls, "2.0", true)]
+#if NET5_0
+        // Specifing HTTP/1.1 does work when the server is using TLS with HTTP/2
+        // Caused by using HttpVersionPolicy.RequestVersionOrHigher setting
+        [TestCase(TestServerEndpointName.Http2WithTls, "1.1", true)]
+#else
+        [TestCase(TestServerEndpointName.Http2WithTls, "1.1", false)]
+#endif
+        [TestCase(TestServerEndpointName.Http2WithTls, null, true)]
+        public async Task SendValidRequest_WithConnectionOptions(TestServerEndpointName endpointName, string? version, bool success)
+        {
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                return !success;
+            });
+
+            // Arrage
+            Version.TryParse(version, out var v);
+            var channel = CreateGrpcWebChannel(endpointName, v);
+
+            var client = new EchoService.EchoServiceClient(channel);
+
+            // Act
+            var call = client.EchoAsync(new EchoRequest { Message = "test" }).ResponseAsync.DefaultTimeout();
+
+            // Assert
+            if (success)
+            {
+                Assert.AreEqual("test", (await call).Message);
+            }
+            else
+            {
+                await ExceptionAssert.ThrowsAsync<RpcException>(async () => await call);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1110