### PR TITLE
Target .NET Framework

### DIFF
--- a/Grpc.DotNet.sln
+++ b/Grpc.DotNet.sln
@@ -122,6 +122,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinkerTestsClient", "testas
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinkerTestsWebsite", "testassets\LinkerTestsWebsite\LinkerTestsWebsite.csproj", "{FC5F9350-B812-4C62-AE76-0FF437F0F362}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.Net.Client.Web.Tests", "test\Grpc.Net.Client.Web.Tests\Grpc.Net.Client.Web.Tests.csproj", "{14B1CA94-1222-4D2E-B37A-1FF8676E233E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -248,6 +250,10 @@ Global
 		{FC5F9350-B812-4C62-AE76-0FF437F0F362}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC5F9350-B812-4C62-AE76-0FF437F0F362}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC5F9350-B812-4C62-AE76-0FF437F0F362}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14B1CA94-1222-4D2E-B37A-1FF8676E233E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14B1CA94-1222-4D2E-B37A-1FF8676E233E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14B1CA94-1222-4D2E-B37A-1FF8676E233E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14B1CA94-1222-4D2E-B37A-1FF8676E233E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -292,6 +298,7 @@ Global
 		{D241B525-3B50-42EA-9E43-052745549BA6} = {1B8B6117-CE39-4580-BAFA-D8026102767A}
 		{1FA0B07B-E65C-4380-94A4-75F10312487D} = {59C7B1F0-EE4D-4098-8596-0ADDBC305234}
 		{FC5F9350-B812-4C62-AE76-0FF437F0F362} = {59C7B1F0-EE4D-4098-8596-0ADDBC305234}
+		{14B1CA94-1222-4D2E-B37A-1FF8676E233E} = {CECC4AE8-9C4E-4727-939B-517CC2E58D65}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD5C2B19-49B4-480A-990C-36D98A719B07}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -25,6 +25,7 @@
     <SystemCommandLineRenderingPackageVersion>0.3.0-alpha.20214.1</SystemCommandLineRenderingPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemIOPipelinesPackageVersion>4.7.2</SystemIOPipelinesPackageVersion>
+    <SystemNetHttpWinHttpHandlerPackageVersion>5.0.0</SystemNetHttpWinHttpHandlerPackageVersion>
     <SystemSecurityPrincipalWindowsPackageVersion>4.6.0</SystemSecurityPrincipalWindowsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Grpc.Net.Client.Web/Properties/AssemblyInfo.cs
+++ b/src/Grpc.Net.Client.Web/Properties/AssemblyInfo.cs
@@ -18,7 +18,7 @@
 
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Grpc.Net.Client.Tests,PublicKey=" +
+[assembly: InternalsVisibleTo("Grpc.Net.Client.Web.Tests,PublicKey=" +
     "00240000048000009400000006020000002400005253413100040000010001002f5797a92c6fcde81bd4098f43" +
     "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
     "27fc95aff3dc604a6971417453f9483c7b5e836756d5b271bf8f2403fe186e31956148c03d804487cf642f8cc0" +

--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,8 +17,8 @@
   <ItemGroup>
     <Compile Include="..\Shared\CommonGrpcProtocolHelpers.cs" Link="Internal\CommonGrpcProtocolHelpers.cs" />
     <Compile Include="..\Shared\DefaultDeserializationContext.cs" Link="Internal\DefaultDeserializationContext.cs" />
-    <Compile Include="..\Shared\HttpHandlerFactory.cs" Link="Internal\HttpHandlerFactory.cs" />
-    <Compile Include="..\Shared\TelemetryHeaderHandler.cs" Link="Internal\TelemetryHeaderHandler.cs" />
+    <Compile Include="..\Shared\HttpHandlerFactory.cs" Link="Internal\Http\HttpHandlerFactory.cs" />
+    <Compile Include="..\Shared\TelemetryHeaderHandler.cs" Link="Internal\Http\TelemetryHeaderHandler.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -46,6 +46,7 @@ namespace Grpc.Net.Client
 
         internal Uri Address { get; }
         internal HttpMessageInvoker HttpInvoker { get; }
+        internal bool IsWinHttp { get; }
         internal int? SendMaxMessageSize { get; }
         internal int? ReceiveMaxMessageSize { get; }
         internal ILoggerFactory LoggerFactory { get; }
@@ -76,6 +77,7 @@ namespace Grpc.Net.Client
 
             Address = address;
             HttpInvoker = channelOptions.HttpClient ?? CreateInternalHttpInvoker(channelOptions.HttpHandler);
+            IsWinHttp = channelOptions.HttpHandler != null ? HttpHandlerFactory.HasHttpHandlerType(channelOptions.HttpHandler, "System.Net.Http.WinHttpHandler") : false;
             SendMaxMessageSize = channelOptions.MaxSendMessageSize;
             ReceiveMaxMessageSize = channelOptions.MaxReceiveMessageSize;
             CompressionProviders = ResolveCompressionProviders(channelOptions.CompressionProviders);
@@ -109,7 +111,7 @@ namespace Grpc.Net.Client
 #if NET5_0
             handler = HttpHandlerFactory.EnsureTelemetryHandler(handler);
 #endif
-
+            
             // Use HttpMessageInvoker instead of HttpClient because it is faster
             // and we don't need client's features.
             var httpInvoker = new HttpMessageInvoker(handler, disposeHandler: true);

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -111,7 +111,7 @@ namespace Grpc.Net.Client
 #if NET5_0
             handler = HttpHandlerFactory.EnsureTelemetryHandler(handler);
 #endif
-            
+
             // Use HttpMessageInvoker instead of HttpClient because it is faster
             // and we don't need client's features.
             var httpInvoker = new HttpMessageInvoker(handler, disposeHandler: true);

--- a/src/Grpc.Net.Client/Internal/ArrayBufferWriter.cs
+++ b/src/Grpc.Net.Client/Internal/ArrayBufferWriter.cs
@@ -1,0 +1,214 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+#if NETSTANDARD2_0
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Represents a heap-based, array-backed output sink into which <typeparam name="T"/> data can be written.
+    /// </summary>
+    internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>
+    {
+        // Copy of Array.MaxArrayLength. For byte arrays the limit is slightly larger
+        private const int MaxArrayLength = 0X7FEFFFFF;
+
+        private const int DefaultInitialBufferSize = 256;
+
+        private T[] _buffer;
+        private int _index;
+
+
+        /// <summary>
+        /// Creates an instance of an <see cref="ArrayBufferWriter{T}"/>, in which data can be written to,
+        /// with the default initial capacity.
+        /// </summary>
+        public ArrayBufferWriter()
+        {
+            _buffer = Array.Empty<T>();
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates an instance of an <see cref="ArrayBufferWriter{T}"/>, in which data can be written to,
+        /// with an initial capacity specified.
+        /// </summary>
+        /// <param name="initialCapacity">The minimum capacity with which to initialize the underlying buffer.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="initialCapacity"/> is not positive (i.e. less than or equal to 0).
+        /// </exception>
+        public ArrayBufferWriter(int initialCapacity)
+        {
+            if (initialCapacity <= 0)
+                throw new ArgumentException(null, nameof(initialCapacity));
+
+            _buffer = new T[initialCapacity];
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Returns the data written to the underlying buffer so far, as a <see cref="ReadOnlyMemory{T}"/>.
+        /// </summary>
+        public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(0, _index);
+
+        /// <summary>
+        /// Returns the data written to the underlying buffer so far, as a <see cref="ReadOnlySpan{T}"/>.
+        /// </summary>
+        public ReadOnlySpan<T> WrittenSpan => _buffer.AsSpan(0, _index);
+
+        /// <summary>
+        /// Returns the amount of data written to the underlying buffer so far.
+        /// </summary>
+        public int WrittenCount => _index;
+
+        /// <summary>
+        /// Returns the total amount of space within the underlying buffer.
+        /// </summary>
+        public int Capacity => _buffer.Length;
+
+        /// <summary>
+        /// Returns the amount of space available that can still be written into without forcing the underlying buffer to grow.
+        /// </summary>
+        public int FreeCapacity => _buffer.Length - _index;
+
+        /// <summary>
+        /// Clears the data written to the underlying buffer.
+        /// </summary>
+        /// <remarks>
+        /// You must clear the <see cref="ArrayBufferWriter{T}"/> before trying to re-use it.
+        /// </remarks>
+        public void Clear()
+        {
+            Debug.Assert(_buffer.Length >= _index);
+            _buffer.AsSpan(0, _index).Clear();
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Notifies <see cref="IBufferWriter{T}"/> that <paramref name="count"/> amount of data was written to the output <see cref="Span{T}"/>/<see cref="Memory{T}"/>
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="count"/> is negative.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when attempting to advance past the end of the underlying buffer.
+        /// </exception>
+        /// <remarks>
+        /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+        /// </remarks>
+        public void Advance(int count)
+        {
+            if (count < 0)
+                throw new ArgumentException(null, nameof(count));
+
+            if (_index > _buffer.Length - count)
+                ThrowInvalidOperationException_AdvancedTooFar(_buffer.Length);
+
+            _index += count;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Memory{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+        /// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="sizeHint"/> is negative.
+        /// </exception>
+        /// <remarks>
+        /// This will never return an empty <see cref="Memory{T}"/>.
+        /// </remarks>
+        /// <remarks>
+        /// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
+        /// </remarks>
+        /// <remarks>
+        /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+        /// </remarks>
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            Debug.Assert(_buffer.Length > _index);
+            return _buffer.AsMemory(_index);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Span{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+        /// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="sizeHint"/> is negative.
+        /// </exception>
+        /// <remarks>
+        /// This will never return an empty <see cref="Span{T}"/>.
+        /// </remarks>
+        /// <remarks>
+        /// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
+        /// </remarks>
+        /// <remarks>
+        /// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+        /// </remarks>
+        public Span<T> GetSpan(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            Debug.Assert(_buffer.Length > _index);
+            return _buffer.AsSpan(_index);
+        }
+
+        private void CheckAndResizeBuffer(int sizeHint)
+        {
+            if (sizeHint < 0)
+                throw new ArgumentException(nameof(sizeHint));
+
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+
+            if (sizeHint > FreeCapacity)
+            {
+                int currentLength = _buffer.Length;
+
+                // Attempt to grow by the larger of the sizeHint and double the current size.
+                int growBy = Math.Max(sizeHint, currentLength);
+
+                if (currentLength == 0)
+                {
+                    growBy = Math.Max(growBy, DefaultInitialBufferSize);
+                }
+
+                int newSize = currentLength + growBy;
+
+                if ((uint)newSize > int.MaxValue)
+                {
+                    // Attempt to grow to MaxArrayLength.
+                    uint needed = (uint)(currentLength - FreeCapacity + sizeHint);
+                    Debug.Assert(needed > currentLength);
+
+                    if (needed > MaxArrayLength)
+                    {
+                        ThrowOutOfMemoryException(needed);
+                    }
+
+                    newSize = MaxArrayLength;
+                }
+
+                Array.Resize(ref _buffer, newSize);
+            }
+
+            Debug.Assert(FreeCapacity > 0 && FreeCapacity >= sizeHint);
+        }
+
+        private static void ThrowInvalidOperationException_AdvancedTooFar(int capacity)
+        {
+            throw new InvalidOperationException();
+        }
+
+        private static void ThrowOutOfMemoryException(uint capacity)
+        {
+            throw new OutOfMemoryException();
+        }
+    }
+}
+
+#endif

--- a/src/Grpc.Net.Client/Internal/ArrayBufferWriter.cs
+++ b/src/Grpc.Net.Client/Internal/ArrayBufferWriter.cs
@@ -1,10 +1,27 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
 
 using System.Diagnostics;
 
 #if NETSTANDARD2_0
 
+// Copied with permission from https://github.com/dotnet/runtime/blob/589d0dc326bf0699149f76033fa66d4b22b9a7fd/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
+// This copy of ArrayBufferWriter is only used with .NET Stardard 2.0. Later versions of .NET ship with this type.
 namespace System.Buffers
 {
     /// <summary>
@@ -201,12 +218,12 @@ namespace System.Buffers
 
         private static void ThrowInvalidOperationException_AdvancedTooFar(int capacity)
         {
-            throw new InvalidOperationException();
+            throw new InvalidOperationException($"Cannot advance past the end of the buffer, which has a size of {capacity}.");
         }
 
         private static void ThrowOutOfMemoryException(uint capacity)
         {
-            throw new OutOfMemoryException();
+            throw new OutOfMemoryException($"Cannot allocate a buffer of size {capacity}.");
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/CompatibilityExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/CompatibilityExtensions.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Grpc.Net.Client.Internal
+{
+    internal static class CompatibilityExtensions
+    {
+#if !NETSTANDARD2_0
+        public static readonly Version Version20 = HttpVersion.Version20;
+#else
+        public static readonly Version Version20 = new Version(2, 0);
+        public static readonly string ResponseTrailersKey = "__ResponseTrailers";
+#endif
+
+        public static HttpHeaders GetTrailingHeaders(this HttpResponseMessage responseMessage)
+        {
+#if !NETSTANDARD2_0
+            return responseMessage.TrailingHeaders;
+#else
+            if (!responseMessage.RequestMessage.Properties.TryGetValue(ResponseTrailersKey, out var headers))
+            {
+                throw new InvalidOperationException();
+            }
+            return (HttpHeaders)headers;
+#endif
+        }
+
+        [Conditional("DEBUG")]
+        public static void Assert([DoesNotReturnIf(false)] bool condition, string? message = null)
+        {
+            Debug.Assert(condition, message);
+        }
+
+        public static bool IsCompletedSuccessfully(this Task task)
+        {
+            // IsCompletedSuccessfully is the faster method, but only currently exposed on .NET Core 2.0+
+#if !NETSTANDARD2_0
+            return task.IsCompletedSuccessfully;
+#else
+            return task.Status == TaskStatus.RanToCompletion;
+#endif
+        }
+
+#if !NETSTANDARD2_0
+        public static bool IsCompletedSuccessfully(this ValueTask task)
+        {
+            return task.IsCompletedSuccessfully;
+        }
+
+        public static bool IsCompletedSuccessfully<T>(this ValueTask<T> task)
+        {
+            return task.IsCompletedSuccessfully;
+        }
+#endif
+    }
+}

--- a/src/Grpc.Net.Client/Internal/GrpcCall.NonGeneric.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.NonGeneric.cs
@@ -83,8 +83,8 @@ namespace Grpc.Net.Client.Internal
                     return false;
                 }
 
-                Debug.Assert(HttpResponse != null);
-                Trailers = GrpcProtocolHelpers.BuildMetadata(HttpResponse.TrailingHeaders);
+                CompatibilityExtensions.Assert(HttpResponse != null);
+                Trailers = GrpcProtocolHelpers.BuildMetadata(HttpResponse.GetTrailingHeaders());
             }
 
             trailers = Trailers;

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -924,44 +924,41 @@ namespace Grpc.Net.Client.Internal
             CancelCall(new Status(StatusCode.DeadlineExceeded, string.Empty));
         }
 
-        internal async ValueTask WriteMessageAsync(
+        internal ValueTask WriteMessageAsync(
             Stream stream,
             TRequest message,
             Action<TRequest, SerializationContext> contextualSerializer,
             CallOptions callOptions)
         {
-            var serializationContext = SerializationContext;
-            serializationContext.CallOptions = callOptions;
-            serializationContext.Initialize();
-
-            try
-            {
-                await stream.WriteMessageAsync(
-                    this,
-                    message,
-                    contextualSerializer,
-                    callOptions,
-                    serializationContext).ConfigureAwait(false);
-            }
-            finally
-            {
-                serializationContext.Reset();
-            }
+            return stream.WriteMessageAsync(
+                this,
+                message,
+                contextualSerializer,
+                callOptions);
         }
 
         internal ValueTask WriteMessageAsync<TSerializationContext>(
             Stream stream,
             TRequest message,
             Action<TRequest, SerializationContext> contextualSerializer,
-            CallOptions callOptions,
-            TSerializationContext serializationContext) where TSerializationContext : SerializationContext, IMemoryOwner<byte>
+            CallOptions callOptions) where TSerializationContext : SerializationContext, IMemoryOwner<byte>
         {
             return stream.WriteMessageAsync(
                 this,
                 message,
                 contextualSerializer,
-                callOptions,
-                serializationContext);
+                callOptions);
+        }
+
+        internal ValueTask WriteMessageAsync(
+            Stream stream,
+            ReadOnlyMemory<byte> message,
+            CallOptions callOptions)
+        {
+            return stream.WriteMessageAsync(
+                this,
+                message,
+                callOptions);
         }
 
 #if !NETSTANDARD2_0

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -25,8 +26,13 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Grpc.Net.Client.Internal.Http;
 using Grpc.Shared;
 using Microsoft.Extensions.Logging;
+
+#if NETSTANDARD2_0
+using ValueTask = System.Threading.Tasks.Task;
+#endif
 
 namespace Grpc.Net.Client.Internal
 {
@@ -188,7 +194,7 @@ namespace Grpc.Net.Client.Internal
 
         public Exception CreateCanceledStatusException()
         {
-            var status = (CallTask.IsCompletedSuccessfully) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
+            var status = (CallTask.IsCompletedSuccessfully()) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
             return CreateRpcException(status);
         }
         
@@ -229,7 +235,7 @@ namespace Grpc.Net.Client.Internal
 
         private async Task<Metadata> GetResponseHeadersCoreAsync()
         {
-            Debug.Assert(_httpResponseTask != null);
+            CompatibilityExtensions.Assert(_httpResponseTask != null);
 
             try
             {
@@ -256,7 +262,7 @@ namespace Grpc.Net.Client.Internal
         {
             using (StartScope())
             {
-                if (CallTask.IsCompletedSuccessfully)
+                if (CallTask.IsCompletedSuccessfully())
                 {
                     return CallTask.Result;
                 }
@@ -267,7 +273,7 @@ namespace Grpc.Net.Client.Internal
 
         public Task<TResponse> GetResponseAsync()
         {
-            Debug.Assert(_responseTcs != null);
+            CompatibilityExtensions.Assert(_responseTcs != null);
             return _responseTcs.Task;
         }
 
@@ -287,7 +293,7 @@ namespace Grpc.Net.Client.Internal
 
             // ALPN negotiation is sending HTTP/1.1 and HTTP/2.
             // Check that the response wasn't downgraded to HTTP/1.1.
-            if (httpResponse.Version < HttpVersion.Version20)
+            if (httpResponse.Version < CompatibilityExtensions.Version20)
             {
                 return new Status(StatusCode.Internal, $"Bad gRPC response. Response protocol downgraded to HTTP/{httpResponse.Version.ToString(2)}.");
             }
@@ -318,7 +324,11 @@ namespace Grpc.Net.Client.Internal
             switch (httpStatusCode)
             {
                 case HttpStatusCode.BadRequest:  // 400
+#if !NETSTANDARD2_0
                 case HttpStatusCode.RequestHeaderFieldsTooLarge: // 431
+#else
+                case (HttpStatusCode)431:
+#endif
                     return StatusCode.Internal;
                 case HttpStatusCode.Unauthorized:  // 401
                     return StatusCode.Unauthenticated;
@@ -326,7 +336,11 @@ namespace Grpc.Net.Client.Internal
                     return StatusCode.PermissionDenied;
                 case HttpStatusCode.NotFound:  // 404
                     return StatusCode.Unimplemented;
+#if !NETSTANDARD2_0
                 case HttpStatusCode.TooManyRequests:  // 429
+#else
+                case (HttpStatusCode)429:
+#endif
                 case HttpStatusCode.BadGateway:  // 502
                 case HttpStatusCode.ServiceUnavailable:  // 503
                 case HttpStatusCode.GatewayTimeout:  // 504
@@ -360,10 +374,22 @@ namespace Grpc.Net.Client.Internal
         private void SetMessageContent(TRequest request, HttpRequestMessage message)
         {
             RequestGrpcEncoding = GrpcProtocolHelpers.GetRequestEncoding(message.Headers);
-            message.Content = new PushUnaryContent<TRequest, TResponse>(
-                request,
-                this,
-                GrpcProtocolConstants.GrpcContentTypeHeaderValue);
+
+            if (!Channel.IsWinHttp)
+            {
+                message.Content = new PushUnaryContent<TRequest, TResponse>(
+                    request,
+                    this,
+                    GrpcProtocolConstants.GrpcContentTypeHeaderValue);
+            }
+            else
+            {
+                // WinHttp doesn't support streaming request data so a length needs to be specified.
+                message.Content = new LengthUnaryContent<TRequest, TResponse>(
+                    request,
+                    this,
+                    GrpcProtocolConstants.GrpcContentTypeHeaderValue);
+            }
         }
 
         public void CancelCallFromCancellationToken()
@@ -549,7 +575,7 @@ namespace Grpc.Net.Client.Internal
                         else
                         {
                             // Duplex or server streaming call
-                            Debug.Assert(ClientStreamReader != null);
+                            CompatibilityExtensions.Assert(ClientStreamReader != null);
                             ClientStreamReader.HttpResponseTcs.TrySetResult((HttpResponse, status));
 
                             // Wait until the response has been read and status read from trailers.
@@ -586,7 +612,7 @@ namespace Grpc.Net.Client.Internal
         {
             if (ex is OperationCanceledException)
             {
-                status = (CallTask.IsCompletedSuccessfully) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
+                status = (CallTask.IsCompletedSuccessfully()) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty);
                 if (!Channel.ThrowOperationCanceledOnCancellation)
                 {
                     resolvedException = CreateRpcException(status.Value);
@@ -625,7 +651,7 @@ namespace Grpc.Net.Client.Internal
 
         private void SetFailedResult(Status status)
         {
-            Debug.Assert(_responseTcs != null);
+            CompatibilityExtensions.Assert(_responseTcs != null);
 
             if (Channel.ThrowOperationCanceledOnCancellation && status.StatusCode == StatusCode.DeadlineExceeded)
             {
@@ -787,7 +813,7 @@ namespace Grpc.Net.Client.Internal
         private HttpRequestMessage CreateHttpRequestMessage(TimeSpan? timeout)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, _grpcMethodInfo.CallUri);
-            message.Version = HttpVersion.Version20;
+            message.Version = CompatibilityExtensions.Version20;
 #if NET5_0
             message.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
 #endif
@@ -898,19 +924,51 @@ namespace Grpc.Net.Client.Internal
             CancelCall(new Status(StatusCode.DeadlineExceeded, string.Empty));
         }
 
-        internal ValueTask WriteMessageAsync(
+        internal async ValueTask WriteMessageAsync(
             Stream stream,
             TRequest message,
+            Action<TRequest, SerializationContext> contextualSerializer,
             CallOptions callOptions)
+        {
+            var serializationContext = SerializationContext;
+            serializationContext.CallOptions = callOptions;
+            serializationContext.Initialize();
+
+            try
+            {
+                await stream.WriteMessageAsync(
+                    this,
+                    message,
+                    contextualSerializer,
+                    callOptions,
+                    serializationContext).ConfigureAwait(false);
+            }
+            finally
+            {
+                serializationContext.Reset();
+            }
+        }
+
+        internal ValueTask WriteMessageAsync<TSerializationContext>(
+            Stream stream,
+            TRequest message,
+            Action<TRequest, SerializationContext> contextualSerializer,
+            CallOptions callOptions,
+            TSerializationContext serializationContext) where TSerializationContext : SerializationContext, IMemoryOwner<byte>
         {
             return stream.WriteMessageAsync(
                 this,
                 message,
-                Method.RequestMarshaller.ContextualSerializer,
-                callOptions);
+                contextualSerializer,
+                callOptions,
+                serializationContext);
         }
 
+#if !NETSTANDARD2_0
         internal ValueTask<TResponse?> ReadMessageAsync(
+#else
+        internal Task<TResponse?> ReadMessageAsync(
+#endif
             Stream responseStream,
             string grpcEncoding,
             bool singleMessage,

--- a/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
@@ -319,9 +319,5 @@ namespace Grpc.Net.Client.Internal
         {
             return _buffer != null ? _buffer.AsSpan(_bufferPosition) : _bufferWriter!.GetSpan(sizeHint);
         }
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/src/Grpc.Net.Client/Internal/GrpcEventSource.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcEventSource.cs
@@ -27,12 +27,14 @@ namespace Grpc.Net.Client.Internal
     {
         public static readonly GrpcEventSource Log = new GrpcEventSource();
 
+#if !NETSTANDARD2_0
         private PollingCounter? _totalCallsCounter;
         private PollingCounter? _currentCallsCounter;
         private PollingCounter? _messagesSentCounter;
         private PollingCounter? _messagesReceivedCounter;
         private PollingCounter? _callsFailedCounter;
         private PollingCounter? _callsDeadlineExceededCounter;
+#endif
 
         private long _totalCalls;
         private long _currentCalls;
@@ -125,6 +127,7 @@ namespace Grpc.Net.Client.Internal
                 // This is the convention for initializing counters in the RuntimeEventSource (lazily on the first enable command).
                 // They aren't disabled afterwards...
 
+#if !NETSTANDARD2_0
                 _totalCallsCounter ??= new PollingCounter("total-calls", this, () => Volatile.Read(ref _totalCalls))
                 {
                     DisplayName = "Total Calls",
@@ -149,6 +152,7 @@ namespace Grpc.Net.Client.Internal
                 {
                     DisplayName = "Total Messages Received",
                 };
+#endif
             }
         }
     }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -59,6 +59,16 @@ namespace Grpc.Net.Client.Internal
         internal static readonly string TEHeader;
         internal static readonly string TEHeaderValue;
 
+        internal static string GetMessageAcceptEncoding(Dictionary<string, ICompressionProvider> compressionProviders)
+        {
+            return IdentityGrpcEncoding + "," +
+#if !NETSTANDARD2_0
+                string.Join(',', compressionProviders.Select(p => p.Key));
+#else
+                string.Join(",", compressionProviders.Select(p => p.Key));
+#endif
+        }
+
         static GrpcProtocolConstants()
         {
             var userAgent = "grpc-dotnet";
@@ -85,7 +95,7 @@ namespace Grpc.Net.Client.Internal
             TEHeader = "TE";
             TEHeaderValue = "trailers";
 
-            DefaultMessageAcceptEncodingValue = IdentityGrpcEncoding + "," + string.Join(',', DefaultCompressionProviders.Select(p => p.Key));
+            DefaultMessageAcceptEncodingValue = GetMessageAcceptEncoding(DefaultCompressionProviders);
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -58,7 +58,7 @@ namespace Grpc.Net.Client.Internal
             return Convert.FromBase64String(decodable);
         }
 
-        public static Metadata BuildMetadata(HttpResponseHeaders responseHeaders)
+        public static Metadata BuildMetadata(HttpHeaders responseHeaders)
         {
             var headers = new Metadata();
 
@@ -227,7 +227,7 @@ namespace Grpc.Net.Client.Internal
                 return GrpcProtocolConstants.DefaultMessageAcceptEncodingValue;
             }
 
-            return GrpcProtocolConstants.IdentityGrpcEncoding + "," + string.Join(',', compressionProviders.Select(p => p.Key));
+            return GrpcProtocolConstants.GetMessageAcceptEncoding(compressionProviders);
         }
 
         internal static bool CanWriteCompressed(WriteOptions? writeOptions)
@@ -332,7 +332,7 @@ namespace Grpc.Net.Client.Internal
             Status? status;
             try
             {
-                if (!TryGetStatusCore(httpResponse.TrailingHeaders, out status))
+                if (!TryGetStatusCore(httpResponse.GetTrailingHeaders(), out status))
                 {
                     var detail = "No grpc-status found on response.";
                     if (isBrowser)
@@ -352,7 +352,7 @@ namespace Grpc.Net.Client.Internal
             return status.Value;
         }
 
-        public static bool TryGetStatusCore(HttpResponseHeaders headers, [NotNullWhen(true)]out Status? status)
+        public static bool TryGetStatusCore(HttpHeaders headers, [NotNullWhen(true)]out Status? status)
         {
             var grpcStatus = GrpcProtocolHelpers.GetHeaderValue(headers, GrpcProtocolConstants.StatusTrailer);
 

--- a/src/Grpc.Net.Client/Internal/Http/LengthUnaryContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/LengthUnaryContent.cs
@@ -1,0 +1,135 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.Core;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+#if NETSTANDARD2_0
+using ValueTask = System.Threading.Tasks.Task;
+#endif
+
+namespace Grpc.Net.Client.Internal.Http
+{
+    /// <summary>
+    /// WinHttp doesn't support streaming request data so a length needs to be specified.
+    /// This HttpContent pre-serializes the payload so it has a length available.
+    /// The payload is then written directly to the request using specialized context
+    /// and serializer method.
+    /// </summary>
+    internal class LengthUnaryContent<TRequest, TResponse> : HttpContent
+        where TRequest : class
+        where TResponse : class
+    {
+        private readonly TRequest _content;
+        private readonly GrpcCall<TRequest, TResponse> _call;
+        private byte[]? _payload;
+
+        public LengthUnaryContent(TRequest content, GrpcCall<TRequest, TResponse> call, MediaTypeHeaderValue mediaType)
+        {
+            _content = content;
+            _call = call;
+            Headers.ContentType = mediaType;
+        }
+
+        private byte[] SerializePayload()
+        {
+            var serializationContext = _call.SerializationContext;
+            serializationContext.CallOptions = _call.Options;
+            serializationContext.Initialize();
+
+            try
+            { 
+                // Serialize message first. Need to know size to prefix the length in the header
+                _call.Method.RequestMarshaller.ContextualSerializer(_content, serializationContext);
+
+                // Remove header. It will be written again with data to the request.
+                return serializationContext.Memory.ToArray();
+            }
+            finally
+            {
+                serializationContext.Reset();
+            }
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            if (_payload == null)
+            {
+                _payload = SerializePayload();
+            }
+
+#pragma warning disable CA2012 // Use ValueTasks correctly
+            var writeMessageTask = _call.WriteMessageAsync(
+                stream,
+                _content,
+                DummySerializer,
+                _call.Options,
+                new PayloadSerializationContext(_payload));
+#pragma warning restore CA2012 // Use ValueTasks correctly
+            if (writeMessageTask.IsCompletedSuccessfully())
+            {
+                GrpcEventSource.Log.MessageSent();
+                return Task.CompletedTask;
+            }
+
+            return WriteMessageCore(writeMessageTask);
+
+            static void DummySerializer(TRequest request, SerializationContext context)
+            {
+                // Don't do anything. PayloadSerializationContext already has payload.
+            }
+        }
+
+        private static async Task WriteMessageCore(ValueTask writeMessageTask)
+        {
+            await writeMessageTask.ConfigureAwait(false);
+            GrpcEventSource.Log.MessageSent();
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            if (_payload == null)
+            {
+                _payload = SerializePayload();
+            }
+
+            length = _payload.Length;
+            return true;
+        }
+
+        private sealed class PayloadSerializationContext : SerializationContext, IMemoryOwner<byte>
+        {
+            public PayloadSerializationContext(Memory<byte> payload)
+            {
+                Memory = payload;
+            }
+
+            public Memory<byte> Memory { get; }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Grpc.Net.Client/Internal/Http/PushStreamContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/PushStreamContent.cs
@@ -23,7 +23,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
-namespace Grpc.Net.Client.Internal
+namespace Grpc.Net.Client.Internal.Http
 {
     internal class PushStreamContent<TRequest, TResponse> : HttpContent
         where TRequest : class
@@ -57,7 +57,8 @@ namespace Grpc.Net.Client.Internal
             return false;
         }
 
-        // Hacky. ReadAsStreamAsync does not complete until SerializeToStreamAsync finishes
+        // Hacky. ReadAsStreamAsync does not complete until SerializeToStreamAsync finishes.
+        // WARNING: Will run SerializeToStreamAsync again on .NET Framework.
         internal Task PushComplete => ReadAsStreamAsync();
     }
 }

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Threading.Tasks;
 using Grpc.Core;
-using Grpc.Net.Client.Internal;
 
 namespace Grpc.Net.Client.Internal
 {

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -83,7 +83,7 @@ namespace Grpc.Net.Client.Internal
                 }
             }
 
-            if (_call.CallTask.IsCompletedSuccessfully)
+            if (_call.CallTask.IsCompletedSuccessfully())
             {
                 var status = _call.CallTask.Result;
                 if (status.StatusCode == StatusCode.OK)
@@ -156,7 +156,7 @@ namespace Grpc.Net.Client.Internal
                     }
                 }
 
-                Debug.Assert(_grpcEncoding != null, "Encoding should have been calculated from response.");
+                CompatibilityExtensions.Assert(_grpcEncoding != null, "Encoding should have been calculated from response.");
 
                 Current = await _call.ReadMessageAsync(
                     _responseStream,

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -93,7 +93,7 @@ namespace Grpc.Net.Client.Internal
                 using (_call.StartScope())
                 {
                     // Call has already completed
-                    if (_call.CallTask.IsCompletedSuccessfully)
+                    if (_call.CallTask.IsCompletedSuccessfully())
                     {
                         var status = _call.CallTask.Result;
                         if (_call.CancellationToken.IsCancellationRequested &&
@@ -159,7 +159,11 @@ namespace Grpc.Net.Client.Internal
                     callOptions = callOptions.WithWriteOptions(WriteOptions);
                 }
 
-                await _call.WriteMessageAsync(writeStream, message, callOptions).ConfigureAwait(false);
+                await _call.WriteMessageAsync(
+                    writeStream,
+                    message,
+                    _call.Method.RequestMarshaller.ContextualSerializer,
+                    callOptions).ConfigureAwait(false);
 
                 // Flush stream to ensure messages are sent immediately
                 await writeStream.FlushAsync(callOptions.CancellationToken).ConfigureAwait(false);

--- a/src/Grpc.Net.Client/Internal/NullableAttributes.cs
+++ b/src/Grpc.Net.Client/Internal/NullableAttributes.cs
@@ -1,0 +1,53 @@
+﻿#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true)]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute
+    { }
+
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute
+    { }
+
+    /// <summary>
+    /// Specifies that the method will not return if the associated Boolean parameter is passed the specified value.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DoesNotReturnIfAttribute"/> class.
+        /// </summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => this.ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+}
+
+#endif

--- a/src/Grpc.Net.Client/Internal/NullableAttributes.cs
+++ b/src/Grpc.Net.Client/Internal/NullableAttributes.cs
@@ -1,4 +1,22 @@
-﻿#if NETSTANDARD2_0
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if NETSTANDARD2_0
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -30,6 +31,10 @@ using Grpc.Net.Client.Internal;
 using Grpc.Net.Compression;
 using Grpc.Shared;
 using Microsoft.Extensions.Logging;
+
+#if NETSTANDARD2_0
+using ValueTask = System.Threading.Tasks.Task;
+#endif
 
 namespace Grpc.Net.Client
 {
@@ -43,7 +48,11 @@ namespace Grpc.Net.Client
             return new Status(StatusCode.Unimplemented, $"Unsupported grpc-encoding value '{unsupportedEncoding}'. Supported encodings: {string.Join(", ", supportedEncodings)}");
         }
 
+#if !NETSTANDARD2_0
         public static async ValueTask<TResponse?> ReadMessageAsync<TResponse>(
+#else
+        public static async Task<TResponse?> ReadMessageAsync<TResponse>(
+#endif
             this Stream responseStream,
             GrpcCall call,
             Func<DeserializationContext, TResponse> deserializer,
@@ -174,6 +183,34 @@ namespace Grpc.Net.Client
             }
         }
 
+#if NETSTANDARD2_0
+        public static Task<int> ReadAsync(this Stream stream, Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (MemoryMarshal.TryGetArray<byte>(buffer, out var segment))
+            {
+                return stream.ReadAsync(segment.Array, segment.Offset, segment.Count, cancellationToken);
+            }
+            else
+            {
+                var array = buffer.ToArray();
+                return stream.ReadAsync(array, 0, array.Length, cancellationToken);
+            }
+        }
+
+        public static Task WriteAsync(this Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (MemoryMarshal.TryGetArray<byte>(buffer, out var segment))
+            {
+                return stream.WriteAsync(segment.Array, segment.Offset, segment.Count, cancellationToken);
+            }
+            else
+            {
+                var array = buffer.ToArray();
+                return stream.WriteAsync(array, 0, array.Length, cancellationToken);
+            }
+        }
+#endif
+
         private static int ReadMessageLength(Span<byte> header)
         {
             var length = BinaryPrimitives.ReadUInt32BigEndian(header);
@@ -243,31 +280,24 @@ namespace Grpc.Net.Client
             }
         }
 
-        public static async ValueTask WriteMessageAsync<TMessage>(
-            this Stream stream,
+        public static async ValueTask WriteMessageAsync<TMessage, TSerializationContext>(
+            this Stream stream, 
             GrpcCall call,
             TMessage message,
             Action<TMessage, SerializationContext> serializer,
-            CallOptions callOptions)
+            CallOptions callOptions,
+            TSerializationContext serializationContext) where TSerializationContext : SerializationContext, IMemoryOwner<byte>
         {
-            var serializationContext = call.SerializationContext;
-            serializationContext.CallOptions = callOptions;
-            serializationContext.Initialize();
-
             try
             {
                 GrpcCallLog.SendingMessage(call.Logger);
 
                 // Serialize message first. Need to know size to prefix the length in the header
                 serializer(message, serializationContext);
-                if (!serializationContext.TryGetPayload(out var data))
-                {
-                    throw new InvalidOperationException("Serialization did not return a payload.");
-                }
 
                 // Sending the header+content in a single WriteAsync call has significant performance benefits
                 // https://github.com/dotnet/runtime/issues/35184#issuecomment-626304981
-                await stream.WriteAsync(data, callOptions.CancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(serializationContext.Memory, callOptions.CancellationToken).ConfigureAwait(false);
 
                 GrpcCallLog.MessageSent(call.Logger);
             }
@@ -275,10 +305,6 @@ namespace Grpc.Net.Client
             {
                 GrpcCallLog.ErrorSendingMessage(call.Logger, ex);
                 throw;
-            }
-            finally
-            {
-                serializationContext.Reset();
             }
         }
     }

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -297,7 +297,7 @@ namespace Grpc.Net.Client
                 
                 // Serialize message first. Need to know size to prefix the length in the header
                 serializer(message, serializationContext);
-                
+
                 // Sending the header+content in a single WriteAsync call has significant performance benefits
                 // https://github.com/dotnet/runtime/issues/35184#issuecomment-626304981
                 await stream.WriteAsync(serializationContext.GetWrittenPayload(), callOptions.CancellationToken).ConfigureAwait(false);

--- a/src/Grpc.Net.Common/AsyncStreamReaderExtensions.cs
+++ b/src/Grpc.Net.Common/AsyncStreamReaderExtensions.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+#if !NETSTANDARD2_0
+
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -53,3 +55,5 @@ namespace Grpc.Core
         }
     }
 }
+
+#endif

--- a/src/Grpc.Net.Common/Grpc.Net.Common.csproj
+++ b/src/Grpc.Net.Common/Grpc.Net.Common.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/HttpHandlerFactory.cs
+++ b/src/Shared/HttpHandlerFactory.cs
@@ -46,17 +46,18 @@ namespace Grpc.Shared
             // HttpClientHandler has an internal handler that sets request telemetry header.
             // If the handler is SocketsHttpHandler then we know that the header will never be set
             // so wrap with a handler that is responsible for setting the telemetry header.
-            if (IsSocketsHttpHandler(handler))
+            if (HasHttpHandlerType(handler, "System.Net.Http.SocketsHttpHandler"))
             {
                 return new TelemetryHeaderHandler(handler);
             }
 
             return handler;
         }
+#endif
 
-        private static bool IsSocketsHttpHandler(HttpMessageHandler handler)
+        public static bool HasHttpHandlerType(HttpMessageHandler handler, string handlerTypeName)
         {
-            if (handler is SocketsHttpHandler)
+            if (handler?.GetType().FullName == handlerTypeName)
             {
                 return true;
             }
@@ -67,7 +68,7 @@ namespace Grpc.Shared
             {
                 currentHandler = delegatingHandler.InnerHandler;
 
-                if (currentHandler is SocketsHttpHandler)
+                if (currentHandler?.GetType().FullName == handlerTypeName)
                 {
                     return true;
                 }
@@ -75,6 +76,5 @@ namespace Grpc.Shared
 
             return false;
         }
-#endif
     }
 }

--- a/src/Shared/HttpHandlerFactory.cs
+++ b/src/Shared/HttpHandlerFactory.cs
@@ -16,7 +16,9 @@
 
 #endregion
 
+using System;
 using System.Net.Http;
+using Grpc.Net.Client;
 
 namespace Grpc.Shared
 {
@@ -37,7 +39,16 @@ namespace Grpc.Shared
             }
 #endif
 
+#if !NETSTANDARD2_0
             return new HttpClientHandler();
+#else
+            var message =
+                $"gRPC requires extra configuration to successfully make RPC calls on older platforms such " +
+                $"as .NET Framework. An HTTP provider must be specified using {nameof(GrpcChannelOptions)}.{nameof(GrpcChannelOptions.HttpHandler)} or " +
+                $"{nameof(GrpcChannelOptions)}.{nameof(GrpcChannelOptions.HttpClient)}. The configured HTTP provider must either support HTTP/2 or " +
+                $"be configured to use gRPC-Web. See https://aka.ms/pzkMXDs for details.";
+            throw new PlatformNotSupportedException(message);
+#endif
         }
 
 #if NET5_0

--- a/test/Grpc.Net.Client.Tests/AsyncServerStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncServerStreamingCallTests.cs
@@ -191,7 +191,7 @@ namespace Grpc.Net.Client.Tests
 
             // Assert
             Assert.NotNull(responseMessage);
-            Assert.IsFalse(responseMessage!.TrailingHeaders.Any()); // sanity check that there are no trailers
+            Assert.IsFalse(responseMessage!.TrailingHeaders().Any()); // sanity check that there are no trailers
 
             Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
             Assert.AreEqual("Detail!", call.GetStatus().Detail);
@@ -219,7 +219,7 @@ namespace Grpc.Net.Client.Tests
             await call.ResponseStream.MoveNext(CancellationToken.None).DefaultTimeout();
 
             // Assert
-            Assert.IsTrue(responseMessage!.TrailingHeaders.TryGetValues(GrpcProtocolConstants.StatusTrailer, out _)); // sanity status is in trailers
+            Assert.IsTrue(responseMessage!.TrailingHeaders().TryGetValues(GrpcProtocolConstants.StatusTrailer, out _)); // sanity status is in trailers
 
             Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
             Assert.AreEqual(null, call.GetStatus().Detail);

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -88,7 +88,7 @@ namespace Grpc.Net.Client.Tests
             // Arrange
             HttpContent? content = null;
 
-            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            var handler = TestHttpMessageHandler.Create(async request =>
             {
                 content = request.Content;
 
@@ -101,7 +101,7 @@ namespace Grpc.Net.Client.Tests
 
                 return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent);
             });
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient);
+            var invoker = HttpClientCallInvokerFactory.Create(handler, "http://localhost");
 
             // Act
             var rs = await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "World" });
@@ -119,7 +119,7 @@ namespace Grpc.Net.Client.Tests
                 maximumMessageSize: null,
                 GrpcProtocolConstants.DefaultCompressionProviders,
                 singleMessage: true,
-                CancellationToken.None).AsTask().DefaultTimeout();
+                CancellationToken.None).DefaultTimeout();
 
             Assert.AreEqual("World", requestMessage!.Name);
         }
@@ -163,7 +163,7 @@ namespace Grpc.Net.Client.Tests
 
             // Assert
             Assert.NotNull(responseMessage);
-            Assert.IsFalse(responseMessage!.TrailingHeaders.Any()); // sanity check that there are no trailers
+            Assert.IsFalse(responseMessage!.TrailingHeaders().Any()); // sanity check that there are no trailers
 
             Assert.AreEqual(StatusCode.Internal, ex.Status.StatusCode);
             Assert.AreEqual("Failed to deserialize response message.", ex.Status.Detail);

--- a/test/Grpc.Net.Client.Tests/CancellationTests.cs
+++ b/test/Grpc.Net.Client.Tests/CancellationTests.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using Greet;
 using Grpc.Core;
 using Grpc.Net.Client.Internal;
+using Grpc.Net.Client.Internal.Http;
 using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
 using NUnit.Framework;

--- a/test/Grpc.Net.Client.Tests/CompressionTests.cs
+++ b/test/Grpc.Net.Client.Tests/CompressionTests.cs
@@ -145,12 +145,12 @@ namespace Grpc.Net.Client.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual("Hello world", response.Message);
 
-            Debug.Assert(httpRequestMessage != null);
+            CompatibilityExtensions.Assert(httpRequestMessage != null);
             Assert.AreEqual("identity,gzip,test", httpRequestMessage.Headers.GetValues(GrpcProtocolConstants.MessageAcceptEncodingHeader).Single());
             Assert.AreEqual("gzip", httpRequestMessage.Headers.GetValues(GrpcProtocolConstants.MessageEncodingHeader).Single());
             Assert.AreEqual(false, httpRequestMessage.Headers.Contains(GrpcProtocolConstants.CompressionRequestAlgorithmHeader));
 
-            Debug.Assert(helloRequest != null);
+            CompatibilityExtensions.Assert(helloRequest != null);
             Assert.AreEqual("Hello", helloRequest.Name);
 
             Assert.AreEqual(compressionDisabledOnOptions, isRequestNotCompressed);
@@ -163,7 +163,7 @@ namespace Grpc.Net.Client.Tests
             HttpRequestMessage? httpRequestMessage = null;
             HelloRequest? helloRequest = null;
 
-            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            var handler = TestHttpMessageHandler.Create(async request =>
             {
                 httpRequestMessage = request;
 
@@ -188,7 +188,7 @@ namespace Grpc.Net.Client.Tests
 
                 return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcEncoding: "gzip");
             });
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient);
+            var invoker = HttpClientCallInvokerFactory.Create(handler, "http://localhost");
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest
@@ -324,14 +324,14 @@ namespace Grpc.Net.Client.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual("Hello world", response.Message);
 
-            Debug.Assert(httpRequestMessage != null);
+            CompatibilityExtensions.Assert(httpRequestMessage != null);
             Assert.AreEqual("identity,gzip,test", httpRequestMessage.Headers.GetValues(GrpcProtocolConstants.MessageAcceptEncodingHeader).Single());
             Assert.AreEqual("gzip", httpRequestMessage.Headers.GetValues(GrpcProtocolConstants.MessageEncodingHeader).Single());
             Assert.AreEqual(false, httpRequestMessage.Headers.Contains(GrpcProtocolConstants.CompressionRequestAlgorithmHeader));
 
-            Debug.Assert(helloRequest1 != null);
+            CompatibilityExtensions.Assert(helloRequest1 != null);
             Assert.AreEqual("Hello One", helloRequest1.Name);
-            Debug.Assert(helloRequest2 != null);
+            CompatibilityExtensions.Assert(helloRequest2 != null);
             Assert.AreEqual("Hello Two", helloRequest2.Name);
 
             Assert.IsTrue(isRequestCompressed1);

--- a/test/Grpc.Net.Client.Tests/DeadlineTests.cs
+++ b/test/Grpc.Net.Client.Tests/DeadlineTests.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using Greet;
 using Grpc.Core;
 using Grpc.Net.Client.Internal;
+using Grpc.Net.Client.Internal.Http;
 using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
 using Microsoft.Extensions.Logging;

--- a/test/Grpc.Net.Client.Tests/DiagnosticsTests.cs
+++ b/test/Grpc.Net.Client.Tests/DiagnosticsTests.cs
@@ -42,7 +42,7 @@ namespace Grpc.Net.Client.Tests
             {
                 var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
                 var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: StatusCode.Aborted);
-                response.TrailingHeaders.Add(GrpcProtocolConstants.MessageTrailer, "value");
+                response.TrailingHeaders().Add(GrpcProtocolConstants.MessageTrailer, "value");
                 return response;
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);
@@ -79,7 +79,7 @@ namespace Grpc.Net.Client.Tests
 
                 var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
                 responseMessage = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: StatusCode.Aborted);
-                responseMessage.TrailingHeaders.Add(GrpcProtocolConstants.MessageTrailer, "value");
+                responseMessage.TrailingHeaders().Add(GrpcProtocolConstants.MessageTrailer, "value");
                 return responseMessage;
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);
@@ -110,7 +110,7 @@ namespace Grpc.Net.Client.Tests
             {
                 var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
                 var responseMessage = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: StatusCode.Aborted);
-                responseMessage.TrailingHeaders.Add(GrpcProtocolConstants.MessageTrailer, "value");
+                responseMessage.TrailingHeaders().Add(GrpcProtocolConstants.MessageTrailer, "value");
                 return responseMessage;
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);

--- a/test/Grpc.Net.Client.Tests/GetStatusTests.cs
+++ b/test/Grpc.Net.Client.Tests/GetStatusTests.cs
@@ -33,11 +33,11 @@ namespace Grpc.Net.Client.Tests
     public class GetStatusTests
     {
         [TestCase(HttpStatusCode.BadRequest, StatusCode.Internal)]
-        [TestCase(HttpStatusCode.RequestHeaderFieldsTooLarge, StatusCode.Internal)]
+        [TestCase((HttpStatusCode)431, StatusCode.Internal)]
         [TestCase(HttpStatusCode.Unauthorized, StatusCode.Unauthenticated)]
         [TestCase(HttpStatusCode.Forbidden, StatusCode.PermissionDenied)]
         [TestCase(HttpStatusCode.NotFound, StatusCode.Unimplemented)]
-        [TestCase(HttpStatusCode.TooManyRequests, StatusCode.Unavailable)]
+        [TestCase((HttpStatusCode)429, StatusCode.Unavailable)]
         [TestCase(HttpStatusCode.BadGateway, StatusCode.Unavailable)]
         [TestCase(HttpStatusCode.ServiceUnavailable, StatusCode.Unavailable)]
         [TestCase(HttpStatusCode.GatewayTimeout, StatusCode.Unavailable)]
@@ -97,7 +97,7 @@ namespace Grpc.Net.Client.Tests
             {
                 var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
                 var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: StatusCode.Aborted);
-                response.TrailingHeaders.Add(GrpcProtocolConstants.MessageTrailer, "value");
+                response.TrailingHeaders().Add(GrpcProtocolConstants.MessageTrailer, "value");
                 return response;
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);
@@ -122,7 +122,7 @@ namespace Grpc.Net.Client.Tests
             {
                 var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
                 var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: StatusCode.Aborted);
-                response.TrailingHeaders.Add(GrpcProtocolConstants.MessageTrailer, "%C2%A3");
+                response.TrailingHeaders().Add(GrpcProtocolConstants.MessageTrailer, "%C2%A3");
                 return response;
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);
@@ -147,8 +147,8 @@ namespace Grpc.Net.Client.Tests
             {
                 var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
                 var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: StatusCode.Aborted);
-                response.TrailingHeaders.Add(GrpcProtocolConstants.MessageTrailer, "one");
-                response.TrailingHeaders.Add(GrpcProtocolConstants.MessageTrailer, "two");
+                response.TrailingHeaders().Add(GrpcProtocolConstants.MessageTrailer, "one");
+                response.TrailingHeaders().Add(GrpcProtocolConstants.MessageTrailer, "two");
                 return response;
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);
@@ -225,7 +225,7 @@ namespace Grpc.Net.Client.Tests
             {
                 var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
                 var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: null);
-                response.TrailingHeaders.Add(GrpcProtocolConstants.StatusTrailer, "value");
+                response.TrailingHeaders().Add(GrpcProtocolConstants.StatusTrailer, "value");
                 return response;
             });
             var invoker = HttpClientCallInvokerFactory.Create(httpClient);

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net4.7.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>
@@ -21,15 +21,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
     <ProjectReference Include="..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
-    <ProjectReference Include="..\..\src\Grpc.Net.Client.Web\Grpc.Net.Client.Web.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Core" Version="$(GrpcPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='net4.7.2'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net4.7.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)'=='net4.7.2'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
@@ -49,7 +49,7 @@ namespace Grpc.Net.Client.Tests
                 serializationContext.Complete();
 
                 // Assert
-                var payload = serializationContext.Memory;
+                var payload = serializationContext.GetWrittenPayload();
                 var header = DecodeHeader(payload.Span);
                 Assert.IsFalse(header.Compressed);
                 Assert.AreEqual(1, header.Length);
@@ -80,10 +80,10 @@ namespace Grpc.Net.Client.Tests
                 serializationContext.Complete();
 
                 // Assert
-                var header = DecodeHeader(serializationContext.Memory.Span);
+                var header = DecodeHeader(serializationContext.GetWrittenPayload().Span);
                 Assert.IsFalse(header.Compressed);
                 Assert.AreEqual(1, header.Length);
-                Assert.AreEqual(byte.MaxValue, serializationContext.Memory.Span[5]);
+                Assert.AreEqual(byte.MaxValue, serializationContext.GetWrittenPayload().Span[5]);
 
                 serializationContext.Reset();
             }
@@ -105,7 +105,7 @@ namespace Grpc.Net.Client.Tests
             serializationContext.Complete();
 
             // Assert
-            var header = DecodeHeader(serializationContext.Memory.Span);
+            var header = DecodeHeader(serializationContext.GetWrittenPayload().Span);
             Assert.IsTrue(header.Compressed);
             Assert.AreEqual(21, header.Length);
         }
@@ -127,7 +127,7 @@ namespace Grpc.Net.Client.Tests
             serializationContext.Complete();
 
             // Assert
-            var header = DecodeHeader(serializationContext.Memory.Span);
+            var header = DecodeHeader(serializationContext.GetWrittenPayload().Span);
             Assert.IsTrue(header.Compressed);
             Assert.AreEqual(21, header.Length);
         }
@@ -150,7 +150,7 @@ namespace Grpc.Net.Client.Tests
             serializationContext.Complete();
 
             // Assert
-            var header = DecodeHeader(serializationContext.Memory.Span);
+            var header = DecodeHeader(serializationContext.GetWrittenPayload().Span);
             Assert.IsFalse(header.Compressed);
             Assert.AreEqual(1, header.Length);
         }
@@ -191,7 +191,7 @@ namespace Grpc.Net.Client.Tests
                 serializationContext.Complete(new byte[] { 1 });
 
                 // Assert
-                var header = DecodeHeader(serializationContext.Memory.Span);
+                var header = DecodeHeader(serializationContext.GetWrittenPayload().Span);
                 Assert.IsFalse(header.Compressed);
                 Assert.AreEqual(1, header.Length);
 
@@ -214,7 +214,7 @@ namespace Grpc.Net.Client.Tests
                 serializationContext.Complete(new byte[] { 1 });
 
                 // Assert
-                var header = DecodeHeader(serializationContext.Memory.Span);
+                var header = DecodeHeader(serializationContext.GetWrittenPayload().Span);
                 Assert.IsTrue(header.Compressed);
                 Assert.AreEqual(21, header.Length);
 
@@ -234,7 +234,7 @@ namespace Grpc.Net.Client.Tests
             serializationContext.Complete(new byte[] { 1 });
 
             // Assert
-            var header = DecodeHeader(serializationContext.Memory.Span);
+            var header = DecodeHeader(serializationContext.GetWrittenPayload().Span);
             Assert.IsFalse(header.Compressed);
             Assert.AreEqual(1, header.Length);
         }
@@ -279,7 +279,7 @@ namespace Grpc.Net.Client.Tests
             serializationContext.Reset();
 
             // Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => serializationContext.Memory.ToArray());
+            var ex = Assert.Throws<InvalidOperationException>(() => serializationContext.GetWrittenPayload().ToArray());
             Assert.AreEqual("Serialization did not return a payload.", ex.Message);
         }
 
@@ -301,7 +301,7 @@ namespace Grpc.Net.Client.Tests
             serializationContext.Reset();
 
             // Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => serializationContext.Memory.ToArray());
+            var ex = Assert.Throws<InvalidOperationException>(() => serializationContext.GetWrittenPayload().ToArray());
             Assert.AreEqual("Serialization did not return a payload.", ex.Message);
         }
 

--- a/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
@@ -20,6 +20,7 @@ using System;
 using System.Buffers.Binary;
 using Grpc.Core;
 using Grpc.Net.Client.Internal;
+using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
 
@@ -318,6 +319,7 @@ namespace Grpc.Net.Client.Tests
         {
             var channelOptions = new GrpcChannelOptions();
             channelOptions.MaxSendMessageSize = maxSendMessageSize;
+            channelOptions.HttpHandler = new NullHttpHandler();
 
             var call = new TestGrpcCall(new CallOptions(), GrpcChannel.ForAddress("http://localhost", channelOptions));
             call.RequestGrpcEncoding = requestGrpcEncoding ?? "identity";

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -82,6 +82,7 @@ namespace Grpc.Net.Client.Tests
         {
             var o = new GrpcChannelOptions();
 #if NET472
+            // An error is thrown if no handler is specified by .NET Standard 2.0 target.
             o.HttpHandler = new NullHttpHandler();
 #endif
             func?.Invoke(o);

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Greet;
 using Grpc.Core;
+using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
 
@@ -34,10 +35,8 @@ namespace Grpc.Net.Client.Tests
         public void Build_SslCredentialsWithHttps_Success()
         {
             // Arrange & Act
-            var channel = GrpcChannel.ForAddress("https://localhost", new GrpcChannelOptions
-            {
-                Credentials = new SslCredentials()
-            });
+            var channel = GrpcChannel.ForAddress("https://localhost",
+                CreateGrpcChannelOptions(o => o.Credentials = new SslCredentials()));
 
             // Assert
             Assert.IsTrue(channel.IsSecure);
@@ -47,10 +46,8 @@ namespace Grpc.Net.Client.Tests
         public void Build_SslCredentialsWithHttp_ThrowsError()
         {
             // Arrange & Act
-            var ex = Assert.Throws<InvalidOperationException>(() => GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
-            {
-                Credentials = new SslCredentials()
-            }));
+            var ex = Assert.Throws<InvalidOperationException>(() => GrpcChannel.ForAddress("http://localhost",
+                CreateGrpcChannelOptions(o => o.Credentials = new SslCredentials())));
 
             // Assert
             Assert.AreEqual("Channel is configured with secure channel credentials and can't use a HttpClient with a 'http' scheme.", ex.Message);
@@ -60,10 +57,8 @@ namespace Grpc.Net.Client.Tests
         public void Build_SslCredentialsWithArgs_ThrowsError()
         {
             // Arrange & Act
-            var ex = Assert.Throws<InvalidOperationException>(() => GrpcChannel.ForAddress("https://localhost", new GrpcChannelOptions
-            {
-                Credentials = new SslCredentials("rootCertificates!!!")
-            }));
+            var ex = Assert.Throws<InvalidOperationException>(() => GrpcChannel.ForAddress("https://localhost",
+                CreateGrpcChannelOptions(o => o.Credentials = new SslCredentials("rootCertificates!!!"))));
 
             // Assert
             Assert.AreEqual(
@@ -76,23 +71,29 @@ namespace Grpc.Net.Client.Tests
         public void Build_InsecureCredentialsWithHttp_Success()
         {
             // Arrange & Act
-            var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
-            {
-                Credentials = ChannelCredentials.Insecure
-            });
+            var channel = GrpcChannel.ForAddress("http://localhost",
+                CreateGrpcChannelOptions(o => o.Credentials = ChannelCredentials.Insecure));
 
             // Assert
             Assert.IsFalse(channel.IsSecure);
+        }
+
+        private static GrpcChannelOptions CreateGrpcChannelOptions(Action<GrpcChannelOptions>? func = null)
+        {
+            var o = new GrpcChannelOptions();
+#if NET472
+            o.HttpHandler = new NullHttpHandler();
+#endif
+            func?.Invoke(o);
+            return o;
         }
 
         [Test]
         public void Build_InsecureCredentialsWithHttps_ThrowsError()
         {
             // Arrange & Act
-            var ex = Assert.Throws<InvalidOperationException>(() => GrpcChannel.ForAddress("https://localhost", new GrpcChannelOptions
-            {
-                Credentials = ChannelCredentials.Insecure
-            }));
+            var ex = Assert.Throws<InvalidOperationException>(() => GrpcChannel.ForAddress("https://localhost",
+                CreateGrpcChannelOptions(o => o.Credentials = ChannelCredentials.Insecure)));
 
             // Assert
             Assert.AreEqual("Channel is configured with insecure channel credentials and can't use a HttpClient with a 'https' scheme.", ex.Message);
@@ -148,11 +149,29 @@ namespace Grpc.Net.Client.Tests
             Assert.AreEqual("HttpHandler", ex.Status.DebugException.Message);
         }
 
+#if NET472
+        [Test]
+        public void Build_NoHttpProviderOnNetFx_Throw()
+        {
+            // Arrange & Act
+            var ex = Assert.Throws<PlatformNotSupportedException>(() => GrpcChannel.ForAddress("https://localhost"));
+
+            // Assert
+            var message =
+                $"gRPC requires extra configuration to successfully make RPC calls on older platforms such " +
+                $"as .NET Framework. An HTTP provider must be specified using {nameof(GrpcChannelOptions)}.{nameof(GrpcChannelOptions.HttpHandler)} or " +
+                $"{nameof(GrpcChannelOptions)}.{nameof(GrpcChannelOptions.HttpClient)}. The configured HTTP provider must either support HTTP/2 or " +
+                $"be configured to use gRPC-Web. See https://aka.ms/pzkMXDs for details.";
+
+            Assert.AreEqual(message, ex.Message);
+        }
+#endif
+
         [Test]
         public void Dispose_NotCalled_NotDisposed()
         {
             // Arrange
-            var channel = GrpcChannel.ForAddress("https://localhost");
+            var channel = GrpcChannel.ForAddress("https://localhost", CreateGrpcChannelOptions());
 
             // Act (nothing)
 
@@ -160,6 +179,7 @@ namespace Grpc.Net.Client.Tests
             Assert.IsFalse(channel.Disposed);
         }
 
+#if !NET472
         [Test]
         public void Dispose_Called_Disposed()
         {
@@ -173,12 +193,13 @@ namespace Grpc.Net.Client.Tests
             Assert.IsTrue(channel.Disposed);
             Assert.Throws<ObjectDisposedException>(() => channel.HttpInvoker.SendAsync(new HttpRequestMessage(), CancellationToken.None));
         }
+#endif
 
         [Test]
         public void Dispose_CalledMultipleTimes_Disposed()
         {
             // Arrange
-            var channel = GrpcChannel.ForAddress("https://localhost");
+            var channel = GrpcChannel.ForAddress("https://localhost", CreateGrpcChannelOptions());
 
             // Act
             channel.Dispose();
@@ -192,7 +213,7 @@ namespace Grpc.Net.Client.Tests
         public void Dispose_CreateCallInvoker_ThrowError()
         {
             // Arrange
-            var channel = GrpcChannel.ForAddress("https://localhost");
+            var channel = GrpcChannel.ForAddress("https://localhost", CreateGrpcChannelOptions());
 
             // Act
             channel.Dispose();
@@ -205,7 +226,7 @@ namespace Grpc.Net.Client.Tests
         public async Task Dispose_StartCallOnClient_ThrowError()
         {
             // Arrange
-            var channel = GrpcChannel.ForAddress("https://localhost");
+            var channel = GrpcChannel.ForAddress("https://localhost", CreateGrpcChannelOptions());
             var client = new Greet.Greeter.GreeterClient(channel);
 
             // Act

--- a/test/Grpc.Net.Client.Tests/HeadersTests.cs
+++ b/test/Grpc.Net.Client.Tests/HeadersTests.cs
@@ -27,7 +27,6 @@ using Grpc.Core;
 using Grpc.Net.Client.Internal;
 using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
-using Microsoft.Net.Http.Headers;
 using NUnit.Framework;
 
 namespace Grpc.Net.Client.Tests
@@ -105,12 +104,12 @@ namespace Grpc.Net.Client.Tests
             // User-Agent is always sent
             Assert.AreEqual(0, httpRequestMessage!.Headers.Count(h =>
             {
-                if (string.Equals(h.Key, HeaderNames.UserAgent, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(h.Key, "user-agent", StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }
 
-                if (string.Equals(h.Key, HeaderNames.TE, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(h.Key, "te", StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }

--- a/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
@@ -42,6 +42,41 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             configure?.Invoke(channelOptions);
 
             var channel = GrpcChannel.ForAddress(httpClient.BaseAddress!, channelOptions);
+            ConfigureChannel(systemClock, disableClientDeadline, maxTimerPeriod, operatingSystem, channel);
+
+            return new HttpClientCallInvoker(channel);
+        }
+
+        public static HttpClientCallInvoker Create(
+            HttpMessageHandler httpMessageHandler,
+            string address,
+            ILoggerFactory? loggerFactory = null,
+            ISystemClock? systemClock = null,
+            Action<GrpcChannelOptions>? configure = null,
+            bool? disableClientDeadline = null,
+            long? maxTimerPeriod = null,
+            IOperatingSystem? operatingSystem = null)
+        {
+            var channelOptions = new GrpcChannelOptions
+            {
+                LoggerFactory = loggerFactory,
+                HttpHandler = httpMessageHandler
+            };
+            configure?.Invoke(channelOptions);
+
+            var channel = GrpcChannel.ForAddress(address, channelOptions);
+            ConfigureChannel(systemClock, disableClientDeadline, maxTimerPeriod, operatingSystem, channel);
+
+            return new HttpClientCallInvoker(channel);
+        }
+
+        private static void ConfigureChannel(
+            ISystemClock? systemClock,
+            bool? disableClientDeadline,
+            long? maxTimerPeriod,
+            IOperatingSystem? operatingSystem,
+            GrpcChannel channel)
+        {
             channel.Clock = systemClock ?? SystemClock.Instance;
             if (disableClientDeadline != null)
             {
@@ -55,8 +90,6 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             {
                 channel.OperatingSystem = operatingSystem;
             }
-
-            return new HttpClientCallInvoker(channel);
         }
     }
 }

--- a/test/Grpc.Net.Client.Tests/Infrastructure/NullHttpHandler.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/NullHttpHandler.cs
@@ -1,0 +1,46 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grpc.Net.Client.Tests.Infrastructure
+{
+    public class NullHttpHandler : HttpMessageHandler
+    {
+        private bool _disposed;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NullHttpHandler));
+            }
+
+            throw new NotImplementedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
@@ -33,7 +33,7 @@ namespace Grpc.Net.Client.Tests.Infrastructure
 {
     internal static class StreamSerializationHelper
     {
-        public static ValueTask<TResponse?> ReadMessageAsync<TResponse>(
+        public static Task<TResponse?> ReadMessageAsync<TResponse>(
             Stream responseStream,
             //ILogger logger,
             Func<DeserializationContext, TResponse> deserializer,
@@ -52,7 +52,13 @@ namespace Grpc.Net.Client.Tests.Infrastructure
 
             var tempCall = new TestGrpcCall(new CallOptions(), tempChannel, typeof(TResponse));
 
-            return responseStream.ReadMessageAsync(tempCall, deserializer, grpcEncoding, singleMessage, cancellationToken);
+            var task = responseStream.ReadMessageAsync(tempCall, deserializer, grpcEncoding, singleMessage, cancellationToken);
+
+#if !NET472
+            return task.AsTask();
+#else
+            return task;
+#endif
         }
 
         private class TestGrpcCall : GrpcCall

--- a/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
@@ -47,7 +47,8 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             var tempChannel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
             {
                 MaxReceiveMessageSize = maximumMessageSize,
-                CompressionProviders = compressionProviders?.Values.ToList()
+                CompressionProviders = compressionProviders?.Values.ToList(),
+                HttpHandler = new NullHttpHandler()
             });
 
             var tempCall = new TestGrpcCall(new CallOptions(), tempChannel, typeof(TResponse));

--- a/test/Grpc.Net.Client.Tests/MaximumMessageSizeTests.cs
+++ b/test/Grpc.Net.Client.Tests/MaximumMessageSizeTests.cs
@@ -45,7 +45,7 @@ namespace Grpc.Net.Client.Tests
                 maximumMessageSize: null,
                 GrpcProtocolConstants.DefaultCompressionProviders,
                 singleMessage: true,
-                CancellationToken.None).AsTask().DefaultTimeout();
+                CancellationToken.None).DefaultTimeout();
 
             var reply = new HelloReply
             {

--- a/test/Grpc.Net.Client.Tests/ReadAllAsyncTests.cs
+++ b/test/Grpc.Net.Client.Tests/ReadAllAsyncTests.cs
@@ -27,6 +27,8 @@ using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
 
+#if !NET472
+
 namespace Grpc.Net.Client.Tests
 {
     [TestFixture]
@@ -278,3 +280,5 @@ namespace Grpc.Net.Client.Tests
         }
     }
 }
+
+#endif

--- a/test/Grpc.Net.Client.Web.Tests/Base64RequestStreamTests.cs
+++ b/test/Grpc.Net.Client.Web.Tests/Base64RequestStreamTests.cs
@@ -25,7 +25,7 @@ using Grpc.Net.Client.Web.Internal;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
 
-namespace Grpc.Net.Client.Tests.Web
+namespace Grpc.Net.Client.Web.Tests
 {
     [TestFixture]
     public class Base64RequestStreamTests

--- a/test/Grpc.Net.Client.Web.Tests/Base64ResponseStreamTests.cs
+++ b/test/Grpc.Net.Client.Web.Tests/Base64ResponseStreamTests.cs
@@ -29,7 +29,7 @@ using Grpc.Net.Client.Web.Internal;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
 
-namespace Grpc.Net.Client.Tests.Web
+namespace Grpc.Net.Client.Web.Tests
 {
     [TestFixture]
     public class Base64ResponseStreamTests

--- a/test/Grpc.Net.Client.Web.Tests/Grpc.Net.Client.Web.Tests.csproj
+++ b/test/Grpc.Net.Client.Web.Tests/Grpc.Net.Client.Web.Tests.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Grpc.Net.Client.Web\Grpc.Net.Client.Web.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\ExceptionAssert.cs" Link="Infrastructure\ExceptionAssert.cs" />
+    <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
+  </ItemGroup>
+
+</Project>

--- a/test/Grpc.Net.Client.Web.Tests/GrpcWebHandlerTests.cs
+++ b/test/Grpc.Net.Client.Web.Tests/GrpcWebHandlerTests.cs
@@ -28,7 +28,7 @@ using Grpc.Net.Client.Web;
 using Grpc.Net.Client.Web.Internal;
 using NUnit.Framework;
 
-namespace Grpc.Net.Client.Tests.Web
+namespace Grpc.Net.Client.Web.Tests
 {
     [TestFixture]
     public class GrpcWebHandlerTests

--- a/test/Grpc.Net.Client.Web.Tests/GrpcWebResponseContentTests.cs
+++ b/test/Grpc.Net.Client.Web.Tests/GrpcWebResponseContentTests.cs
@@ -25,7 +25,7 @@ using Grpc.Net.Client.Web;
 using Grpc.Net.Client.Web.Internal;
 using NUnit.Framework;
 
-namespace Grpc.Net.Client.Tests.Web
+namespace Grpc.Net.Client.Web.Tests
 {
     [TestFixture]
     public class GrpcWebResponseContentTests

--- a/test/Grpc.Net.Client.Web.Tests/GrpcWebResponseStreamTests.cs
+++ b/test/Grpc.Net.Client.Web.Tests/GrpcWebResponseStreamTests.cs
@@ -22,12 +22,11 @@ using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using Grpc.Net.Client.Internal;
 using Grpc.Net.Client.Web.Internal;
 using Grpc.Tests.Shared;
 using NUnit.Framework;
 
-namespace Grpc.Net.Client.Tests.Web
+namespace Grpc.Net.Client.Web.Tests
 {
     [TestFixture]
     public class GrpcWebResponseStreamTests
@@ -59,7 +58,7 @@ namespace Grpc.Net.Client.Tests.Web
             // Assert 2
             Assert.AreEqual(0, read2);
             Assert.AreEqual(1, trailingHeaders.Count());
-            Assert.AreEqual("0", trailingHeaders.GetValues(GrpcProtocolConstants.StatusTrailer).Single());
+            Assert.AreEqual("0", trailingHeaders.GetValues("grpc-status").Single());
         }
 
         [Test]

--- a/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
+++ b/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
@@ -29,8 +29,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(MicrosoftExtensionsLoggingTestingPackageVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Infrastructure\" />
-  </ItemGroup>
-
 </Project>

--- a/test/Shared/ClientTestHelpers.cs
+++ b/test/Shared/ClientTestHelpers.cs
@@ -98,9 +98,11 @@ namespace Grpc.Tests.Shared
 
                 var output = new MemoryStream();
                 var compressionStream = compressionProvider.CreateCompressionStream(output, System.IO.Compression.CompressionLevel.Fastest);
+                var compressedData = response.ToByteArray();
 
-                compressionStream.Write(response.ToByteArray());
+                compressionStream.Write(compressedData, 0, compressedData.Length);
                 compressionStream.Flush();
+                compressionStream.Dispose();
                 data = output.ToArray();
             }
             else
@@ -109,7 +111,7 @@ namespace Grpc.Tests.Shared
             }
 
             await ResponseUtils.WriteHeaderAsync(ms, data.Length, compress, CancellationToken.None);
-            await ms.WriteAsync(data);
+            await ms.WriteAsync(data, 0, data.Length);
         }
 
         public static async Task<byte[]> GetResponseDataAsync<TResponse>(TResponse response) where TResponse : IMessage<TResponse>

--- a/test/Shared/TaskExtensions.cs
+++ b/test/Shared/TaskExtensions.cs
@@ -93,6 +93,7 @@ namespace Grpc.Tests.Shared
             ? $"The operation timed out after reaching the limit of {timeout.TotalMilliseconds}ms."
             : $"The operation at {filePath}:{lineNumber} timed out after reaching the limit of {timeout.TotalMilliseconds}ms.";
 
+#if !NET472
         public static IAsyncEnumerable<T> DefaultTimeout<T>(this IAsyncEnumerable<T> enumerable,
             [CallerFilePath] string? filePath = null,
             [CallerLineNumber] int lineNumber = default)
@@ -159,5 +160,6 @@ namespace Grpc.Tests.Shared
                 return new ValueTask<bool>(_enumerator.MoveNextAsync().AsTask().TimeoutAfter(_timeout, _filePath, _lineNumber));
             }
         }
+#endif
     }
 }

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net5.0;net4.7.2</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net5.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net5.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net5.0;net4.7.2</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,8 +23,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
-    <ProjectReference Include="..\..\src\Grpc.Net.Client.Web\Grpc.Net.Client.Web.csproj" />
-
     <ProjectReference Include="..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
@@ -35,6 +34,11 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLinePackageVersion)" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemNetHttpWinHttpHandlerPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <ProjectReference Include="..\..\src\Grpc.Net.Client.Web\Grpc.Net.Client.Web.csproj" />
   </ItemGroup>
 
 </Project>

--- a/testassets/InteropTestsClient/Program.cs
+++ b/testassets/InteropTestsClient/Program.cs
@@ -19,6 +19,7 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Reflection;
 using System.Threading.Tasks;
 using Grpc.Shared.TestAssets;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,10 +43,16 @@ namespace InteropTestsClient
             rootCommand.AddOption(new Option<string>(new string[] { "--oauth_scope", nameof(ClientOptions.OAuthScope) }));
             rootCommand.AddOption(new Option<string>(new string[] { "--service_account_key_file", nameof(ClientOptions.ServiceAccountKeyFile) }));
             rootCommand.AddOption(new Option<string>(new string[] { "--grpc_web_mode", nameof(ClientOptions.GrpcWebMode) }));
+            rootCommand.AddOption(new Option<bool>(new string[] { "--use_winhttp", nameof(ClientOptions.UseWinHttp) }));
 
             rootCommand.Handler = CommandHandler.Create<ClientOptions>(async (options) =>
             {
+                var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
+
+                Console.WriteLine("Runtime: " + runtimeVersion);
                 Console.WriteLine("Use TLS: " + options.UseTls);
+                Console.WriteLine("Use WinHttp: " + options.UseWinHttp);
+                Console.WriteLine("Use GrpcWebMode: " + options.GrpcWebMode);
                 Console.WriteLine("Use Test CA: " + options.UseTestCa);
                 Console.WriteLine("Client type: " + options.ClientType);
                 Console.WriteLine("Server host: " + options.ServerHost);

--- a/testassets/InteropTestsClient/RunGrpcTests.ps1
+++ b/testassets/InteropTestsClient/RunGrpcTests.ps1
@@ -1,6 +1,8 @@
 ﻿Param
 (
-    [bool]$use_tls = $false
+    [bool]$use_tls = $false,
+    [bool]$use_winhttp = $false,
+    [string]$framework = "net5.0"
 )
 
 $allTests =
@@ -31,21 +33,15 @@ $allTests =
 
 Write-Host "Running $($allTests.Count) tests" -ForegroundColor Cyan
 Write-Host "Use TLS: $use_tls" -ForegroundColor Cyan
+Write-Host "Use WinHttp: $use_winhttp" -ForegroundColor Cyan
+Write-Host "Framework: $framework" -ForegroundColor Cyan
 Write-Host
 
 foreach ($test in $allTests)
 {
   Write-Host "Running $test" -ForegroundColor Cyan
 
-  if (!$use_tls)
-  {
-    dotnet run --use_tls false --server_port 50052 --client_type httpclient --test_case $test
-  }
-  else
-  {
-    # Certificate is for test.google.com host. To run locally, setup the host file to point test.google.com to 127.0.0.1
-    dotnet run --use_tls true --server_port 50052 --client_type httpclient --test_case $test --server_host test.google.com
-  }
+  dotnet run --framework $framework --use_tls $use_tls --server_host localhost --server_port 50052 --client_type httpclient --test_case $test --use_winhttp $use_winhttp
 
   Write-Host
 }

--- a/testassets/InteropTestsGrpcWebClient/InteropTestsGrpcWebClient.csproj
+++ b/testassets/InteropTestsGrpcWebClient/InteropTestsGrpcWebClient.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" PrivateAssets="all" />
 
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemNetHttpWinHttpHandlerPackageVersion)" />
+
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
     


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1176

Experiment targeting .NET Framework with Grpc.Net.Client

~Blocked on [WinHttpHandler: Read HTTP/2 trailing headers](https://github.com/dotnet/runtime/pull/46602).~ Key/type is unlikely to change. If it does then we can react relatively easily.