### PR TITLE
Fix running in benchmarks environment with net60

### DIFF
--- a/build/sources.props
+++ b/build/sources.props
@@ -7,6 +7,7 @@
       https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)feed')">

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Uncomment line below to enable gRPC-Web on the server -->
     <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
@@ -12,12 +11,6 @@
     <!-- <EnableDefaultProtoBufItems>true</EnableDefaultProtoBufItems> -->
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>
-
-  <!-- Allow benchmarks to specify the latest framework -->
-  <ItemGroup Condition="'$(BenchmarksTargetFramework)' != ''">
-    <FrameworkReference Update="Microsoft.AspNetCore.App" RuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)" />
-    <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="$(MicrosoftNETCoreAppPackageVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
     <Protobuf Include="..\Shared\benchmark_service.proto" GrpcServices="Server" Link="Protos\benchmark_service.proto" />
@@ -41,7 +34,7 @@
     <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -102,7 +102,7 @@ namespace GrpcAspNetCoreServer
                         Console.WriteLine($"Console Logging enabled with level '{logLevel}'");
 
                         loggerFactory
-#if NET5_0
+#if NET5_0 || NET6_0
                             .AddSimpleConsole(o => o.TimestampFormat = "ss.ffff ")
 #else
                             .AddConsole(o => o.TimestampFormat = "ss.ffff ")

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
@@ -21,7 +21,7 @@ using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Grpc.Testing;
-#if NET5_0
+#if NET5_0 || NET6_0
 using Microsoft.AspNetCore.Authentication.Certificate;
 #endif
 using Microsoft.AspNetCore.Builder;
@@ -47,7 +47,7 @@ namespace GrpcAspNetCoreServer
         {
             services.AddGrpc(o =>
             {
-#if NET5_0
+#if NET5_0 || NET6_0
                 // Small performance benefit to not add catch-all routes to handle UNIMPLEMENTED for unknown services
                 o.IgnoreUnknownServices = true;
 #endif
@@ -60,7 +60,7 @@ namespace GrpcAspNetCoreServer
             services.AddSingleton<BenchmarkServiceImpl>();
             services.AddControllers();
 
-#if NET5_0
+#if NET5_0 || NET6_0
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {
@@ -83,7 +83,7 @@ namespace GrpcAspNetCoreServer
 
             app.UseRouting();
 
-#if NET5_0
+#if NET5_0 || NET6_0
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {
@@ -139,7 +139,7 @@ namespace GrpcAspNetCoreServer
 
         private void ConfigureAuthorization(IEndpointConventionBuilder builder)
         {
-#if NET5_0
+#if NET5_0 || NET6_0
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {

--- a/perf/benchmarkapps/GrpcClient/ClientOptions.cs
+++ b/perf/benchmarkapps/GrpcClient/ClientOptions.cs
@@ -23,7 +23,7 @@ namespace GrpcClient
     public class ClientOptions
     {
         public string? Url { get; set; }
-#if NET5_0
+#if NET5_0 || NET6_0
         public string? UdsFileName { get; set; }
 #endif
         public int Connections { get; set; }

--- a/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
+++ b/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
@@ -2,18 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
     <!-- Enable server GC to more closely simulate a microservice app making calls -->
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
-
-  <!-- Allow benchmarks to specify the latest framework -->
-  <ItemGroup Condition="'$(BenchmarksTargetFramework)' != ''">
-    <FrameworkReference Update="Microsoft.AspNetCore.App" RuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)" />
-    <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="$(MicrosoftNETCoreAppPackageVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
     <Protobuf Include="..\Shared\benchmark_service.proto" GrpcServices="Client" Link="Protos\benchmark_service.proto" />
@@ -45,7 +38,7 @@
     <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Web\Grpc.AspNetCore.Web.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <ProjectReference Include="..\..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />

--- a/perf/benchmarkapps/GrpcClient/Program.cs
+++ b/perf/benchmarkapps/GrpcClient/Program.cs
@@ -419,7 +419,7 @@ namespace GrpcClient
                             clientCertificate
                         };
                     }
-#if NET5_0
+#if NET5_0 || NET6_0
                     if (!string.IsNullOrEmpty(_options.UdsFileName))
                     {
                         var connectionFactory = new UnixDomainSocketConnectionFactory(new UnixDomainSocketEndPoint(ResolveUdsPath(_options.UdsFileName)));
@@ -432,7 +432,7 @@ namespace GrpcClient
 
                     return GrpcChannel.ForAddress(address, new GrpcChannelOptions
                     {
-#if NET5_0
+#if NET5_0 || NET6_0
                         HttpHandler = httpClientHandler,
 #else
                         HttpClient = new HttpClient(httpClientHandler),

--- a/perf/benchmarkapps/GrpcClient/UnixDomainSocketConnectionFactory.cs
+++ b/perf/benchmarkapps/GrpcClient/UnixDomainSocketConnectionFactory.cs
@@ -23,7 +23,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-#if NET5_0
+#if NET5_0 || NET6_0
 
 namespace GrpcClient
 {

--- a/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-
-  <!-- Allow benchmarks to specify the latest framework -->
-  <ItemGroup Condition="'$(BenchmarksTargetFramework)' != ''">
-    <FrameworkReference Update="Microsoft.AspNetCore.App" RuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)" />
-    <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="$(MicrosoftNETCoreAppPackageVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
     <Protobuf Include="..\Shared\benchmark_service.proto" GrpcServices="Server" Link="Protos\benchmark_service.proto" />


### PR DESCRIPTION
Benchmarks currently fail when running on .NET 6 in benchmark environment

Also, remove content no longer needed in project files for benchmarks.