### PR TITLE
Fix build on benchmark server

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -40,6 +40,10 @@
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
 
+    <!--
+      TODO(JamesNK): This package ref should use MicrosoftAspNetCoreAppPackageVersion.
+      There is currently an issue using 6.0 versions so hardcode to 5.0
+      -->
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="5.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Failing because of reference to 6.0 version of a package.