### PR TITLE
Roll forward using LatestMajor behaviour

### DIFF
--- a/src/dotnet-grpc/dotnet-grpc.csproj
+++ b/src/dotnet-grpc/dotnet-grpc.csproj
@@ -14,6 +14,8 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>
     <NoWarn>$(NoWarn);CA2007</NoWarn>
 
+    <RollForward>LatestMajor</RollForward>
+
     <!-- The runtimeconfig.template.json file is used to allow roll-forward for future runtimes. We target netcoreapp3.0 as the lowest TFM. 
       See https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/roll-forward-on-no-candidate-fx.md#roll-forward-in-absence-of-candidate-fx for details-->
   </PropertyGroup>

--- a/src/dotnet-grpc/runtimeconfig.template.json
+++ b/src/dotnet-grpc/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-  "rollForwardOnNoCandidateFx": 2
-}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues

Currently the roll forward behaviour is set to Major which
> Roll forward to lowest higher major version, and lowest minor version, if requested major version is missing. If the requested major version is present, then the Minor policy is used.

This breaks when both 3.1 and 5.0 runtimes are installed as was the scenario in the linked issue. Specifically, the tool itself targets netcoreapp3.0 and ends up using the 3.1 runtime due to the Major roll forward policy. However, the MSBuild locator picks the 5.0 SDK which ends up loading a NugetSDKResolver binary that depends on 5.0 runtime assemblies. This conflict results in the assembly not found error. To resolve this, we can just rely on the LatestMajor roll forward policy, this ensures we run on the latest runtime, which will be compatible with the latest installed SDK.

