### PR TITLE
Improve error message when CORS is not configured correctly

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -55,8 +55,10 @@ namespace Grpc.Net.Client
         internal Dictionary<string, ICompressionProvider> CompressionProviders { get; }
         internal string MessageAcceptEncoding { get; }
         internal bool Disposed { get; private set; }
-        // Timing related options that are set in unit tests
+
+        // Options that are set in unit tests
         internal ISystemClock Clock = SystemClock.Instance;
+        internal IOperatingSystem OperatingSystem = Internal.OperatingSystem.Instance;
         internal bool DisableClientDeadline;
         internal long MaxTimerDueTime = uint.MaxValue - 1; // Max System.Threading.Timer due time
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -503,7 +503,7 @@ namespace Grpc.Net.Client.Internal
                                 GrpcProtocolHelpers.GetGrpcEncoding(HttpResponse),
                                 singleMessage: true,
                                 _callCts.Token).ConfigureAwait(false);
-                            status = GrpcProtocolHelpers.GetResponseStatus(HttpResponse);
+                            status = GrpcProtocolHelpers.GetResponseStatus(HttpResponse, Channel.OperatingSystem.IsBrowser);
 
                             if (message == null)
                             {

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -327,14 +327,20 @@ namespace Grpc.Net.Client.Internal
             }
         }
 
-        public static Status GetResponseStatus(HttpResponseMessage httpResponse)
+        public static Status GetResponseStatus(HttpResponseMessage httpResponse, bool isBrowser)
         {
             Status? status;
             try
             {
                 if (!TryGetStatusCore(httpResponse.TrailingHeaders, out status))
                 {
-                    status = new Status(StatusCode.Cancelled, "No grpc-status found on response.");
+                    var detail = "No grpc-status found on response.";
+                    if (isBrowser)
+                    {
+                        detail += " If the gRPC call is cross domain then CORS must be correctly configured. Access-Control-Expose-Headers needs to include 'grpc-status' and 'grpc-message'.";
+                    }
+
+                    status = new Status(StatusCode.Cancelled, detail);
                 }
             }
             catch (Exception ex)

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -167,7 +167,7 @@ namespace Grpc.Net.Client.Internal
                 {
                     // No more content in response so report status to call.
                     // The call will handle finishing the response.
-                    var status = GrpcProtocolHelpers.GetResponseStatus(_httpResponse);
+                    var status = GrpcProtocolHelpers.GetResponseStatus(_httpResponse, _call.Channel.OperatingSystem.IsBrowser);
                     _call.ResponseStreamEnded(status);
                     if (status.StatusCode != StatusCode.OK)
                     {

--- a/src/Grpc.Net.Client/Internal/OperatingSystem.cs
+++ b/src/Grpc.Net.Client/Internal/OperatingSystem.cs
@@ -1,0 +1,39 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Runtime.InteropServices;
+
+namespace Grpc.Net.Client.Internal
+{
+    internal interface IOperatingSystem
+    {
+        bool IsBrowser { get; }
+    }
+
+    internal class OperatingSystem : IOperatingSystem
+    {
+        public static readonly OperatingSystem Instance = new OperatingSystem();
+
+        public bool IsBrowser { get; }
+
+        private OperatingSystem()
+        {
+            IsBrowser = RuntimeInformation.IsOSPlatform(OSPlatform.Create("browser"));
+        }
+    }
+}

--- a/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/HttpClientCallInvokerFactory.cs
@@ -31,7 +31,8 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             ISystemClock? systemClock = null,
             Action<GrpcChannelOptions>? configure = null,
             bool? disableClientDeadline = null,
-            long? maxTimerPeriod = null)
+            long? maxTimerPeriod = null,
+            IOperatingSystem? operatingSystem = null)
         {
             var channelOptions = new GrpcChannelOptions
             {
@@ -49,6 +50,10 @@ namespace Grpc.Net.Client.Tests.Infrastructure
             if (maxTimerPeriod != null)
             {
                 channel.MaxTimerDueTime = maxTimerPeriod.Value;
+            }
+            if (operatingSystem != null)
+            {
+                channel.OperatingSystem = operatingSystem;
             }
 
             return new HttpClientCallInvoker(channel);


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1163

Not including required gRPC headers in CORS configuration is a common error when using gRPC client in the browser. Why the error happens with CORS, and how to fix it is non-obvious.

Update error message to provide more information.