### PR TITLE
Change gRPC client factory to set HttpHandler

### DIFF
--- a/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
@@ -28,17 +28,17 @@ namespace Grpc.Net.ClientFactory.Internal
         private readonly IServiceProvider _serviceProvider;
         private readonly GrpcCallInvokerFactory _callInvokerFactory;
         private readonly IOptionsMonitor<GrpcClientFactoryOptions> _clientFactoryOptionsMonitor;
-        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IHttpMessageHandlerFactory _messageHandlerFactory;
 
         public DefaultGrpcClientFactory(IServiceProvider serviceProvider,
             GrpcCallInvokerFactory callInvokerFactory,
             IOptionsMonitor<GrpcClientFactoryOptions> clientFactoryOptionsMonitor,
-            IHttpClientFactory httpClientFactory)
+            IHttpMessageHandlerFactory messageHandlerFactory)
         {
             _serviceProvider = serviceProvider;
             _callInvokerFactory = callInvokerFactory;
             _clientFactoryOptionsMonitor = clientFactoryOptionsMonitor;
-            _httpClientFactory = httpClientFactory;
+            _messageHandlerFactory = messageHandlerFactory;
         }
 
         public override TClient CreateClient<TClient>(string name) where TClient : class
@@ -50,8 +50,8 @@ namespace Grpc.Net.ClientFactory.Internal
             }
 
             var clientFactoryOptions = _clientFactoryOptionsMonitor.Get(name);
-            var httpClient = _httpClientFactory.CreateClient(name);
-            var callInvoker = _callInvokerFactory.CreateCallInvoker(httpClient, name, clientFactoryOptions);
+            var httpHandler = _messageHandlerFactory.CreateHandler(name);
+            var callInvoker = _callInvokerFactory.CreateCallInvoker(httpHandler, name, clientFactoryOptions);
 
             if (clientFactoryOptions.Creator != null)
             {

--- a/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
@@ -51,7 +51,7 @@ namespace Grpc.Net.ClientFactory.Internal
 
             var clientFactoryOptions = _clientFactoryOptionsMonitor.Get(name);
             var httpHandler = _messageHandlerFactory.CreateHandler(name);
-            var callInvoker = _callInvokerFactory.CreateCallInvoker(httpHandler, name, clientFactoryOptions);
+            var callInvoker = _callInvokerFactory.CreateCallInvoker(httpHandler, name, typeof(TClient), clientFactoryOptions);
 
             if (clientFactoryOptions.Creator != null)
             {

--- a/src/Grpc.Net.ClientFactory/Internal/GrpcCallInvokerFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/GrpcCallInvokerFactory.cs
@@ -40,7 +40,7 @@ namespace Grpc.Net.ClientFactory.Internal
             _loggerFactory = loggerFactory;
         }
 
-        public CallInvoker CreateCallInvoker(HttpMessageHandler httpHandler, string name, GrpcClientFactoryOptions clientFactoryOptions)
+        public CallInvoker CreateCallInvoker(HttpMessageHandler httpHandler, string name, Type type, GrpcClientFactoryOptions clientFactoryOptions)
         {
             if (httpHandler == null)
             {
@@ -62,7 +62,7 @@ namespace Grpc.Net.ClientFactory.Internal
             var address = clientFactoryOptions.Address;
             if (address == null)
             {
-                throw new InvalidOperationException($@"Could not resolve the address for gRPC client '{name}'. Set an address when registering the client: services.AddGrpcClient<{name}>(o => o.Address = new Uri(""https://localhost:5001""))");
+                throw new InvalidOperationException($@"Could not resolve the address for gRPC client '{name}'. Set an address when registering the client: services.AddGrpcClient<{type.Name}>(o => o.Address = new Uri(""https://localhost:5001""))");
             }
 
             var channel = GrpcChannel.ForAddress(address, channelOptions);

--- a/src/Grpc.Net.ClientFactory/Internal/GrpcCallInvokerFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/GrpcCallInvokerFactory.cs
@@ -40,15 +40,15 @@ namespace Grpc.Net.ClientFactory.Internal
             _loggerFactory = loggerFactory;
         }
 
-        public CallInvoker CreateCallInvoker(HttpClient httpClient, string name, GrpcClientFactoryOptions clientFactoryOptions)
+        public CallInvoker CreateCallInvoker(HttpMessageHandler httpHandler, string name, GrpcClientFactoryOptions clientFactoryOptions)
         {
-            if (httpClient == null)
+            if (httpHandler == null)
             {
-                throw new ArgumentNullException(nameof(httpClient));
+                throw new ArgumentNullException(nameof(httpHandler));
             }
 
             var channelOptions = new GrpcChannelOptions();
-            channelOptions.HttpClient = httpClient;
+            channelOptions.HttpHandler = httpHandler;
             channelOptions.LoggerFactory = _loggerFactory;
 
             if (clientFactoryOptions.ChannelOptionsActions.Count > 0)
@@ -59,10 +59,10 @@ namespace Grpc.Net.ClientFactory.Internal
                 }
             }
 
-            var address = clientFactoryOptions.Address ?? httpClient.BaseAddress;
+            var address = clientFactoryOptions.Address;
             if (address == null)
             {
-                throw new InvalidOperationException($"Could not resolve the address for gRPC client '{name}'.");
+                throw new InvalidOperationException($@"Could not resolve the address for gRPC client '{name}'. Set an address when registering the client: services.AddGrpcClient<{name}>(o => o.Address = new Uri(""https://localhost:5001""))");
             }
 
             var channel = GrpcChannel.ForAddress(address, channelOptions);

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -251,7 +251,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             return new DefaultGrpcClientFactory(serviceProvider,
                 serviceProvider.GetRequiredService<GrpcCallInvokerFactory>(),
                 serviceProvider.GetRequiredService<IOptionsMonitor<GrpcClientFactoryOptions>>(),
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+                serviceProvider.GetRequiredService<IHttpMessageHandlerFactory>());
         }
     }
 }

--- a/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -41,7 +41,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
     public class DefaultGrpcClientFactoryTests
     {
         [Test]
-        public void CreateClient_Default_InternalHttpClientHasInfiniteTimeout()
+        public void CreateClient_Default_DefaultInvokerSet()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -56,7 +56,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
 
             // Assert
-            Assert.AreEqual(Timeout.InfiniteTimeSpan, ((HttpClient)client.CallInvoker.Channel.HttpInvoker).Timeout);
+            Assert.IsInstanceOf(typeof(HttpMessageInvoker), client.CallInvoker.Channel.HttpInvoker);
         }
 
         [Test]
@@ -144,16 +144,17 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             var ex = Assert.Throws<InvalidOperationException>(() => clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient)));
 
             // Assert
-            Assert.AreEqual("Could not resolve the address for gRPC client 'GreeterClient'.", ex.Message);
+            Assert.AreEqual(@"Could not resolve the address for gRPC client 'GreeterClient'. Set an address when registering the client: services.AddGrpcClient<GreeterClient>(o => o.Address = new Uri(""https://localhost:5001""))", ex.Message);
         }
 
         [Test]
-        public void CreateClient_AddressSpecifiedOnHttpClientFactory_UseHttpClientFactoryAddress()
+        public void CreateClient_AddressSpecifiedOnHttpClientFactory_ThrowError()
         {
             // Arrange
             var services = new ServiceCollection();
             services
                 .AddGrpcClient<TestGreeterClient>()
+                // The underlying handler is used directly so no longer look for address on HttpClient
                 .ConfigureHttpClient(options => options.BaseAddress = new Uri("http://contoso"));
 
             var serviceProvider = services.BuildServiceProvider(validateScopes: true);
@@ -161,10 +162,10 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             var clientFactory = CreateGrpcClientFactory(serviceProvider);
 
             // Act
-            var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
+            var ex = Assert.Throws<InvalidOperationException>(() => clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient)));
 
             // Assert
-            Assert.AreEqual("http://contoso", client.CallInvoker.Channel.Address.OriginalString);
+            Assert.AreEqual(@"Could not resolve the address for gRPC client 'TestGreeterClient'. Set an address when registering the client: services.AddGrpcClient<TestGreeterClient>(o => o.Address = new Uri(""https://localhost:5001""))", ex.Message);
         }
 
         [Test]
@@ -284,7 +285,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             return new DefaultGrpcClientFactory(serviceProvider,
                 serviceProvider.GetRequiredService<GrpcCallInvokerFactory>(),
                 serviceProvider.GetRequiredService<IOptionsMonitor<GrpcClientFactoryOptions>>(),
-                serviceProvider.GetRequiredService<IHttpClientFactory>());
+                serviceProvider.GetRequiredService<IHttpMessageHandlerFactory>());
         }
     }
 }

--- a/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -141,10 +141,10 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             var clientFactory = CreateGrpcClientFactory(serviceProvider);
 
             // Act
-            var ex = Assert.Throws<InvalidOperationException>(() => clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient)));
+            var ex = Assert.Throws<InvalidOperationException>(() => clientFactory.CreateClient<Greeter.GreeterClient>("CustomName"));
 
             // Assert
-            Assert.AreEqual(@"Could not resolve the address for gRPC client 'GreeterClient'. Set an address when registering the client: services.AddGrpcClient<GreeterClient>(o => o.Address = new Uri(""https://localhost:5001""))", ex.Message);
+            Assert.AreEqual(@"Could not resolve the address for gRPC client 'CustomName'. Set an address when registering the client: services.AddGrpcClient<GreeterClient>(o => o.Address = new Uri(""https://localhost:5001""))", ex.Message);
         }
 
         [Test]


### PR DESCRIPTION
Using HttpHandler is faster than HttpClient.

There is one behaverial change (address could also be configured on HttpClient) but that isn't the typical way of using the client factory. I've improved the error message to made it clear how to use the client factory.