### PR TITLE
Fix deadline timer rescheduling because of timer precision

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -690,7 +690,7 @@ namespace Grpc.Net.Client.Internal
                 {
                     GrpcCallLog.StartingDeadlineTimeout(Logger, timeout.Value);
 
-                    var dueTime = GetTimerDueTime(timeout.Value);
+                    var dueTime = CommonGrpcProtocolHelpers.GetTimerDueTime(timeout.Value, Channel.MaxTimerDueTime);
                     _deadlineTimer = new Timer(DeadlineExceededCallback, null, dueTime, Timeout.Infinite);
                 }
             }
@@ -847,8 +847,6 @@ namespace Grpc.Net.Client.Internal
             return message;
         }
 
-        private long GetTimerDueTime(TimeSpan timeout) => CommonGrpcProtocolHelpers.GetTimerDueTime(timeout, Channel.MaxTimerDueTime);
-
         private TimeSpan? GetTimeout()
         {
             if (_deadline == DateTime.MaxValue)
@@ -889,7 +887,8 @@ namespace Grpc.Net.Client.Internal
                     // Reschedule DeadlineExceeded again until deadline has been exceeded.
                     GrpcCallLog.DeadlineTimerRescheduled(Logger, remaining);
 
-                    _deadlineTimer!.Change(GetTimerDueTime(remaining), Timeout.Infinite);
+                    var dueTime = CommonGrpcProtocolHelpers.GetTimerDueTime(remaining, Channel.MaxTimerDueTime);
+                    _deadlineTimer!.Change(dueTime, Timeout.Infinite);
                 }
             }
         }

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -837,17 +837,7 @@ namespace Grpc.Net.Client.Internal
             return message;
         }
 
-        private long GetTimerDueTime(TimeSpan timeout)
-        {
-            // Timer has a maximum allowed due time.
-            // The called method will rechedule the timer if the deadline time has not passed.
-            var dueTimeMilliseconds = timeout.Ticks / TimeSpan.TicksPerMillisecond;
-            dueTimeMilliseconds = Math.Min(dueTimeMilliseconds, Channel.MaxTimerDueTime);
-            // Timer can't have a negative due time
-            dueTimeMilliseconds = Math.Max(dueTimeMilliseconds, 0);
-
-            return dueTimeMilliseconds;
-        }
+        private long GetTimerDueTime(TimeSpan timeout) => CommonGrpcProtocolHelpers.GetTimerDueTime(timeout, Channel.MaxTimerDueTime);
 
         private TimeSpan? GetTimeout()
         {

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -452,8 +452,18 @@ namespace Grpc.Net.Client.Internal
                     }
                     catch (Exception ex)
                     {
-                        GrpcCallLog.ErrorStartingCall(Logger, ex);
-                        throw;
+                        // Don't log OperationCanceledException if deadline has exceeded.
+                        if (ex is OperationCanceledException &&
+                            _callTcs.Task.IsCompletedSuccessfully &&
+                            _callTcs.Task.Result.StatusCode == StatusCode.DeadlineExceeded)
+                        {
+                            throw;
+                        }
+                        else
+                        {
+                            GrpcCallLog.ErrorStartingCall(Logger, ex);
+                            throw;
+                        }
                     }
 
                     status = ValidateHeaders(HttpResponse);

--- a/src/Shared/CommonGrpcProtocolHelpers.cs
+++ b/src/Shared/CommonGrpcProtocolHelpers.cs
@@ -23,7 +23,7 @@ namespace Grpc.Shared
 {
     internal static class CommonGrpcProtocolHelpers
     {
-        // Timer and DateTime.UtcNow have a 14ms precision. Use half that value when scheduling deadline
+        // Timer and DateTime.UtcNow have a 14ms precision. Add a small delay when scheduling deadline
         // timer that tests if exceeded or not. This avoids rescheduling the deadline callback multiple
         // times when timer is triggered before DateTime.UtcNow reports the deadline has been exceeded.
         // e.g.
@@ -31,7 +31,7 @@ namespace Grpc.Shared
         // - The timer is rescheduled to run in 0.5ms.
         // - The deadline callback is raised again and there is now 0.4ms until deadline.
         // - The timer is rescheduled to run in 0.4ms, etc.
-        private static readonly int TimerEpsilonMilliseconds = 7;
+        private static readonly int TimerEpsilonMilliseconds = 4;
 
         public static long GetTimerDueTime(TimeSpan timeout, long maxTimerDueTime)
         {

--- a/test/FunctionalTests/Client/DeadlineTests.cs
+++ b/test/FunctionalTests/Client/DeadlineTests.cs
@@ -31,7 +31,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
     public class DeadlineTests : FunctionalTestBase
     {
         [Test]
-        public async Task Unary_DeadlineExceedAfterServerCall_Failure()
+        public async Task Unary_SmallDeadline_ExceededWithoutReschedule()
         {
             var tcs = new TaskCompletionSource<DataMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
             Task<DataMessage> UnaryTimeout(DataMessage request, ServerCallContext context)

--- a/test/FunctionalTests/Client/DeadlineTests.cs
+++ b/test/FunctionalTests/Client/DeadlineTests.cs
@@ -1,0 +1,62 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.FunctionalTests.Infrastructure;
+using Grpc.Core;
+using Grpc.Tests.Shared;
+using NUnit.Framework;
+using Streaming;
+
+namespace Grpc.AspNetCore.FunctionalTests.Client
+{
+    [TestFixture]
+    public class DeadlineTests : FunctionalTestBase
+    {
+        [Test]
+        public async Task Unary_DeadlineExceedAfterServerCall_Failure()
+        {
+            var tcs = new TaskCompletionSource<DataMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Task<DataMessage> UnaryTimeout(DataMessage request, ServerCallContext context)
+            {
+                return tcs.Task;
+            }
+
+            // Arrange
+            var method = Fixture.DynamicGrpc.AddUnaryMethod<DataMessage, DataMessage>(UnaryTimeout);
+
+            var channel = CreateChannel();
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.UnaryCall(new DataMessage(), new CallOptions(deadline: DateTime.UtcNow.AddMilliseconds(200)));
+
+            // Assert
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
+            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
+            Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+
+            Assert.IsFalse(Logs.Any(l => l.EventId.Name == "DeadlineTimerRescheduled"));
+
+            tcs.SetResult(new DataMessage());
+        }
+    }
+}

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcProtocolHelpersTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcProtocolHelpersTests.cs
@@ -84,6 +84,7 @@ namespace Grpc.AspNetCore.Server.Tests
         [TestCase("1m", 10000, true)]
         [TestCase("1u", 10, true)]
         [TestCase("100n", 1, true)]
+        [TestCase("1n", 0, true)]
         [TestCase("0S", 0, true)]
         [TestCase("", 0, false)]
         [TestCase("5", 0, false)]

--- a/test/Grpc.Net.Client.Tests/DeadlineTests.cs
+++ b/test/Grpc.Net.Client.Tests/DeadlineTests.cs
@@ -141,7 +141,7 @@ namespace Grpc.Net.Client.Tests
             var invoker = HttpClientCallInvokerFactory.Create(httpClient, loggerFactory: testLoggerFactory, systemClock: testSystemClock);
 
             // Act
-            await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: deadline), new HelloRequest());
+            await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: deadline), new HelloRequest()).ResponseAsync.DefaultTimeout();
 
             // Assert
             Assert.IsNotNull(httpRequestMessage);


### PR DESCRIPTION
Also, don't log OperationCanceledException in client when deadline has been exceeded.

Avoid this situation:
```
 0.203s Grpc.Net.Client.Internal.GrpcCall - Trace: Deadline timer triggered but 00:00:00.0009580 remaining before deadline exceeded. Deadline timer rescheduled.
 0.203s Grpc.Net.Client.Internal.GrpcCall - Trace: Deadline timer triggered but 00:00:00.0008698 remaining before deadline exceeded. Deadline timer rescheduled.
```