### PR TITLE
v2.36.x - Fix client hang when call has missing or invalid trailers

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -510,7 +510,7 @@ namespace Grpc.Net.Client.Internal
                                 GrpcProtocolHelpers.GetGrpcEncoding(HttpResponse),
                                 singleMessage: true,
                                 _callCts.Token).ConfigureAwait(false);
-                            status = GrpcProtocolHelpers.GetResponseStatus(HttpResponse, Channel.OperatingSystem.IsBrowser);
+                            status = GrpcProtocolHelpers.GetResponseStatus(HttpResponse, Channel.OperatingSystem.IsBrowser, Channel.IsWinHttp);
 
                             if (message == null)
                             {

--- a/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
@@ -99,6 +99,9 @@ namespace Grpc.Net.Client.Internal
         private static readonly Action<ILogger, TimeSpan, Exception?> _deadlineTimerRescheduled =
             LoggerMessage.Define<TimeSpan>(LogLevel.Trace, new EventId(25, "DeadlineTimerRescheduled"), "Deadline timer triggered but {Remaining} remaining before deadline exceeded. Deadline timer rescheduled.");
 
+        private static readonly Action<ILogger, Exception> _errorParsingTrailers =
+            LoggerMessage.Define(LogLevel.Error, new EventId(26, "ErrorParsingTrailers"), "Error parsing trailers.");
+
         public static void StartingCall(ILogger logger, MethodType methodType, Uri uri)
         {
             _startingCall(logger, methodType, uri, null);
@@ -222,6 +225,11 @@ namespace Grpc.Net.Client.Internal
         public static void DeadlineTimerRescheduled(ILogger logger, TimeSpan remaining)
         {
             _deadlineTimerRescheduled(logger, remaining, null);
+        }
+
+        public static void ErrorParsingTrailers(ILogger logger, Exception ex)
+        {
+            _errorParsingTrailers(logger, ex);
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -53,7 +53,7 @@ namespace Grpc.Net.Client.Internal
                     break;
                 default:
                     // length%4 == 1 should be illegal
-                    throw new FormatException("Invalid base64 header value");
+                    throw new FormatException("Invalid Base-64 header value.");
             }
 
             return Convert.FromBase64String(decodable);
@@ -328,7 +328,7 @@ namespace Grpc.Net.Client.Internal
             }
         }
 
-        public static Status GetResponseStatus(HttpResponseMessage httpResponse, bool isBrowser)
+        public static Status GetResponseStatus(HttpResponseMessage httpResponse, bool isBrowser, bool isWinHttp)
         {
             Status? status;
             try
@@ -339,6 +339,10 @@ namespace Grpc.Net.Client.Internal
                     if (isBrowser)
                     {
                         detail += " If the gRPC call is cross domain then CORS must be correctly configured. Access-Control-Expose-Headers needs to include 'grpc-status' and 'grpc-message'.";
+                    }
+                    if (isWinHttp)
+                    {
+                        detail += " Using gRPC with WinHttp has Windows and package version requirements. See https://aka.ms/pzkMXDs for details.";
                     }
 
                     status = new Status(StatusCode.Cancelled, detail);

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -171,7 +171,7 @@ namespace Grpc.Net.Client.Internal
                 {
                     // No more content in response so report status to call.
                     // The call will handle finishing the response.
-                    var status = GrpcProtocolHelpers.GetResponseStatus(_httpResponse, _call.Channel.OperatingSystem.IsBrowser);
+                    var status = GrpcProtocolHelpers.GetResponseStatus(_httpResponse, _call.Channel.OperatingSystem.IsBrowser, _call.Channel.IsWinHttp);
                     _call.ResponseStreamEnded(status, finishedGracefully: true);
                     if (status.StatusCode != StatusCode.OK)
                     {


### PR DESCRIPTION
Cherry picked changes from #1232 onto v2.36.x release branch.

I found this issue when testing. I don't think another preview is required but I want to include this fix with 2.36.

@jtattermusch 