### PR TITLE
GrpcChannel created by factory has same lifetime as handlers

### DIFF
--- a/src/Grpc.Net.ClientFactory/GrpcClientFactoryOptions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientFactoryOptions.cs
@@ -48,5 +48,15 @@ namespace Grpc.Net.ClientFactory
         /// Gets or sets a delegate that will override how a client is created.
         /// </summary>
         public Func<CallInvoker, object>? Creator { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public TimeSpan AbsoluteChannelLifeTime { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public TimeSpan SlidingChannelLifeTime { get; set; }
     }
 }

--- a/src/Grpc.Net.ClientFactory/GrpcClientFactoryOptions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientFactoryOptions.cs
@@ -48,15 +48,5 @@ namespace Grpc.Net.ClientFactory
         /// Gets or sets a delegate that will override how a client is created.
         /// </summary>
         public Func<CallInvoker, object>? Creator { get; set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public TimeSpan AbsoluteChannelLifeTime { get; set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public TimeSpan SlidingChannelLifeTime { get; set; }
     }
 }

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class GrpcClientServiceExtensions
     {
+        private static readonly TimeSpan DefaultChannelAndHandlerLifeTime = TimeSpan.FromMinutes(30);
+
         /// <summary>
         /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/> and configures
         /// a binding between the <typeparamref name="TClient"/> type and a named <see cref="HttpClient"/>. The client name
@@ -356,27 +358,7 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             builder.AddHttpMessageHandler<DefaultGrpcClientFactoryHandler>();
-            builder.SetHandlerLifetime(TimeSpan.FromMinutes(30));
-
-            // Buckle up, because this is the biggest hack you've ever seen.
-            //builder.AddHttpMessageHandler(s =>
-            //{
-            //    var handler = new DefaultGrpcClientFactoryHandler();
-
-            //    var clientFactory = s.GetRequiredService<GrpcClientFactory>();
-            //    if (clientFactory is DefaultGrpcClientFactory defaultClientFactory)
-            //    {
-            //        var topLevelHandler = new ChannelRootHandler();
-
-            //        var result = defaultClientFactory.CreateChannel(builder.Name, topLevelHandler, typeof(TClient), s);
-
-            //        handler.Channel = result.Channel;
-            //        handler.Invoker = result.Invoker;
-            //        handler.RootHandler = topLevelHandler;
-            //    }
-
-            //    return handler;
-            //});
+            builder.SetHandlerLifetime(DefaultChannelAndHandlerLifeTime);
 
             ReserveClient(builder, typeof(TClient), name);
 

--- a/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactoryHandler.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactoryHandler.cs
@@ -1,0 +1,48 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using Grpc.Core;
+using Grpc.Net.Client;
+
+namespace Grpc.Net.ClientFactory.Internal
+{
+    internal class DefaultGrpcClientFactoryHandler : DelegatingHandler
+    {
+        [MemberNotNullWhen(true, nameof(Channel), nameof(Invoker))]
+        public bool IsInitialized { get; set; }
+
+        public GrpcChannel? Channel { get; set; }
+        public CallInvoker? Invoker { get; set; }
+        public IServiceProvider Services { get; }
+
+        public DefaultGrpcClientFactoryHandler(IServiceProvider services)
+        {
+            Services = services;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Channel?.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Grpc.Net.ClientFactory/Internal/GrpcCallInvokerFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/GrpcCallInvokerFactory.cs
@@ -40,7 +40,7 @@ namespace Grpc.Net.ClientFactory.Internal
             _loggerFactory = loggerFactory;
         }
 
-        public CallInvoker CreateCallInvoker(HttpMessageHandler httpHandler, string name, Type type, GrpcClientFactoryOptions clientFactoryOptions)
+        public (CallInvoker Invoker, GrpcChannel Channel) CreateCallInvoker(HttpMessageHandler httpHandler, string name, Type type, GrpcClientFactoryOptions clientFactoryOptions)
         {
             if (httpHandler == null)
             {
@@ -73,7 +73,7 @@ namespace Grpc.Net.ClientFactory.Internal
                 ? httpClientCallInvoker
                 : httpClientCallInvoker.Intercept(clientFactoryOptions.Interceptors.ToArray());
 
-            return resolvedCallInvoker;
+            return (resolvedCallInvoker, channel);
         }
     }
 }

--- a/src/Shared/NullableAttributes.cs
+++ b/src/Shared/NullableAttributes.cs
@@ -16,10 +16,10 @@
 
 #endregion
 
-#if NETSTANDARD2_0
-
 namespace System.Diagnostics.CodeAnalysis
 {
+#if NETSTANDARD2_0
+
     /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true)]
     internal sealed class NotNullAttribute : Attribute { }
@@ -66,6 +66,67 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets the condition parameter value.</summary>
         public bool ParameterValue { get; }
     }
-}
 
 #endif
+
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+#endif
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1264

* GrpcChannel now has same lifetime as underlying HttpHandlers
* GrpcChannel is disposed with HttpHandlers
* Default lifetime changed to 30 minutes