### PR TITLE
Minor improvements in examples codebase: Mailer

### DIFF
--- a/examples/Mailer/Client/Program.cs
+++ b/examples/Mailer/Client/Program.cs
@@ -75,7 +75,8 @@ namespace Client
 
         private static string GetMailboxName(string[] args)
         {
-            if (args.Length != 1)
+
+            if (args.Length < 1)
             {
                 Console.WriteLine("No mailbox name provided. Using default name. Usage: dotnet run <name>.");
                 return "DefaultMailbox";

--- a/examples/Mailer/Server/MailQueue.cs
+++ b/examples/Mailer/Server/MailQueue.cs
@@ -25,17 +25,9 @@ using Mail;
 
 namespace Server
 {
-    public class Mail
-    {
-        public Mail(int id, string content)
-        {
-            Id = id;
-            Content = content;
-        }
+    public record Mail(int Id, string Content);
 
-        public int Id { get; }
-        public string Content { get; }
-    }
+    public record MailQueueChangeState(int TotalCount, int ForwardedCount, MailboxMessage.Types.Reason Reason);
 
     public class MailQueue
     {
@@ -44,7 +36,7 @@ namespace Server
         private int _forwardedMailCount;
 
         public string Name { get; }
-        public event Func<(int totalCount, int newCount, MailboxMessage.Types.Reason reason), Task>? Changed;
+        public event Func<MailQueueChangeState, Task>? Changed;
 
         public MailQueue(string name)
         {
@@ -52,7 +44,7 @@ namespace Server
 
             _incomingMail = Channel.CreateUnbounded<Mail>();
 
-            Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 var random = new Random();
 
@@ -83,7 +75,7 @@ namespace Server
 
         private void OnChange(MailboxMessage.Types.Reason reason)
         {
-            Changed?.Invoke((_totalMailCount, _forwardedMailCount, reason));
+            Changed?.Invoke(new MailQueueChangeState(_totalMailCount, _forwardedMailCount, reason));
         }
     }
 }

--- a/examples/Mailer/Server/MailQueueRepository.cs
+++ b/examples/Mailer/Server/MailQueueRepository.cs
@@ -22,7 +22,7 @@ namespace Server
 {
     public class MailQueueRepository
     {
-        private ConcurrentDictionary<string, MailQueue> _mailQueues = new ConcurrentDictionary<string, MailQueue>();
+        private readonly ConcurrentDictionary<string, MailQueue> _mailQueues = new();
 
         public MailQueue GetMailQueue(string name)
         {

--- a/examples/Mailer/Server/Services/MailerService.cs
+++ b/examples/Mailer/Server/Services/MailerService.cs
@@ -69,13 +69,13 @@ namespace Server
 
             _logger.LogInformation($"{mailboxName} disconnected");
 
-            async Task ReportChanges((int totalCount, int fowardCount, MailboxMessage.Types.Reason reason) state)
+            async Task ReportChanges(MailQueueChangeState state)
             {
                 await responseStream.WriteAsync(new MailboxMessage
                 {
-                    Forwarded = state.fowardCount,
-                    New = state.totalCount - state.fowardCount,
-                    Reason = state.reason
+                    Forwarded = state.ForwardedCount,
+                    New = state.TotalCount - state.ForwardedCount,
+                    Reason = state.Reason
                 });
             }
         }


### PR DESCRIPTION
Small improvements in the [Mailer example](https://github.com/grpc/grpc-dotnet/tree/master/examples/Mailer) codebase including:

- argument length checks
- adding `readonly` modifier
- replacing `class` and `ValueTuple` types with `record`s