### PR TITLE
Update HedgingPolicy.cs

### DIFF
--- a/src/Grpc.Net.Client/Configuration/HedgingPolicy.cs
+++ b/src/Grpc.Net.Client/Configuration/HedgingPolicy.cs
@@ -65,9 +65,9 @@ namespace Grpc.Net.Client.Configuration
         /// Gets or sets the hedging delay.
         /// The first call will be sent immediately, but the subsequent
         /// hedged call will be sent at intervals of the specified delay.
-        /// Set this to 0 or <c>null</c> to immediately send all hedged calls.
+        /// Set this to 0 to immediately send all hedged calls.
         /// </summary>
-        public TimeSpan? HedgingDelay
+        public TimeSpan HedgingDelay
         {
             get => ConvertHelpers.ConvertDurationText(GetValue<string>(HedgingDelayPropertyName));
             set => SetValue(HedgingDelayPropertyName, ConvertHelpers.ToDurationText(value));


### PR DESCRIPTION
Setting null to HedgingDelay will cause InvalidOperationException and based on the internal code(https://github.com/grpc/grpc-dotnet/blob/bf26e0377abfa86f34778ee1347565f02d90ffb5/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs#L31), this property should not be a nullable property