### PR TITLE
Update SDK and targets to .NET 6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,11 +4,12 @@
     <GoogleProtobufPackageVersion>3.15.8</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.38.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.38.0</GrpcPackageVersion>
-    <MicrosoftAspNetCoreAppPackageVersion>5.0.3</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>6.0.0-rc.1.21367.4</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>
     <MicrosoftAspNetCoreApp31PackageVersion>3.1.3</MicrosoftAspNetCoreApp31PackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersPackageVersion>5.0.3</MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersPackageVersion>6.0.0-rc1.21366.3</MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
     <MicrosoftCrankEventSourcesPackageVersion>0.2.0-alpha.21255.1</MicrosoftCrankEventSourcesPackageVersion>
     <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.1</MicrosoftExtensionsLoggingTestingPackageVersion>
     <MicrosoftExtensionsPackageVersion>3.0.3</MicrosoftExtensionsPackageVersion>

--- a/build/get-dotnet.sh
+++ b/build/get-dotnet.sh
@@ -30,5 +30,8 @@ chmod +x $install_script_path
 # Install .NET Core 3.x SDK to run 3.x test targets
 $install_script_path -v 3.1.300 -i $dotnet_install_path
 
+# Install .NET 5 SDK to run 5.0 test targets
+$install_script_path -v 5.0.302 -i $dotnet_install_path
+
 # Install .NET version specified by global.json
 $install_script_path -v $sdk_version -i $dotnet_install_path

--- a/build/get-dotnet.sh
+++ b/build/get-dotnet.sh
@@ -18,7 +18,10 @@ ensure_dir() {
 # main
 
 # resolve SDK version
-sdk_version=$(jq -r .sdk.version $global_json_path)
+#sdk_version=$(jq -r .sdk.version $global_json_path)
+
+# TODO(JamesNK): Temporarily override global.json while using preview version
+sdk_version="6.0.100-rc.1.21380.19"
 
 # download dotnet-install.sh
 ensure_dir $OBJDIR

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -37,7 +37,7 @@ test_projects=( $( ls test/**/*Tests.csproj ) )
 for test_project in "${test_projects[@]}"
 do
     # https://github.com/microsoft/vstest/issues/2080#issuecomment-539879345
-    dotnet test $test_project -c Release -v n --no-build -d --blame < /dev/null
+    dotnet test $test_project -c Release -v n --no-build < /dev/null
 done
 
 echo "Tests finished"

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -37,7 +37,7 @@ test_projects=( $( ls test/**/*Tests.csproj ) )
 for test_project in "${test_projects[@]}"
 do
     # https://github.com/microsoft/vstest/issues/2080#issuecomment-539879345
-    dotnet test $test_project -c Release -v n --no-build < /dev/null
+    dotnet test $test_project -c Release -v n --no-build -d --blame < /dev/null
 done
 
 echo "Tests finished"

--- a/examples/Blazor/Client/Client.csproj
+++ b/examples/Blazor/Client/Client.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" PrivateAssets="all" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcPackageVersion)" PrivateAssets="All" />

--- a/examples/Blazor/Server/Server.csproj
+++ b/examples/Blazor/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\weather.proto" GrpcServices="Server" Link="Protos\weather.proto" />
     <Protobuf Include="..\Proto\count.proto" GrpcServices="Server" Link="Protos\count.proto" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="$(GrpcDotNetPackageVersion)" />
   </ItemGroup>

--- a/examples/Certifier/Server/Server.csproj
+++ b/examples/Certifier/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\certify.proto" GrpcServices="Server" Link="Protos\certify.proto" />
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/examples/Container/Backend/Backend.csproj
+++ b/examples/Container/Backend/Backend.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <Protobuf Include="..\Proto\weather.proto" GrpcServices="Server" Link="Protos\weather.proto" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="$(GrpcDotNetPackageVersion)" />
   </ItemGroup>

--- a/examples/Spar/Server/Server.csproj
+++ b/examples/Spar/Server/Server.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
   </ItemGroup>
 
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">

--- a/examples/Tester/Tests/Tests.csproj
+++ b/examples/Tester/Tests/Tests.csproj
@@ -8,7 +8,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="NUnit" Version="$(NunitPackageVersion)" />

--- a/examples/Ticketer/Server/Server.csproj
+++ b/examples/Ticketer/Server/Server.csproj
@@ -8,7 +8,7 @@
     <Protobuf Include="..\Proto\ticket.proto" GrpcServices="Server" Link="Protos\ticket.proto" />
 
     <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21380.19",
+    "version": "6.0.100-preview.6.21352.12",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.202",
+    "version": "6.0.100-rc.1.21380.19",
     "rollForward": "latestFeature"
   }
 }

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Uncomment line below to enable gRPC-Web on the server -->
     <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
@@ -13,6 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
+    
     <Protobuf Include="..\Shared\benchmark_service.proto" GrpcServices="Server" Link="Protos\benchmark_service.proto" />
     <Protobuf Include="..\Shared\messages.proto" GrpcServices="Server" Link="Protos\messages.proto" />
 

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -60,16 +60,6 @@ namespace GrpcAspNetCoreServer
                     webBuilder.UseConfiguration(config);
                     webBuilder.UseStartup<Startup>();
 
-#if NET6_0
-#pragma warning disable CA1416 // Validate platform compatibility
-                    webBuilder.UseQuic(options =>
-                    {
-                        options.IdleTimeout = TimeSpan.FromSeconds(60);
-                        options.Alpn = "h3";
-                    });
-#pragma warning restore CA1416 // Validate platform compatibility
-#endif
-
                     webBuilder.ConfigureKestrel((context, options) =>
                     {
                         var endPoint = config.CreateIPEndPoint();

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -19,10 +19,12 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using Common;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -57,6 +59,16 @@ namespace GrpcAspNetCoreServer
                     webBuilder.UseContentRoot(Directory.GetCurrentDirectory());
                     webBuilder.UseConfiguration(config);
                     webBuilder.UseStartup<Startup>();
+
+#if NET6_0
+#pragma warning disable CA1416 // Validate platform compatibility
+                    webBuilder.UseQuic(options =>
+                    {
+                        options.IdleTimeout = TimeSpan.FromSeconds(60);
+                        options.Alpn = "h3";
+                    });
+#pragma warning restore CA1416 // Validate platform compatibility
+#endif
 
                     webBuilder.ConfigureKestrel((context, options) =>
                     {
@@ -102,7 +114,7 @@ namespace GrpcAspNetCoreServer
                         Console.WriteLine($"Console Logging enabled with level '{logLevel}'");
 
                         loggerFactory
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
                             .AddSimpleConsole(o => o.TimestampFormat = "ss.ffff ")
 #else
                             .AddConsole(o => o.TimestampFormat = "ss.ffff ")
@@ -132,17 +144,30 @@ namespace GrpcAspNetCoreServer
             {
                 listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
 
-                var basePath = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-                var certPath = Path.Combine(basePath!, "Certs/testCert.pfx");
-                listenOptions.UseHttps(certPath, "testPassword", httpsOptions =>
+                listenOptions.UseHttps(httpsOptions =>
                 {
                     if (enableCertAuth)
                     {
-                        httpsOptions.ClientCertificateMode = Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode.AllowCertificate;
+                        httpsOptions.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
                         httpsOptions.AllowAnyClientCertificate();
                     }
                 });
             }
+#if NET6_0
+            else if (protocol.Equals("h3", StringComparison.OrdinalIgnoreCase))
+            {
+                listenOptions.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
+
+                listenOptions.UseHttps(httpsOptions =>
+                {
+                    if (enableCertAuth)
+                    {
+                        httpsOptions.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
+                        httpsOptions.AllowAnyClientCertificate();
+                    }
+                });
+            }
+#endif
             else if (protocol.Equals("h2c", StringComparison.OrdinalIgnoreCase))
             {
                 listenOptions.Protocols = HttpProtocols.Http2;

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Startup.cs
@@ -21,7 +21,7 @@ using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Grpc.Testing;
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 using Microsoft.AspNetCore.Authentication.Certificate;
 #endif
 using Microsoft.AspNetCore.Builder;
@@ -47,7 +47,7 @@ namespace GrpcAspNetCoreServer
         {
             services.AddGrpc(o =>
             {
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
                 // Small performance benefit to not add catch-all routes to handle UNIMPLEMENTED for unknown services
                 o.IgnoreUnknownServices = true;
 #endif
@@ -60,7 +60,7 @@ namespace GrpcAspNetCoreServer
             services.AddSingleton<BenchmarkServiceImpl>();
             services.AddControllers();
 
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {
@@ -83,7 +83,7 @@ namespace GrpcAspNetCoreServer
 
             app.UseRouting();
 
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {
@@ -139,7 +139,7 @@ namespace GrpcAspNetCoreServer
 
         private void ConfigureAuthorization(IEndpointConventionBuilder builder)
         {
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
             bool.TryParse(_config["enableCertAuth"], out var enableCertAuth);
             if (enableCertAuth)
             {

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/hosting.json
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/hosting.json
@@ -1,6 +1,7 @@
 {
   "urls": "",
   "server.urls": "",
-  "protocol": "h2c", // This will be overriden when benchmarks are run
-  "certificateAuth": false
+  "protocol": "h3", // This will be overriden when benchmarks are run
+  "certificateAuth": false,
+  "LogLevel": ""
 }

--- a/perf/benchmarkapps/GrpcClient/ClientOptions.cs
+++ b/perf/benchmarkapps/GrpcClient/ClientOptions.cs
@@ -23,7 +23,7 @@ namespace GrpcClient
     public class ClientOptions
     {
         public string? Url { get; set; }
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
         public string? UdsFileName { get; set; }
 #endif
         public int Connections { get; set; }

--- a/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
+++ b/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
     <!-- Enable server GC to more closely simulate a microservice app making calls -->
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
+
     <Protobuf Include="..\Shared\benchmark_service.proto" GrpcServices="Client" Link="Protos\benchmark_service.proto" />
     <Protobuf Include="..\Shared\messages.proto" GrpcServices="Client" Link="Protos\messages.proto" />
     

--- a/perf/benchmarkapps/GrpcClient/Program.cs
+++ b/perf/benchmarkapps/GrpcClient/Program.cs
@@ -385,7 +385,7 @@ namespace GrpcClient
 
         private static ChannelBase CreateChannel(string target)
         {
-            var useTls = _options.Protocol == "h2";
+            var useTls = _options.Protocol == "h2" || _options.Protocol == "h3";
 
             switch (_options.GrpcClientType)
             {
@@ -407,6 +407,7 @@ namespace GrpcClient
 #if NETCOREAPP3_1
                     AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 #endif
+
                     var httpClientHandler = new SocketsHttpHandler();
                     httpClientHandler.UseProxy = false;
                     httpClientHandler.AllowAutoRedirect = false;
@@ -420,7 +421,7 @@ namespace GrpcClient
                             clientCertificate
                         };
                     }
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
                     if (!string.IsNullOrEmpty(_options.UdsFileName))
                     {
                         var connectionFactory = new UnixDomainSocketConnectionFactory(new UnixDomainSocketEndPoint(ResolveUdsPath(_options.UdsFileName)));
@@ -431,12 +432,19 @@ namespace GrpcClient
                     httpClientHandler.SslOptions.RemoteCertificateValidationCallback =
                         (object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors) => true;
 
+                    HttpMessageHandler httpMessageHandler = httpClientHandler;
+
+                    if (_options.Protocol == "h3")
+                    {
+                        httpMessageHandler = new Http3DelegatingHandler(httpMessageHandler);
+                    }
+
                     return GrpcChannel.ForAddress(address, new GrpcChannelOptions
                     {
-#if NET5_0 || NET6_0
-                        HttpHandler = httpClientHandler,
+#if NET5_0_OR_GREATER
+                        HttpHandler = httpMessageHandler,
 #else
-                        HttpClient = new HttpClient(httpClientHandler),
+                        HttpClient = new HttpClient(httpMessageHandler),
 #endif
                         LoggerFactory = _loggerFactory
                     });
@@ -673,6 +681,23 @@ namespace GrpcClient
             }
 
             return false;
+        }
+
+        private class Http3DelegatingHandler : DelegatingHandler
+        {
+            private static readonly Version Http3Version = new Version(3, 0);
+
+            public Http3DelegatingHandler(HttpMessageHandler innerHandler)
+            {
+                InnerHandler = innerHandler;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                request.Version = Http3Version;
+                request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                return base.SendAsync(request, cancellationToken);
+            }
         }
     }
 }

--- a/perf/benchmarkapps/GrpcClient/UnixDomainSocketConnectionFactory.cs
+++ b/perf/benchmarkapps/GrpcClient/UnixDomainSocketConnectionFactory.cs
@@ -23,7 +23,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 
 namespace GrpcClient
 {

--- a/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
+++ b/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
+++ b/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Server/GrpcEndpointRouteBuilderExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcEndpointRouteBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public static class GrpcEndpointRouteBuilderExtensions
     {
-#if NET5_0
+#if NET5_0_OR_GREATER
         private const DynamicallyAccessedMemberTypes ServiceAccessibility = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
 #endif
 
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="builder">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
         /// <returns>A <see cref="GrpcServiceEndpointConventionBuilder"/> for endpoints associated with the service.</returns>
         public static GrpcServiceEndpointConventionBuilder MapGrpcService<
-#if NET5_0
+#if NET5_0_OR_GREATER
             [DynamicallyAccessedMembers(ServiceAccessibility)]
 #endif
             TService>(this IEndpointRouteBuilder builder) where TService : class

--- a/src/Grpc.AspNetCore.Server/InterceptorCollection.cs
+++ b/src/Grpc.AspNetCore.Server/InterceptorCollection.cs
@@ -35,7 +35,7 @@ namespace Grpc.AspNetCore.Server
         /// <typeparam name="TInterceptor">The interceptor type.</typeparam>
         /// <param name="args">The list of arguments to pass to the interceptor constructor when creating an instance.</param>
         public void Add<
-#if NET5_0
+#if NET5_0_OR_GREATER
             [DynamicallyAccessedMembers(InterceptorRegistration.InterceptorAccessibility)]
 #endif
             TInterceptor>(params object[] args) where TInterceptor : Interceptor
@@ -49,7 +49,7 @@ namespace Grpc.AspNetCore.Server
         /// <param name="interceptorType">The interceptor type.</param>
         /// <param name="args">The list of arguments to pass to the interceptor constructor when creating an instance.</param>
         public void Add(
-#if NET5_0
+#if NET5_0_OR_GREATER
             [DynamicallyAccessedMembers(InterceptorRegistration.InterceptorAccessibility)]
 #endif
             Type interceptorType, params object[] args)

--- a/src/Grpc.AspNetCore.Server/InterceptorRegistration.cs
+++ b/src/Grpc.AspNetCore.Server/InterceptorRegistration.cs
@@ -30,14 +30,14 @@ namespace Grpc.AspNetCore.Server
     /// </summary>
     public class InterceptorRegistration
     {
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal const DynamicallyAccessedMemberTypes InterceptorAccessibility = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods;
 #endif
 
         internal object[] _args;
 
         internal InterceptorRegistration(
-#if NET5_0
+#if NET5_0_OR_GREATER
             [DynamicallyAccessedMembers(InterceptorAccessibility)]
 #endif
             Type type, object[] arguments)
@@ -65,7 +65,7 @@ namespace Grpc.AspNetCore.Server
         /// <summary>
         /// Get the type of the interceptor.
         /// </summary>
-#if NET5_0
+#if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(InterceptorAccessibility)]
 #endif
         public Type Type { get; }

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -54,7 +54,11 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
                 return ProcessInvalidContentTypeRequest(httpContext, error);
             }
 
-            if (!GrpcProtocolConstants.IsHttp2(httpContext.Request.Protocol))
+            if (!GrpcProtocolConstants.IsHttp2(httpContext.Request.Protocol)
+#if NET6_0_OR_GREATER
+                && !GrpcProtocolConstants.IsHttp3(httpContext.Request.Protocol)
+#endif
+                )
             {
                 return ProcessNonHttp2Request(httpContext);
             }

--- a/src/Grpc.AspNetCore.Server/Internal/DefaultGrpcServiceActivator.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/DefaultGrpcServiceActivator.cs
@@ -24,12 +24,12 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Grpc.AspNetCore.Server.Internal
 {
     internal sealed class DefaultGrpcServiceActivator<
-#if NET5_0
+#if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(ServiceAccessibility)]
 #endif
         TGrpcService> : IGrpcServiceActivator<TGrpcService> where TGrpcService : class
     {
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal const DynamicallyAccessedMemberTypes ServiceAccessibility = DynamicallyAccessedMemberTypes.PublicConstructors;
 #endif
         private static readonly Lazy<ObjectFactory> _objectFactory = new Lazy<ObjectFactory>(static () => ActivatorUtilities.CreateFactory(typeof(TGrpcService), Type.EmptyTypes));

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
@@ -30,26 +30,26 @@ namespace Grpc.AspNetCore.Server.Internal
         internal const string GrpcWebContentType = "application/grpc-web";
         internal const string GrpcWebTextContentType = "application/grpc-web-text";
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal static readonly string Http2Protocol = HttpProtocol.Http2;
 #else
         internal const string Http2Protocol = "HTTP/2";
         internal const string Http20Protocol = "HTTP/2.0"; // This is what IIS sets
 #endif
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal static readonly string TimeoutHeader = HeaderNames.GrpcTimeout;
 #else
         internal const string TimeoutHeader = "grpc-timeout";
 #endif
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal static readonly string MessageEncodingHeader = HeaderNames.GrpcEncoding;
 #else
         internal const string MessageEncodingHeader = "grpc-encoding";
 #endif
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal static readonly string MessageAcceptEncodingHeader = HeaderNames.GrpcAcceptEncoding;
 #else
         internal const string MessageAcceptEncodingHeader = "grpc-accept-encoding";
@@ -57,20 +57,21 @@ namespace Grpc.AspNetCore.Server.Internal
 
         internal const string CompressionRequestAlgorithmHeader = "grpc-internal-encoding-request";
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal static readonly string StatusTrailer = HeaderNames.GrpcStatus;
 #else
         internal const string StatusTrailer = "grpc-status";
 #endif
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal static readonly string MessageTrailer = HeaderNames.GrpcMessage;
 #else
         internal const string MessageTrailer = "grpc-message";
 #endif
 
         internal const string IdentityGrpcEncoding = "identity";
-        internal const int ResetStreamNoError = 0;
+        internal const int Http2ResetStreamNoError = 0;
+        internal const int Http3ResetStreamNoError = 0x100;
 
         internal static readonly HashSet<string> FilteredHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -95,12 +96,20 @@ namespace Grpc.AspNetCore.Server.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsHttp2(string protocol)
         {
-#if NET5_0
+#if NET5_0_OR_GREATER
             return HttpProtocol.IsHttp2(protocol);
 #else
             return protocol == Http2Protocol || protocol == Http20Protocol;
 #endif
         }
+
+#if NET6_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsHttp3(string protocol)
+        {
+            return HttpProtocol.IsHttp3(protocol);
+        }
+#endif
 
         internal static bool IsGrpcEncodingIdentity(string encoding)
         {

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolConstants.cs
@@ -71,7 +71,6 @@ namespace Grpc.AspNetCore.Server.Internal
 
         internal const string IdentityGrpcEncoding = "identity";
         internal const int Http2ResetStreamNoError = 0;
-        internal const int Http3ResetStreamNoError = 0x100;
 
         internal static readonly HashSet<string> FilteredHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -461,6 +461,18 @@ namespace Grpc.AspNetCore.Server.Internal
                 await completionFeature.CompleteAsync();
             }
 
+#if NET6_0_OR_GREATER
+            // With HTTP/3 we don't want to abort the write side of the stream.
+            // That will create a race between the completed response and the abort
+            // reaching the client.
+            // Instead we just want to abort the read side of the stream.
+            // Kestrel will do this automatically if there is unread request content.
+            if (GrpcProtocolConstants.IsHttp3(HttpContext.Request.Protocol))
+            {
+                return;
+            }
+#endif
+
             // HttpResetFeature should always be set on context,
             // but in case it isn't, fall back to HttpContext.Abort.
             // Abort will send error code INTERNAL_ERROR instead of NO_ERROR.
@@ -468,14 +480,7 @@ namespace Grpc.AspNetCore.Server.Internal
             if (resetFeature != null)
             {
                 // HTTP/3 has different error codes
-                var errorCode =
-#if NET6_0_OR_GREATER
-                    GrpcProtocolConstants.IsHttp2(HttpContext.Request.Protocol)
-                        ? GrpcProtocolConstants.Http2ResetStreamNoError
-                        : GrpcProtocolConstants.Http3ResetStreamNoError;
-#else
-                    GrpcProtocolConstants.Http2ResetStreamNoError;
-#endif
+                var errorCode = GrpcProtocolConstants.Http2ResetStreamNoError;
 
                 GrpcServerLog.ResettingResponse(Logger, errorCode);
                 resetFeature.Reset(errorCode);

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -467,8 +467,18 @@ namespace Grpc.AspNetCore.Server.Internal
             var resetFeature = HttpContext.Features.Get<IHttpResetFeature>();
             if (resetFeature != null)
             {
-                GrpcServerLog.ResettingResponse(Logger, GrpcProtocolConstants.ResetStreamNoError);
-                resetFeature.Reset(GrpcProtocolConstants.ResetStreamNoError);
+                // HTTP/3 has different error codes
+                var errorCode =
+#if NET6_0_OR_GREATER
+                    GrpcProtocolConstants.IsHttp2(HttpContext.Request.Protocol)
+                        ? GrpcProtocolConstants.Http2ResetStreamNoError
+                        : GrpcProtocolConstants.Http3ResetStreamNoError;
+#else
+                    GrpcProtocolConstants.Http2ResetStreamNoError;
+#endif
+
+                GrpcServerLog.ResettingResponse(Logger, errorCode);
+                resetFeature.Reset(errorCode);
             }
             else
             {

--- a/src/Grpc.AspNetCore.Server/Model/Internal/BinderServiceModelProvider.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/BinderServiceModelProvider.cs
@@ -25,7 +25,7 @@ using Log = Grpc.AspNetCore.Server.Model.Internal.BinderServiceMethodProviderLog
 namespace Grpc.AspNetCore.Server.Model.Internal
 {
     internal class BinderServiceMethodProvider<
-#if NET5_0
+#if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(ProviderServiceBinder<TService>.ServiceAccessibility)]
 #endif
         TService> : IServiceMethodProvider<TService> where TService : class

--- a/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
@@ -26,12 +26,12 @@ using Microsoft.AspNetCore.Routing;
 namespace Grpc.AspNetCore.Server.Model.Internal
 {
     internal class ProviderServiceBinder<
-#if NET5_0
+#if NET5_0_OR_GREATER
         [DynamicallyAccessedMembers(ServiceAccessibility)]
 #endif
         TService> : ServiceBinderBase where TService : class
     {
-#if NET5_0
+#if NET5_0_OR_GREATER
         // Non-public methods is required by GetMethod overload that has a BindingFlags argument.
         internal const DynamicallyAccessedMemberTypes ServiceAccessibility = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
 #endif

--- a/src/Grpc.AspNetCore.Web/Grpc.AspNetCore.Web.csproj
+++ b/src/Grpc.AspNetCore.Web/Grpc.AspNetCore.Web.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Web/Internal/GrpcWebMiddleware.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/GrpcWebMiddleware.cs
@@ -44,7 +44,7 @@ namespace Grpc.AspNetCore.Web.Internal
             var mode = GetGrpcWebMode(httpContext);
             if (mode != ServerGrpcWebMode.None)
             {
-                Log.DetectedGrpcWebRequest(_logger, httpContext.Request.ContentType);
+                Log.DetectedGrpcWebRequest(_logger, httpContext.Request.ContentType!);
 
                 var metadata = httpContext.GetEndpoint()?.Metadata.GetMetadata<IGrpcWebEnabledMetadata>();
                 if (metadata?.GrpcWebEnabled ?? _options.DefaultEnabled)
@@ -66,7 +66,7 @@ namespace Grpc.AspNetCore.Web.Internal
 
             // Modifying the request is required to stop Grpc.AspNetCore.Server from rejecting it
             httpContext.Request.Protocol = GrpcWebProtocolConstants.Http2Protocol;
-            httpContext.Request.ContentType = ResolveContentType(GrpcWebProtocolConstants.GrpcContentType, httpContext.Request.ContentType);
+            httpContext.Request.ContentType = ResolveContentType(GrpcWebProtocolConstants.GrpcContentType, httpContext.Request.ContentType!);
 
             // Update response content type back to gRPC-Web
             httpContext.Response.OnStarting(() =>
@@ -75,7 +75,7 @@ namespace Grpc.AspNetCore.Web.Internal
                 // delay when making HTTP/1.1 calls.
                 httpContext.Request.Protocol = initialProtocol;
 
-                if (CommonGrpcProtocolHelpers.IsContentType(GrpcWebProtocolConstants.GrpcContentType, httpContext.Response.ContentType))
+                if (CommonGrpcProtocolHelpers.IsContentType(GrpcWebProtocolConstants.GrpcContentType, httpContext.Response.ContentType!))
                 {
                     var contentType = mode == ServerGrpcWebMode.GrpcWeb
                         ? GrpcWebProtocolConstants.GrpcWebContentType

--- a/src/Grpc.AspNetCore.Web/Internal/GrpcWebProtocolConstants.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/GrpcWebProtocolConstants.cs
@@ -26,7 +26,7 @@ namespace Grpc.AspNetCore.Web.Internal
         internal const string GrpcWebContentType = "application/grpc-web";
         internal const string GrpcWebTextContentType = "application/grpc-web-text";
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         internal static readonly string Http2Protocol = HttpProtocol.Http2;
 #else
         internal const string Http2Protocol = "HTTP/2";

--- a/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
+++ b/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
-    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
 
     <!-- Don't include empty DLL or PDB in metapackage -->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Grpc.Net.Client.Web/Grpc.Net.Client.Web.csproj
+++ b/src/Grpc.Net.Client.Web/Grpc.Net.Client.Web.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
+++ b/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
@@ -142,8 +142,10 @@ namespace Grpc.Net.Client.Web
                 // uses what the browser has negotiated.
                 request.Version = HttpVersion;
             }
-#if NET5_0
-            else if (request.RequestUri?.Scheme == Uri.UriSchemeHttps)
+#if NET5_0_OR_GREATER
+            else if (request.RequestUri?.Scheme == Uri.UriSchemeHttps
+                && request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher
+                && request.Version == System.Net.HttpVersion.Version20)
             {
                 // If no explicit HttpVersion is set and the request is using TLS then default to HTTP/1.1.
                 // HTTP/1.1 together with HttpVersionPolicy.RequestVersionOrHigher it will be compatible

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -322,7 +322,7 @@ namespace Grpc.Net.Client.Balancer
         {
             lock (Lock)
             {
-                return string.Join(", ", _addresses);
+                return $"Id: {Id}, Addresses: {string.Join(", ", _addresses)}, State: {State}";
             }
         }
 

--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -6,14 +6,14 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourcePackageVersion)" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>SUPPORT_LOAD_BALANCING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -793,7 +793,7 @@ namespace Grpc.Net.Client.Internal
         {
             var message = new HttpRequestMessage(HttpMethod.Post, _grpcMethodInfo.CallUri);
             message.Version = GrpcProtocolConstants.Http2Version;
-#if NET5_0
+#if NET5_0_OR_GREATER
             message.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
 #endif
 

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -145,7 +145,7 @@ namespace Grpc.Net.Client.Internal
                 {
                     try
                     {
-#if NET5_0
+#if NET5_0_OR_GREATER
                         _responseStream = await _httpResponse.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #else
                         _responseStream = await _httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -248,9 +248,9 @@ namespace Grpc.Net.Client.Internal.Retry
             // https://github.com/grpc/proposal/blob/master/A6-client-retries.md#pushback
             if (httpResponse != null)
             {
-                if (httpResponse.Headers.TryGetValues(GrpcProtocolConstants.RetryPushbackHeader, out var values))
+                var headerValue = GrpcProtocolHelpers.GetHeaderValue(httpResponse.Headers, GrpcProtocolConstants.RetryPushbackHeader);
+                if (headerValue != null)
                 {
-                    var headerValue = values.Single();
                     Log.RetryPushbackReceived(Logger, headerValue);
 
                     // A non-integer value means the server wants retries to stop.

--- a/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
+++ b/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc.Net.Common/Grpc.Net.Common.csproj
+++ b/src/Grpc.Net.Common/Grpc.Net.Common.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/HttpHandlerFactory.cs
+++ b/src/Shared/HttpHandlerFactory.cs
@@ -27,7 +27,7 @@ namespace Grpc.Shared
     {
         public static HttpMessageHandler CreatePrimaryHandler()
         {
-#if NET5_0
+#if NET5_0_OR_GREATER
             // If we're in .NET 5 and SocketsHttpHandler is supported (it's not in Blazor WebAssembly)
             // then create SocketsHttpHandler with EnableMultipleHttp2Connections set to true. That will
             // allow a gRPC channel to create new connections if the maximum allow concurrency is exceeded.

--- a/src/Shared/Server/BindMethodFinder.cs
+++ b/src/Shared/Server/BindMethodFinder.cs
@@ -66,7 +66,7 @@ namespace Grpc.Shared.Server
             return null;
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Fallback doesn't have BindServiceMethodAttribute so can't be verified.")]
 #endif

--- a/test/FunctionalTests/Balancer/BalancerHelpers.cs
+++ b/test/FunctionalTests/Balancer/BalancerHelpers.cs
@@ -147,19 +147,21 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             return channel;
         }
 
-        public static async Task WaitForChannelStateAsync(GrpcChannel channel, ConnectivityState state)
+        public static async Task WaitForChannelStateAsync(ILogger logger, GrpcChannel channel, ConnectivityState state, int channelId = 1)
         {
-            ConnectivityState currentState = channel.State;
-            if (currentState == state)
-            {
-                return;
-            }
+            logger.LogInformation($"{channelId}: Waiting for channel state '{state}'.");
 
-            do
+            var currentState = channel.State;
+
+            while (currentState != state)
             {
+                logger.LogInformation($"{channelId}: Current channel state '{currentState}' doesn't match expected state '{state}'.");
+
                 await channel.WaitForStateChangedAsync(currentState).DefaultTimeout();
                 currentState = channel.State;
-            } while (currentState != state);
+            }
+
+            logger.LogInformation($"{channelId}: Current channel state '{currentState}' matches expected state '{state}'.");
         }
 
         public static T? GetInnerLoadBalancer<T>(GrpcChannel channel) where T : LoadBalancer

--- a/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
@@ -237,7 +237,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             Logger.LogInformation($"All gRPC calls on server");
 
-            await BalancerHelpers.WaitForChannelStateAsync(channel, ConnectivityState.Ready).DefaultTimeout();
+            await BalancerHelpers.WaitForChannelStateAsync(Logger, channel, ConnectivityState.Ready).DefaultTimeout();
 
             var balancer = BalancerHelpers.GetInnerLoadBalancer<PickFirstBalancer>(channel)!;
             var subchannel = balancer._subchannel!;
@@ -342,8 +342,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             endpoint.Dispose();
 
             await Task.WhenAll(
-                BalancerHelpers.WaitForChannelStateAsync(channel1, ConnectivityState.Idle),
-                BalancerHelpers.WaitForChannelStateAsync(channel2, ConnectivityState.Idle)).DefaultTimeout();
+                BalancerHelpers.WaitForChannelStateAsync(Logger, channel1, ConnectivityState.Idle, channelId: 1),
+                BalancerHelpers.WaitForChannelStateAsync(Logger, channel2, ConnectivityState.Idle, channelId: 2)).DefaultTimeout();
 
             Logger.LogInformation("Restarting");
             using var endpointNew = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod));

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -19,7 +19,9 @@
 #if SUPPORT_LOAD_BALANCING
 #if NET5_0_OR_GREATER
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -62,24 +64,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             await channel.ConnectAsync().DefaultTimeout();
 
-            Subchannel? subchannel = null;
-            await TestHelpers.AssertIsTrueRetryAsync(() =>
-            {
-                var picker = channel.ConnectionManager._picker as RoundRobinPicker;
-                if (picker?._subchannels.Count == 1)
-                {
-                    subchannel = picker?._subchannels[0];
-                    return true;
-                }
-                return false;
-            }, "Wait for all subchannels to be connected.").DefaultTimeout();
+            await WaitForSubChannelsToBeReady(channel, 1).DefaultTimeout();
+            
+            var subchannel = (await WaitForSubChannelsToBeReady(channel, 1).DefaultTimeout()).Single();
 
             // Act
             endpoint.Dispose();
 
             // Assert
             await TestHelpers.AssertIsTrueRetryAsync(
-                () => subchannel!.State == ConnectivityState.TransientFailure,
+                () => subchannel.State == ConnectivityState.TransientFailure,
                 "Wait for subchannel to fail.").DefaultTimeout();
         }
 
@@ -204,11 +198,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), new[] { endpoint1.Address, endpoint2.Address }, connect: true);
 
-            await TestHelpers.AssertIsTrueRetryAsync(() =>
-            {
-                var picker = channel.ConnectionManager._picker as RoundRobinPicker;
-                return picker?._subchannels.Count == 2;
-            }, "Wait for all subconnections to be connected.").DefaultTimeout();
+            await WaitForSubChannelsToBeReady(channel, 2).DefaultTimeout();
 
             var client = TestClientFactory.Create(channel, endpoint1.Method);
 
@@ -259,11 +249,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), new[] { endpoint1.Address, endpoint2.Address }, connect: true);
 
-            await TestHelpers.AssertIsTrueRetryAsync(() =>
-            {
-                var picker = channel.ConnectionManager._picker as RoundRobinPicker;
-                return picker?._subchannels.Count == 2;
-            }, "Wait for all subconnections to be connected.").DefaultTimeout();
+            await WaitForSubChannelsToBeReady(channel, 2).DefaultTimeout();
 
             var client = TestClientFactory.Create(channel, endpoint1.Method);
 
@@ -284,11 +270,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             Assert.AreEqual("Balancer", reply1.Message);
             Assert.AreEqual("127.0.0.1:50052", host);
 
-            await TestHelpers.AssertIsTrueRetryAsync(() =>
-            {
-                var picker = channel.ConnectionManager._picker as RoundRobinPicker;
-                return picker?._subchannels.Count == 1;
-            }, "Wait for all subconnections to be connected.").DefaultTimeout();
+            await WaitForSubChannelsToBeReady(channel, 1).DefaultTimeout();
         }
 
         [Test]
@@ -327,11 +309,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), resolver, connect: true);
 
-            await TestHelpers.AssertIsTrueRetryAsync(() =>
-            {
-                var picker = channel.ConnectionManager._picker as RoundRobinPicker;
-                return picker?._subchannels.Count == 2;
-            }, "Wait for all subconnections to be connected.").DefaultTimeout();
+            await WaitForSubChannelsToBeReady(channel, 2).DefaultTimeout();
 
             var client = TestClientFactory.Create(channel, endpoint1.Method);
 
@@ -348,11 +326,31 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             syncPoint.Continue();
 
+            await WaitForSubChannelsToBeReady(channel, 1).DefaultTimeout();
+        }
+
+        private async Task<Subchannel[]> WaitForSubChannelsToBeReady(GrpcChannel channel, int expectedCount)
+        {
+            Logger.LogInformation($"Waiting for subchannel ready count: {expectedCount}");
+
+            Subchannel[]? subChannelsCopy = null;
             await TestHelpers.AssertIsTrueRetryAsync(() =>
             {
                 var picker = channel.ConnectionManager._picker as RoundRobinPicker;
-                return picker?._subchannels.Count == 1;
-            }, "Wait for all subconnections to be connected.").DefaultTimeout();
+                subChannelsCopy = picker?._subchannels.ToArray() ?? Array.Empty<Subchannel>();
+                Logger.LogInformation($"Current subchannel ready count: {subChannelsCopy.Length}");
+                for (var i = 0; i < subChannelsCopy.Length; i++)
+                {
+                    Logger.LogInformation($"Ready subchannel: {subChannelsCopy[i]}");
+                }
+
+                return subChannelsCopy.Length == expectedCount;
+            }, "Wait for all subconnections to be connected.");
+
+            Logger.LogInformation($"Finished waiting for subchannel ready.");
+
+            Debug.Assert(subChannelsCopy != null);
+            return subChannelsCopy;
         }
     }
 }

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -160,8 +160,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             endpoint.Dispose();
 
             await Task.WhenAll(
-                BalancerHelpers.WaitForChannelStateAsync(channel1, ConnectivityState.Connecting),
-                BalancerHelpers.WaitForChannelStateAsync(channel2, ConnectivityState.Connecting)).DefaultTimeout();
+                BalancerHelpers.WaitForChannelStateAsync(Logger, channel1, ConnectivityState.Connecting, channelId: 1),
+                BalancerHelpers.WaitForChannelStateAsync(Logger, channel2, ConnectivityState.Connecting, channelId: 2)).DefaultTimeout();
 
             Logger.LogInformation("Restarting");
             using var endpointNew = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod));

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -253,7 +253,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
             var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingCall);
 
-            var channel = CreateChannel(useHandler: true);
+            var channel = CreateChannel();
 
             var client = TestClientFactory.Create(channel, method);
 

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -438,14 +438,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
             // Act
             var call1Task = MakeCall(Fixture, channel, request, sp1);
-            await sp1.WaitForSyncPoint();
+            await sp1.WaitForSyncPoint().DefaultTimeout();
 
             var call2Task = MakeCall(Fixture, channel, request, sp2);
-            await sp2.WaitForSyncPoint();
+            await sp2.WaitForSyncPoint().DefaultTimeout();
 
             // Will exceed channel buffer limit and won't retry
             var call3Task = MakeCall(Fixture, channel, request, sp3);
-            await sp3.WaitForSyncPoint();
+            await sp3.WaitForSyncPoint().DefaultTimeout();
 
             // Assert
             Assert.AreEqual(194, channel.CurrentRetryBufferSize);

--- a/test/FunctionalTests/Client/TelemetryTests.cs
+++ b/test/FunctionalTests/Client/TelemetryTests.cs
@@ -41,7 +41,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             await TestTelemetryHeaderIsSet(clientType, handler: null);
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         [TestCase(ClientType.Channel)]
         [TestCase(ClientType.ClientFactory)]
         public async Task Channel_SocketsHttpHandler_UnaryCall_TelemetryHeaderSentWithRequest(ClientType clientType)
@@ -70,7 +70,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             Task<HelloReply> UnaryTelemetryHeader(HelloRequest request, ServerCallContext context)
             {
                 telemetryHeader = context.RequestHeaders.GetValue(
-#if NET5_0
+#if NET5_0_OR_GREATER
                     "traceparent"
 #else
                     "request-id"
@@ -85,7 +85,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             var client = CreateClient(clientType, method, handler);
 
             // Act
-#if NET5_0
+#if NET5_0_OR_GREATER
             var result = new List<KeyValuePair<string, object?>>();
 
             using var allSubscription = new AllListenersObserver(new Dictionary<string, IObserver<KeyValuePair<string, object?>>>
@@ -101,7 +101,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             // Assert
             Assert.IsNotNull(telemetryHeader);
 
-#if NET5_0
+#if NET5_0_OR_GREATER
             Assert.AreEqual(4, result.Count);
             Assert.AreEqual("System.Net.Http.HttpRequestOut.Start", result[0].Key);
             Assert.AreEqual("System.Net.Http.Request", result[1].Key);

--- a/test/FunctionalTests/Client/UnaryTests.cs
+++ b/test/FunctionalTests/Client/UnaryTests.cs
@@ -71,7 +71,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             Assert.AreEqual("Failed to deserialize response message.", call.GetStatus().Detail);
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         [Test]
         public async Task MaxConcurrentStreams_StartConcurrently_AdditionalConnectionsCreated()
         {

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>SUPPORT_LOAD_BALANCING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
@@ -24,6 +23,11 @@
     <Compile Include="..\Shared\CallbackInterceptor.cs" Link="Infrastructure\CallbackInterceptor.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
+  </ItemGroup>
+  
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
@@ -48,6 +52,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreApp31PackageVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
 

--- a/test/FunctionalTests/Infrastructure/GrpcHttpHelper.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcHttpHelper.cs
@@ -27,7 +27,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         {
             var request = new HttpRequestMessage(method ?? HttpMethod.Post, url);
             request.Version = new Version(2, 0);
-#if NET5_0
+#if NET5_0_OR_GREATER
             request.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
 #endif
 

--- a/test/FunctionalTests/Infrastructure/GrpcTestContext.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestContext.cs
@@ -59,7 +59,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
                     }
                     else if (category.StartsWith("Microsoft") || category.StartsWith("System"))
                     {
-                        return l >= LogLevel.Debug;
+                        return l >= LogLevel.Trace;
                     }
 
                     return true;

--- a/test/FunctionalTests/Infrastructure/InProcessTestServer.cs
+++ b/test/FunctionalTests/Infrastructure/InProcessTestServer.cs
@@ -105,19 +105,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
                 })
                 .UseContentRoot(Directory.GetCurrentDirectory());
 
-#if NET6_0_OR_GREATER
-#pragma warning disable CA1416 // Validate platform compatibility
-            if (RequireHttp3Attribute.IsSupported(out _))
-            {
-                builder = builder.UseQuic(options =>
-                     {
-                         options.IdleTimeout = TimeSpan.FromSeconds(60);
-                         options.Alpn = "h3";
-                     });
-            }
-#pragma warning restore CA1416 // Validate platform compatibility
-#endif
-
             _host = builder.Build();
 
             var t = Task.Run(() => _host.Start());

--- a/test/FunctionalTests/Infrastructure/ListenerSubscription.cs
+++ b/test/FunctionalTests/Infrastructure/ListenerSubscription.cs
@@ -51,5 +51,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         {
             _tcs.TrySetResult(null);
         }
+
+        internal bool IsMatched => _tcs.Task.IsCompletedSuccessfully;
     }
 }

--- a/test/FunctionalTests/Infrastructure/ListenerSubscription.cs
+++ b/test/FunctionalTests/Infrastructure/ListenerSubscription.cs
@@ -41,6 +41,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
 
         // Set the last value encountered for debugging purposes
         public long? LastValue { get; internal set; }
+        public int CheckCount { get; internal set; }
 
         public void Dispose()
         {

--- a/test/FunctionalTests/Infrastructure/RequireHttp3Attribute.cs
+++ b/test/FunctionalTests/Infrastructure/RequireHttp3Attribute.cs
@@ -1,0 +1,60 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class RequireHttp3Attribute : NUnitAttribute, IApplyToTest
+    {
+        public void ApplyToTest(NUnit.Framework.Internal.Test test)
+        {
+            if (test.RunState == RunState.NotRunnable)
+            {
+                return;
+            }
+
+            if (IsSupported(out var message))
+            {
+                return;
+            }
+
+            test.RunState = RunState.Ignored;
+            test.Properties.Set(PropertyNames.SkipReason, message!);
+        }
+
+        public static bool IsSupported(out string? message)
+        {
+            var osVersion = Environment.OSVersion;
+            if (osVersion.Platform == PlatformID.Win32NT &&
+                osVersion.Version.Major >= 10 &&
+                osVersion.Version.Build >= 22000)
+            {
+                message = null;
+                return true;
+            }
+
+            message = "HTTP/3 requires Windows 11 or later.";
+            return false;
+        }
+    }
+}

--- a/test/FunctionalTests/Infrastructure/TestEventListener.cs
+++ b/test/FunctionalTests/Infrastructure/TestEventListener.cs
@@ -70,14 +70,12 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
                     {
                         if (subscription.CounterName == Convert.ToString(name))
                         {
+                            subscription.CheckCount++;
                             var currentValue = Convert.ToInt64(value);
-
-                            // For debugging. Printed in message if subscription fails.
-                            subscription.LastValue = currentValue;
 
                             if (subscription.ExpectedValue == currentValue)
                             {
-                                _logger.LogDebug($"{subscription.CounterName} current value {currentValue} matched expected {subscription.ExpectedValue}.");
+                                _logger.LogDebug($"Check {subscription.CheckCount}: {subscription.CounterName} current value {currentValue} matched expected {subscription.ExpectedValue}.");
 
                                 subscription.SetMatched();
                                 subscription.Dispose();
@@ -86,9 +84,15 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
                             {
                                 if (!subscription.IsMatched)
                                 {
-                                    _logger.LogDebug($"{subscription.CounterName} current value {currentValue} doesn't match expected {subscription.ExpectedValue}.");
+                                    if (subscription.LastValue != currentValue || subscription.CheckCount % 1000 == 0)
+                                    {
+                                        _logger.LogDebug($"Check {subscription.CheckCount}: {subscription.CounterName} current value {currentValue} doesn't match expected {subscription.ExpectedValue}.");
+                                    }
                                 }
                             }
+
+                            // For debugging. Printed in message if subscription fails.
+                            subscription.LastValue = currentValue;
                         }
                     }
                 }

--- a/test/FunctionalTests/Infrastructure/TestServerEndpointName.cs
+++ b/test/FunctionalTests/Infrastructure/TestServerEndpointName.cs
@@ -23,6 +23,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         Http2,
         Http1,
         Http2WithTls,
-        Http1WithTls
+        Http1WithTls,
+#if NET6_0_OR_GREATER
+        Http3WithTls,
+#endif
     }
 }

--- a/test/FunctionalTests/Server/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Server/ServerStreamingMethodTests.cs
@@ -25,6 +25,7 @@ using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Tests.Shared;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 namespace Grpc.AspNetCore.FunctionalTests.Server
@@ -78,7 +79,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
         [Test]
         public async Task WriteResponseHeadersAsyncCore_FlushesHeadersToClient()
         {
+            async Task SayHellosSendHeadersFirst(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+            {
+                await context.WriteResponseHeadersAsync(null);
+
+                await SayHellosCore(Logger, request, responseStream);
+            }
+
             // Arrange
+            var method = Fixture.DynamicGrpc.AddServerStreamingMethod<HelloRequest, HelloReply>(SayHellosSendHeadersFirst);
+
             var requestMessage = new HelloRequest
             {
                 Name = "World"
@@ -87,7 +97,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             var requestStream = new MemoryStream();
             MessageHelpers.WriteMessage(requestStream, requestMessage);
 
-            var httpRequest = GrpcHttpHelper.Create("Greet.Greeter/SayHellosSendHeadersFirst");
+            var httpRequest = GrpcHttpHelper.Create(method.FullName);
             httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act
@@ -96,20 +106,27 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             // Assert
             response.AssertIsSuccessfulGrpcRequest();
 
+            Logger.LogInformation("Headers received. Starting to read stream");
+
             var responseStream = await response.Content.ReadAsStreamAsync().DefaultTimeout();
             var pipeReader = PipeReader.Create(responseStream);
 
             for (var i = 0; i < 3; i++)
             {
+                Logger.LogInformation($"Reading message {i}.");
+
                 var greetingTask = MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader);
 
                 // The headers are already sent
                 // All responses are streamed
+                Logger.LogInformation($"Message task completed: {greetingTask.IsCompleted}");
                 Assert.False(greetingTask.IsCompleted);
 
-                var greeting = await greetingTask.DefaultTimeout();
+                var greeting = (await greetingTask.DefaultTimeout())!;
 
-                Assert.AreEqual($"How are you World? {i}", greeting!.Message);
+                Logger.LogInformation($"Received message {i}: {greeting.Message}");
+
+                Assert.AreEqual($"How are you World? {i}", greeting.Message);
             }
 
             var goodbyeTask = MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader);
@@ -169,6 +186,28 @@ namespace Grpc.AspNetCore.FunctionalTests.Server
             Assert.IsNull(await MessageHelpers.AssertReadStreamMessageAsync<HelloReply>(pipeReader).DefaultTimeout());
 
             response.AssertTrailerStatus();
+        }
+
+        public static async Task SayHellosCore(ILogger logger, HelloRequest request, IServerStreamWriter<HelloReply> responseStream)
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                // Gotta look busy
+                logger.LogInformation("Delaying");
+                await Task.Delay(1000);
+
+                logger.LogInformation("Sending message");
+
+                var message = $"How are you {request.Name}? {i}";
+                await responseStream.WriteAsync(new HelloReply { Message = message });
+            }
+
+            // Gotta look busy
+            logger.LogInformation("Delaying");
+            await Task.Delay(1000);
+
+            logger.LogInformation("Sending message");
+            await responseStream.WriteAsync(new HelloReply { Message = $"Goodbye {request.Name}!" });
         }
     }
 }

--- a/test/FunctionalTests/Server/UnaryMethodTests.cs
+++ b/test/FunctionalTests/Server/UnaryMethodTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Threading.Tasks;
 using Any;
 using FunctionalTestsWebsite.Infrastructure;

--- a/test/FunctionalTests/Web/Client/ConnectionTests.cs
+++ b/test/FunctionalTests/Web/Client/ConnectionTests.cs
@@ -57,7 +57,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
         [TestCase(TestServerEndpointName.Http2, "2.0", true)]
         [TestCase(TestServerEndpointName.Http2, "1.1", false)]
         [TestCase(TestServerEndpointName.Http2, null, true)]
-#if NET5_0
+#if NET5_0_OR_GREATER
         // Specifing HTTP/2 doesn't work when the server is using TLS with HTTP/1.1
         // Caused by using HttpVersionPolicy.RequestVersionOrHigher setting
         [TestCase(TestServerEndpointName.Http1WithTls, "2.0", false)]
@@ -67,7 +67,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
         [TestCase(TestServerEndpointName.Http1WithTls, "1.1", true)]
         [TestCase(TestServerEndpointName.Http1WithTls, null, true)]
         [TestCase(TestServerEndpointName.Http2WithTls, "2.0", true)]
-#if NET5_0
+#if NET5_0_OR_GREATER
         // Specifing HTTP/1.1 does work when the server is using TLS with HTTP/2
         // Caused by using HttpVersionPolicy.RequestVersionOrHigher setting
         [TestCase(TestServerEndpointName.Http2WithTls, "1.1", true)]
@@ -75,8 +75,19 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
         [TestCase(TestServerEndpointName.Http2WithTls, "1.1", false)]
 #endif
         [TestCase(TestServerEndpointName.Http2WithTls, null, true)]
+#if NET6_0_OR_GREATER
+        [TestCase(TestServerEndpointName.Http3WithTls, null, true)]
+#endif
         public async Task SendValidRequest_WithConnectionOptions(TestServerEndpointName endpointName, string? version, bool success)
         {
+#if NET6_0_OR_GREATER
+            if (endpointName == TestServerEndpointName.Http3WithTls &&
+                !RequireHttp3Attribute.IsSupported(out var message))
+            {
+                Assert.Ignore(message);
+            }
+#endif
+
             SetExpectedErrorsFilter(writeContext =>
             {
                 return !success;

--- a/test/FunctionalTests/Web/Client/IssueTests.cs
+++ b/test/FunctionalTests/Web/Client/IssueTests.cs
@@ -29,9 +29,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
 {
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
+#endif
     public class IssueTests : GrpcWebFunctionalTestBase
     {
         public IssueTests(GrpcTestMode grpcTestMode, TestServerEndpointName endpointName)

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -33,9 +33,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
 {
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
+#endif
     public class ServerStreamingMethodTests : GrpcWebFunctionalTestBase
     {
         public ServerStreamingMethodTests(GrpcTestMode grpcTestMode, TestServerEndpointName endpointName)

--- a/test/FunctionalTests/Web/Client/TrailerMetadataTests.cs
+++ b/test/FunctionalTests/Web/Client/TrailerMetadataTests.cs
@@ -29,9 +29,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
 {
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
+#endif
     public class TrailerMetadataTests : GrpcWebFunctionalTestBase
     {
         public TrailerMetadataTests(GrpcTestMode grpcTestMode, TestServerEndpointName endpointName)

--- a/test/FunctionalTests/Web/Client/UnaryMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/UnaryMethodTests.cs
@@ -28,9 +28,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
 {
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
+#endif
     public class UnaryMethodTests : GrpcWebFunctionalTestBase
     {
         public UnaryMethodTests(GrpcTestMode grpcTestMode, TestServerEndpointName endpointName)

--- a/test/FunctionalTests/Web/GrpcWebFunctionalTestBase.cs
+++ b/test/FunctionalTests/Web/GrpcWebFunctionalTestBase.cs
@@ -21,6 +21,7 @@ using System.Net.Http;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Net.Client;
 using Grpc.Net.Client.Web;
+using NUnit.Framework;
 
 namespace Grpc.AspNetCore.FunctionalTests.Web
 {
@@ -40,13 +41,34 @@ namespace Grpc.AspNetCore.FunctionalTests.Web
         {
             GrpcTestMode = grpcTestMode;
             EndpointName = endpointName;
+
+#if NET6_0_OR_GREATER
+            if (endpointName == TestServerEndpointName.Http3WithTls &&
+                !RequireHttp3Attribute.IsSupported(out var message))
+            {
+                Assert.Ignore(message);
+            }
+#endif
         }
 
         protected HttpClient CreateGrpcWebClient()
         {
-            var protocol = EndpointName == TestServerEndpointName.Http1
-                ? new Version(1, 1)
-                : new Version(2, 0);
+            Version protocol;
+
+            if (EndpointName == TestServerEndpointName.Http1)
+            {
+                protocol = new Version(1, 1);
+            }
+#if NET6_0_OR_GREATER
+            else if (EndpointName == TestServerEndpointName.Http3WithTls)
+            {
+                protocol = new Version(3, 0);
+            }
+#endif
+            else
+            {
+                protocol = new Version(2, 0);
+            }
 
             GrpcWebHandler? grpcWebHandler = null;
             if (GrpcTestMode != GrpcTestMode.Grpc)

--- a/test/FunctionalTests/Web/Server/DeadlineTests.cs
+++ b/test/FunctionalTests/Web/Server/DeadlineTests.cs
@@ -34,9 +34,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Server
 {
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
+#endif
     public class DeadlineTests : GrpcWebFunctionalTestBase
     {
         public DeadlineTests(GrpcTestMode grpcTestMode, TestServerEndpointName endpointName)
@@ -90,7 +99,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Server
             MessageHelpers.WriteMessage(requestStream, requestMessage);
 
             var httpRequest = GrpcHttpHelper.Create(method.FullName);
-            httpRequest.Headers.Add(GrpcProtocolConstants.TimeoutHeader, "100m");
+            httpRequest.Headers.Add(GrpcProtocolConstants.TimeoutHeader, "300m");
             httpRequest.Content = new GrpcStreamContent(requestStream);
 
             // Act

--- a/test/FunctionalTests/Web/Server/UnaryMethodTests.cs
+++ b/test/FunctionalTests/Web/Server/UnaryMethodTests.cs
@@ -31,9 +31,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Server
 {
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
     [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
+#endif
     [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
+#if NET6_0_OR_GREATER
+    [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
+#endif
     public class UnaryMethodTests : GrpcWebFunctionalTestBase
     {
         public UnaryMethodTests(GrpcTestMode grpcTestMode, TestServerEndpointName endpointName)

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Grpc.AspNetCore.Server.Tests/CallHandlerTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/CallHandlerTests.cs
@@ -62,7 +62,7 @@ namespace Grpc.AspNetCore.Server.Tests
             await call.HandleCallAsync(httpContext).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(hasRequestBodyDataRate, httpContext.Features.Get<IHttpMinRequestBodyDataRateFeature>().MinDataRate != null);
+            Assert.AreEqual(hasRequestBodyDataRate, httpContext.Features.Get<IHttpMinRequestBodyDataRateFeature>()?.MinDataRate != null);
         }
 
         [TestCase(MethodType.Unary, true)]
@@ -79,7 +79,7 @@ namespace Grpc.AspNetCore.Server.Tests
             await call.HandleCallAsync(httpContext).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(hasMaxRequestBodySize, httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize != null);
+            Assert.AreEqual(hasMaxRequestBodySize, httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>()?.MaxRequestBodySize != null);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace Grpc.AspNetCore.Server.Tests
             await call.HandleCallAsync(httpContext).DefaultTimeout();
 
             // Assert
-            Assert.AreEqual(true, httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize != null);
+            Assert.AreEqual(true, httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>()?.MaxRequestBodySize != null);
             Assert.IsTrue(testSink.Writes.Any(w => w.EventId.Name == "UnableToDisableMaxRequestBodySizeLimit"));
         }
 
@@ -157,7 +157,7 @@ namespace Grpc.AspNetCore.Server.Tests
             Assert.AreEqual("Request protocol of 'HTTP/1.1' is not supported.", log!.Message);
         }
 
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         // .NET Core 3.0 + IIS returned HTTP/2.0 as the protocol
         [Test]
         public async Task ProtocolValidation_IISHttp2Protocol_Success()
@@ -190,7 +190,7 @@ namespace Grpc.AspNetCore.Server.Tests
             await call.HandleCallAsync(httpContext).DefaultTimeout();
 
             // Assert
-            var serverCallContext = httpContext.Features.Get<IServerCallContextFeature>();
+            var serverCallContext = httpContext.Features.Get<IServerCallContextFeature>()!;
             Assert.AreEqual(ex, serverCallContext.ServerCallContext.Status.DebugException);
         }
 
@@ -213,7 +213,7 @@ namespace Grpc.AspNetCore.Server.Tests
             await handleCallTask;
 
             // Assert
-            var serverCallContext = httpContext.Features.Get<IServerCallContextFeature>();
+            var serverCallContext = httpContext.Features.Get<IServerCallContextFeature>()!;
             Assert.AreEqual(StatusCode.DeadlineExceeded, serverCallContext.ServerCallContext.Status.StatusCode);
 
             Assert.IsFalse(isHandleCallTaskCompleteDuringDeadline);

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HttpContextServerCallContextTests.cs
@@ -199,7 +199,7 @@ namespace Grpc.AspNetCore.Server.Tests
             httpContext.Response.ConsolidateTrailers(serverCallContext);
 
             // Assert
-            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>().Trailers;
+            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>()!.Trailers;
 
             Assert.AreEqual(2, responseTrailers.Count);
             Assert.AreEqual(expectedTrailerValue, responseTrailers[expectedTrailerName].ToString());
@@ -221,7 +221,7 @@ namespace Grpc.AspNetCore.Server.Tests
             httpContext.Response.ConsolidateTrailers(serverCallContext);
 
             // Assert
-            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>().Trailers;
+            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>()!.Trailers;
 
             Assert.AreEqual(2, responseTrailers.Count);
             Assert.AreEqual(StatusCode.Internal.ToString("D"), responseTrailers[GrpcProtocolConstants.StatusTrailer]);
@@ -266,7 +266,7 @@ namespace Grpc.AspNetCore.Server.Tests
             httpContext.Response.ConsolidateTrailers(serverCallContext);
 
             // Assert
-            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>().Trailers;
+            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>()!.Trailers;
 
             Assert.AreEqual(2, responseTrailers.Count);
             Assert.AreEqual(StatusCode.Internal.ToString("D"), responseTrailers[GrpcProtocolConstants.StatusTrailer]);
@@ -290,7 +290,7 @@ namespace Grpc.AspNetCore.Server.Tests
             httpContext.Response.ConsolidateTrailers(serverCallContext);
 
             // Assert
-            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>().Trailers;
+            var responseTrailers = httpContext.Features.Get<IHttpResponseTrailersFeature>()!.Trailers;
 
             Assert.AreEqual(2, responseTrailers.Count);
             Assert.AreEqual(StatusCode.OK.ToString("D"), responseTrailers[GrpcProtocolConstants.StatusTrailer]);
@@ -631,6 +631,7 @@ namespace Grpc.AspNetCore.Server.Tests
 
             var httpResetFeature = new TestHttpResetFeature();
             var httpContext = new DefaultHttpContext();
+            httpContext.Request.Protocol = "HTTP/2";
             httpContext.Request.Headers[GrpcProtocolConstants.TimeoutHeader] = "200m";
             httpContext.Features.Set<IHttpResponseBodyFeature>(new TestBlockingHttpResponseCompletionFeature(syncPoint));
             httpContext.Features.Set<IHttpResetFeature>(httpResetFeature);
@@ -657,7 +658,7 @@ namespace Grpc.AspNetCore.Server.Tests
             syncPoint.Continue();
             await methodTask.DefaultTimeout();
 
-            Assert.AreEqual(GrpcProtocolConstants.ResetStreamNoError, httpResetFeature.ErrorCode);
+            Assert.AreEqual(GrpcProtocolConstants.Http2ResetStreamNoError, httpResetFeature.ErrorCode);
 
             Assert.IsTrue(serverCallContext.DeadlineManager!.IsCallComplete);
         }

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>SUPPORT_LOAD_BALANCING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/test/Grpc.Net.Client.Web.Tests/Grpc.Net.Client.Web.Tests.csproj
+++ b/test/Grpc.Net.Client.Web.Tests/Grpc.Net.Client.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>

--- a/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
+++ b/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>

--- a/test/Shared/HttpContextHelpers.cs
+++ b/test/Shared/HttpContextHelpers.cs
@@ -51,7 +51,7 @@ namespace Grpc.Tests.Shared
         {
             var httpContext = new DefaultHttpContext();
             var responseFeature = new TestHttpResponseFeature();
-            var responseBodyFeature = new TestHttpResponseBodyFeature(httpContext.Features.Get<IHttpResponseBodyFeature>(), responseFeature, completeAsyncAction);
+            var responseBodyFeature = new TestHttpResponseBodyFeature(httpContext.Features.Get<IHttpResponseBodyFeature>()!, responseFeature, completeAsyncAction);
 
             httpContext.RequestServices = serviceProvider!;
             httpContext.Request.Protocol = protocol ?? GrpcProtocolConstants.Http2Protocol;
@@ -134,7 +134,7 @@ namespace Grpc.Tests.Shared
 
         public class TestMinRequestBodyDataRateFeature : IHttpMinRequestBodyDataRateFeature
         {
-            public MinDataRate MinDataRate { get; set; } = new MinDataRate(1, TimeSpan.FromSeconds(5));
+            public MinDataRate? MinDataRate { get; set; } = new MinDataRate(1, TimeSpan.FromSeconds(5));
         }
 
         public class TestMaxRequestBodySizeFeature : IHttpMaxRequestBodySizeFeature

--- a/test/dotnet-grpc.Tests/dotnet-grpc.Tests.csproj
+++ b/test/dotnet-grpc.Tests/dotnet-grpc.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- MSBuild has issues with testing frameworks other than the one referenced in global.json -->
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Grpc.Dotnet.Cli.Tests</RootNamespace>
   </PropertyGroup>

--- a/testassets/FunctionalTestsWebsite/Startup.cs
+++ b/testassets/FunctionalTestsWebsite/Startup.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FunctionalTestsWebsite.Infrastructure;
@@ -57,6 +58,7 @@ namespace FunctionalTestsWebsite
 
             services
                 .AddGrpcClient<Greeter.GreeterClient>((s, o) => { o.Address = GetCurrentAddress(s); })
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator })
                 .EnableCallContextPropagation();
 
             services.AddAuthorization(options =>

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -2,9 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net5.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net6.0;net5.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net5.0</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Shared\Assert.cs" Link="Assert.cs" />

--- a/testassets/InteropTestsClient/Program.cs
+++ b/testassets/InteropTestsClient/Program.cs
@@ -44,6 +44,7 @@ namespace InteropTestsClient
             rootCommand.AddOption(new Option<string>(new string[] { "--service_account_key_file", nameof(ClientOptions.ServiceAccountKeyFile) }));
             rootCommand.AddOption(new Option<string>(new string[] { "--grpc_web_mode", nameof(ClientOptions.GrpcWebMode) }));
             rootCommand.AddOption(new Option<bool>(new string[] { "--use_winhttp", nameof(ClientOptions.UseWinHttp) }));
+            rootCommand.AddOption(new Option<bool>(new string[] { "--use_http3", nameof(ClientOptions.UseHttp3) }));
 
             rootCommand.Handler = CommandHandler.Create<ClientOptions>(async (options) =>
             {
@@ -52,6 +53,7 @@ namespace InteropTestsClient
                 Console.WriteLine("Runtime: " + runtimeVersion);
                 Console.WriteLine("Use TLS: " + options.UseTls);
                 Console.WriteLine("Use WinHttp: " + options.UseWinHttp);
+                Console.WriteLine("Use HTTP/3: " + options.UseHttp3);
                 Console.WriteLine("Use GrpcWebMode: " + options.GrpcWebMode);
                 Console.WriteLine("Use Test CA: " + options.UseTestCa);
                 Console.WriteLine("Client type: " + options.ClientType);

--- a/testassets/InteropTestsClient/RunGrpcTests.ps1
+++ b/testassets/InteropTestsClient/RunGrpcTests.ps1
@@ -2,7 +2,8 @@
 (
     [bool]$use_tls = $false,
     [bool]$use_winhttp = $false,
-    [string]$framework = "net5.0",
+    [bool]$use_http3 = $false,
+    [string]$framework = "net6.0",
     [string]$grpc_web_mode = "None",
     [int]$server_port = 50052
 )
@@ -36,6 +37,7 @@ $allTests =
 Write-Host "Running $($allTests.Count) tests" -ForegroundColor Cyan
 Write-Host "Use TLS: $use_tls" -ForegroundColor Cyan
 Write-Host "Use WinHttp: $use_winhttp" -ForegroundColor Cyan
+Write-Host "Use HTTP/3: $use_http3" -ForegroundColor Cyan
 Write-Host "Framework: $framework" -ForegroundColor Cyan
 Write-Host "gRPC-Web mode: $grpc_web_mode" -ForegroundColor Cyan
 Write-Host
@@ -44,7 +46,7 @@ foreach ($test in $allTests)
 {
   Write-Host "Running $test" -ForegroundColor Cyan
 
-  dotnet run --framework $framework --use_tls $use_tls --server_host localhost --server_port $server_port --client_type httpclient --test_case $test --use_winhttp $use_winhttp --grpc_web_mode $grpc_web_mode
+  dotnet run --framework $framework --use_tls $use_tls --server_host localhost --server_port $server_port --client_type httpclient --test_case $test --use_winhttp $use_winhttp --grpc_web_mode $grpc_web_mode --use_http3 $use_http3
 
   Write-Host
 }

--- a/testassets/InteropTestsGrpcWebClient/InteropTestsGrpcWebClient.csproj
+++ b/testassets/InteropTestsGrpcWebClient/InteropTestsGrpcWebClient.csproj
@@ -17,8 +17,8 @@
     <ProjectReference Include="..\..\src\Grpc.Net.Client.Web\Grpc.Net.Client.Web.csproj" />
     <ProjectReference Include="..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" PrivateAssets="all" />
 
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemNetHttpWinHttpHandlerPackageVersion)" />
 

--- a/testassets/InteropTestsGrpcWebWebsite/Dockerfile
+++ b/testassets/InteropTestsGrpcWebWebsite/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 
 # Copy everything

--- a/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
+++ b/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreApp5PackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testassets/InteropTestsWebsite/Dockerfile
+++ b/testassets/InteropTestsWebsite/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 
 # Copy everything

--- a/testassets/InteropTestsWebsite/Dockerfile
+++ b/testassets/InteropTestsWebsite/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . ./
 RUN dotnet --info
 RUN dotnet restore testassets/InteropTestsWebsite
-RUN dotnet publish testassets/InteropTestsWebsite -c Release -o out -p:LatestFramework=true
+RUN dotnet publish testassets/InteropTestsWebsite --framework net5.0 -c Release -o out -p:LatestFramework=true
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:5.0

--- a/testassets/InteropTestsWebsite/Dockerfile
+++ b/testassets/InteropTestsWebsite/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . ./
 RUN dotnet --info
 RUN dotnet restore testassets/InteropTestsWebsite
-RUN dotnet publish testassets/InteropTestsWebsite -c Release -o out
+RUN dotnet publish testassets/InteropTestsWebsite -c Release -o out -p:LatestFramework=true
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:5.0

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net5.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>

--- a/testassets/InteropTestsWebsite/Program.cs
+++ b/testassets/InteropTestsWebsite/Program.cs
@@ -51,6 +51,7 @@ namespace InteropTestsWebsite
                         // by gRPC interop servers.
                         var http2Port = context.Configuration.GetValue<int>("port", 50052);
                         var http1Port = context.Configuration.GetValue<int>("port_http1", -1);
+                        var http3Port = context.Configuration.GetValue<int>("port_http3", -1);
                         var useTls = context.Configuration.GetValue<bool>("use_tls", false);
 
                         options.Limits.MinRequestBodyDataRate = null;
@@ -58,6 +59,10 @@ namespace InteropTestsWebsite
                         if (http1Port != -1)
                         {
                             options.ListenAnyIP(http1Port, o => ConfigureEndpoint(o, useTls, HttpProtocols.Http1));
+                        }
+                        if (http3Port != -1)
+                        {
+                            options.ListenAnyIP(http3Port, o => ConfigureEndpoint(o, useTls, HttpProtocols.Http3));
                         }
 
                         void ConfigureEndpoint(ListenOptions listenOptions, bool useTls, HttpProtocols httpProtocols)


### PR DESCRIPTION
Support .NET 6 and add new targets on client and server:
* Remove custom telemetry handler from client
* Use NonValidated headers in client to fix thread-safety issues
* Don't error if client upgrades protocol to HTTP/3