### PR TITLE
Fix client timeout when error in custom CallCredential

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
@@ -51,7 +52,7 @@ namespace Grpc.Net.Client.Balancer.Internal
         private readonly ILogger _logger;
         private readonly Subchannel _subchannel;
         private readonly TimeSpan _socketPingInterval;
-        internal readonly List<(DnsEndPoint EndPoint, Socket Socket, Stream? Stream)> _activeStreams;
+        private readonly List<(DnsEndPoint EndPoint, Socket Socket, Stream? Stream)> _activeStreams;
         private readonly Timer _socketConnectedTimer;
 
         private int _lastEndPointIndex;
@@ -72,6 +73,15 @@ namespace Grpc.Net.Client.Balancer.Internal
         public object Lock => _subchannel.Lock;
         public DnsEndPoint? CurrentEndPoint => _currentEndPoint;
         public bool HasStream { get; }
+
+        // For testing. Take a copy under lock for thread-safety.
+        internal IReadOnlyList<(DnsEndPoint EndPoint, Socket Socket, Stream? Stream)> GetActiveStreams()
+        {
+            lock (Lock)
+            {
+                return _activeStreams.ToList();
+            }
+        }
 
         public void Disconnect()
         {

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -415,11 +415,6 @@ namespace Grpc.Net.Client.Internal
             {
                 var (diagnosticSourceEnabled, activity) = InitializeCall(request, timeout);
 
-                if (Options.Credentials != null || Channel.CallCredentials?.Count > 0)
-                {
-                    await ReadCredentials(request).ConfigureAwait(false);
-                }
-
                 // Unset variable to check that FinishCall is called in every code path
                 bool finished;
 
@@ -427,6 +422,13 @@ namespace Grpc.Net.Client.Internal
 
                 try
                 {
+                    // User supplied call credentials could error and so must be run
+                    // inside try/catch to handle errors.
+                    if (Options.Credentials != null || Channel.CallCredentials?.Count > 0)
+                    {
+                        await ReadCredentials(request).ConfigureAwait(false);
+                    }
+
                     // Fail early if deadline has already been exceeded
                     _callCts.Token.ThrowIfCancellationRequested();
 

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -110,12 +110,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             var balancer = BalancerHelpers.GetInnerLoadBalancer<PickFirstBalancer>(channel)!;
             var subchannel = balancer._subchannel!;
             var transport = (SocketConnectivitySubchannelTransport)subchannel.Transport;
-            var activeStreams = transport._activeStreams;
+            var activeStreams = transport.GetActiveStreams();
 
             // Assert
             Assert.AreEqual(HttpHandlerType.SocketsHttpHandler, channel.HttpHandlerType);
 
-            await TestHelpers.AssertIsTrueRetryAsync(() => activeStreams.Count == 10, "Wait for connections to start.");
+            await TestHelpers.AssertIsTrueRetryAsync(() =>
+            {
+                activeStreams = transport.GetActiveStreams();
+                return activeStreams.Count == 10;
+            }, "Wait for connections to start.");
             foreach (var t in activeStreams)
             {
                 Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), t.EndPoint);
@@ -134,7 +138,11 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             Logger.LogInformation($"Done sending gRPC calls");
 
             // Assert
-            await TestHelpers.AssertIsTrueRetryAsync(() => activeStreams.Count == 11, "Wait for connections to start.");
+            await TestHelpers.AssertIsTrueRetryAsync(() =>
+            {
+                activeStreams = transport.GetActiveStreams();
+                return activeStreams.Count == 11;
+            }, "Wait for connections to start.");
             Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams.Last().EndPoint);
 
             tcs.SetResult(null);
@@ -149,7 +157,11 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             // There are still be 10 HTTP/1.1 connections because they aren't immediately removed
             // when the server is shutdown and connectivity is lost.
-            await TestHelpers.AssertIsTrueRetryAsync(() => activeStreams.Count == 10, "Wait for HTTP/2 connection to end.");
+            await TestHelpers.AssertIsTrueRetryAsync(() =>
+            {
+                activeStreams = transport.GetActiveStreams();
+                return activeStreams.Count == 10;
+            }, "Wait for HTTP/2 connection to end.");
 
             grpcWebHandler.HttpVersion = new Version(1, 1);
 
@@ -160,6 +172,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             Assert.AreEqual(StatusCode.Unavailable, ex.StatusCode);
 
             // Removed by failed call.
+            activeStreams = transport.GetActiveStreams();
             Assert.AreEqual(0, activeStreams.Count);
             Assert.AreEqual(ConnectivityState.Idle, channel.State);
 
@@ -168,6 +181,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             Assert.AreEqual("Balancer", reply.Message);
             Assert.AreEqual("127.0.0.1:50052", host);
 
+            activeStreams = transport.GetActiveStreams();
             Assert.AreEqual(1, activeStreams.Count);
             Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].EndPoint);
         }

--- a/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
@@ -246,7 +246,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             var balancer = BalancerHelpers.GetInnerLoadBalancer<PickFirstBalancer>(channel)!;
             var subchannel = balancer._subchannel!;
             var transport = (SocketConnectivitySubchannelTransport)subchannel.Transport;
-            var activeStreams = transport._activeStreams;
+            var activeStreams = transport.GetActiveStreams();
 
             // Assert
             Assert.AreEqual(2, activeStreams.Count);
@@ -263,6 +263,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             await TestHelpers.AssertIsTrueRetryAsync(() =>
             {
+                activeStreams = transport.GetActiveStreams();
                 Logger.LogInformation($"Current active stream endpoints: {string.Join(", ", activeStreams.Select(s => s.EndPoint))}");
                 return activeStreams.Count == 0;
             }, "Active streams removed.", Logger).DefaultTimeout();
@@ -271,6 +272,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             Assert.AreEqual("Balancer", reply.Message);
             Assert.AreEqual("127.0.0.1:50052", host);
 
+            activeStreams = transport.GetActiveStreams();
             Assert.AreEqual(1, activeStreams.Count);
             Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].EndPoint);
         }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1384

Also fixes a flakey test that failed during CI.