### PR TITLE
Fix gRPC retry calls not unregistering from cancellation token

### DIFF
--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -45,5 +45,7 @@ namespace Grpc.Net.Client.Internal
         void StartDuplexStreaming();
 
         Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state);
+
+        bool Disposed { get; }
     }
 }

--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -199,6 +199,13 @@ namespace Grpc.Net.Client.Internal.Retry
                     }
                 }
             }
+
+            if (CommitedCallTask.IsCompletedSuccessfully() && CommitedCallTask.Result == call)
+            {
+                // Wait until the commited call is finished and then clean up hedging call.
+                await call.CallTask.ConfigureAwait(false);
+                Cleanup();
+            }
         }
 
         protected override void OnCommitCall(IGrpcCall<TRequest, TResponse> call)

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -247,9 +247,7 @@ namespace Grpc.Net.Client.Internal.Retry
             {
                 if (CommitedCallTask.IsCompletedSuccessfully())
                 {
-                    var call = CommitedCallTask.Result as GrpcCall<TRequest, TResponse>;
-
-                    if (call != null)
+                    if (CommitedCallTask.Result is GrpcCall<TRequest, TResponse> call)
                     {
                         // Wait until the commited call is finished and then clean up retry call.
                         await call.CallTask.ConfigureAwait(false);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -245,6 +245,18 @@ namespace Grpc.Net.Client.Internal.Retry
             }
             finally
             {
+                if (CommitedCallTask.IsCompletedSuccessfully())
+                {
+                    var call = CommitedCallTask.Result as GrpcCall<TRequest, TResponse>;
+
+                    if (call != null)
+                    {
+                        // Wait until the commited call is finished and then clean up retry call.
+                        await call.CallTask.ConfigureAwait(false);
+                        Cleanup();
+                    }
+                }
+
                 Log.StoppingRetryWorker(Logger);
             }
         }

--- a/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
@@ -38,6 +38,7 @@ namespace Grpc.Net.Client.Internal.Retry
 
         public IClientStreamWriter<TRequest>? ClientStreamWriter => _clientStreamWriter ??= new StatusClientStreamWriter(_status);
         public IAsyncStreamReader<TResponse>? ClientStreamReader => _clientStreamReader ??= new StatusStreamReader(_status);
+        public bool Disposed => true;
 
         public StatusGrpcCall(Status status)
         {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1397