### PR TITLE
Fix deadline counter not being incremented if server returns first

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -736,7 +736,7 @@ namespace Grpc.Net.Client.Internal
                     // Usually a deadline will be triggered via the deadline timer. However,
                     // if the client and server are on the same machine it is possible for the
                     // client to get the response before the timer triggers. In that situation
-                    // treat a returned DEADLINE_EXCEEDED status as the client exceeding deadline
+                    // treat a returned DEADLINE_EXCEEDED status as the client exceeding deadline.
                     // To ensure that the deadline counter isn't incremented twice in a race
                     // between the timer and status, lock and use _deadline to check whether
                     // the client has processed that it has exceeded or not.

--- a/test/FunctionalTests/Client/EventSourceTests.cs
+++ b/test/FunctionalTests/Client/EventSourceTests.cs
@@ -203,7 +203,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 }
 
                 // Arrange
-                var clock = new TestSystemClock(DateTime.UtcNow);
                 var clientEventListener = CreateEnableListener(Grpc.Net.Client.Internal.GrpcEventSource.Log);
                 var serverEventListener = CreateEnableListener(Grpc.AspNetCore.Server.Internal.GrpcEventSource.Log);
 
@@ -211,13 +210,13 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 var method = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(UnaryDeadlineExceeded);
 
                 using var channel = CreateChannel();
-                channel.Clock = clock;
+                // Force client to handle deadline status from call
                 channel.DisableClientDeadline = true;
 
                 var client = TestClientFactory.Create(channel, method);
 
                 // Need a high deadline to avoid flakiness. No way to disable server deadline timer.
-                var deadline = clock.UtcNow.AddMilliseconds(500);
+                var deadline = DateTime.UtcNow.AddMilliseconds(500);
                 var call = client.UnaryCall(new HelloRequest(), new CallOptions(deadline: deadline));
 
                 // Assert - Call in progress

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -9,6 +9,10 @@
     <DefineConstants>SUPPORT_LOAD_BALANCING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <DefineConstants>HTTP3_TESTING;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Shared\ServiceConfigHelpers.cs" Link="Infrastructure\ServiceConfigHelpers.cs" />
     <Compile Include="..\Shared\ExceptionAssert.cs" Link="Infrastructure\ExceptionAssert.cs" />

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -9,10 +9,6 @@
     <DefineConstants>SUPPORT_LOAD_BALANCING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <DefineConstants>HTTP3_TESTING;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\Shared\ServiceConfigHelpers.cs" Link="Infrastructure\ServiceConfigHelpers.cs" />
     <Compile Include="..\Shared\ExceptionAssert.cs" Link="Infrastructure\ExceptionAssert.cs" />

--- a/test/FunctionalTests/Infrastructure/TestEventListener.cs
+++ b/test/FunctionalTests/Infrastructure/TestEventListener.cs
@@ -32,18 +32,23 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         private readonly List<ListenerSubscription> _subscriptions;
         private readonly ILogger _logger;
         private readonly int _eventId;
+        private readonly EventSource _eventSource;
 
-        public TestEventListener(int eventId, ILoggerFactory loggerFactory)
+        public TestEventListener(int eventId, ILoggerFactory loggerFactory, EventSource eventSource)
         {
             _eventId = eventId;
+            _eventSource = eventSource;
             _subscriptions = new List<ListenerSubscription>();
             _logger = loggerFactory.CreateLogger<TestEventListener>();
         }
 
-        public EventWrittenEventArgs? EventData { get; private set; }
-
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
+            if (eventData.EventSource != _eventSource)
+            {
+                return;
+            }
+
             // Subscriptions change on multiple threads so make a local copy
             ListenerSubscription[]? subscriptions = null;
             lock (_lock)

--- a/test/Shared/HttpEventSourceListener.cs
+++ b/test/Shared/HttpEventSourceListener.cs
@@ -39,8 +39,7 @@ namespace Grpc.Tests.Shared
         {
             base.OnEventSourceCreated(eventSource);
 
-            if (eventSource.Name.Contains("System.Net.Quic") ||
-                eventSource.Name.Contains("System.Net.Http"))
+            if (IsHttpEventSource(eventSource))
             {
                 lock (_lock)
                 {
@@ -52,9 +51,19 @@ namespace Grpc.Tests.Shared
             }
         }
 
+        private static bool IsHttpEventSource(EventSource eventSource)
+        {
+            return eventSource.Name.Contains("System.Net.Quic") || eventSource.Name.Contains("System.Net.Http");
+        }
+
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             base.OnEventWritten(eventData);
+
+            if (!IsHttpEventSource(eventData.EventSource))
+            {
+                return;
+            }
 
             string message;
             lock (_messageBuilder)


### PR DESCRIPTION
I noticed event counter tests were combining counters from client and server. This hid a bug where the exceeded deadline counter on client wasn't correctly incremented.