### PR TITLE
Fix streaming with no response messages not successful

### DIFF
--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -152,11 +152,14 @@ namespace Grpc.Net.Client.Internal.Retry
 
                     CancellationTokenSource.Token.ThrowIfCancellationRequested();
 
-                    // Check to see the response returned from the server makes the call commited
-                    // Null status code indicates the headers were valid and a "Response-Headers" response
-                    // was received from the server.
+                    // Check to see the response returned from the server makes the call commited.
+                    // 1. Null status code indicates the headers were valid and a "Response-Headers" response
+                    //    was received from the server.
+                    // 2. An OK response status at this point means a streaming call completed without
+                    //    sending any messages to the client.
+                    //
                     // https://github.com/grpc/proposal/blob/master/A6-client-retries.md#when-retries-are-valid
-                    if (responseStatus == null)
+                    if (responseStatus == null || responseStatus.GetValueOrDefault().StatusCode == StatusCode.OK)
                     {
                         // Headers were returned. We're commited.
                         CommitCall(currentCall, CommitReason.ResponseHeadersReceived);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -181,8 +181,7 @@ namespace Grpc.Net.Client.Internal.Retry
                         return;
                     }
 
-                    Status status = responseStatus.Value;
-
+                    var status = responseStatus.Value;
                     var retryPushbackMS = GetRetryPushback(httpResponse);
 
                     // Failures only count towards retry throttling if they have a known, retriable status.

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -205,8 +205,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             Assert.IsFalse(Logs.Any(l => l.EventId.Name == "DeadlineTimerRescheduled"));
 
             AssertHasLog(LogLevel.Debug, "CallCommited", "Call commited. Reason: DeadlineExceeded");
-
-            tcs.SetResult(new DataMessage());
         }
 
         [Test]

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -397,6 +397,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                     }
                 }
 
+                // Resources for past calls were successfully GCed.
                 return true;
             }, "Assert that retry call resources are released.");
         }

--- a/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
@@ -761,6 +761,75 @@ namespace Grpc.Net.Client.Tests.Retry
         }
 
         [Test]
+        public async Task AsyncUnaryCall_Success_SuccussCommitLogged()
+        {
+            // Arrange
+            var testSink = new TestSink();
+            var services = new ServiceCollection();
+            services.AddLogging(b =>
+            {
+                b.AddProvider(new TestLoggerProvider(testSink));
+            });
+            services.AddNUnitLogger();
+            var provider = services.BuildServiceProvider();
+
+            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            {
+                var content = request.Content!;
+                await content.CopyToAsync(new MemoryStream());
+
+                var reply = new HelloReply { Message = "Hello world" };
+                var streamContent = await ClientTestHelpers.CreateResponseContent(reply).DefaultTimeout();
+
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent);
+            });
+            var serviceConfig = ServiceConfigHelpers.CreateRetryServiceConfig();
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, loggerFactory: provider.GetRequiredService<ILoggerFactory>(), serviceConfig: serviceConfig);
+
+            // Act
+            var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.GetServiceMethod(MethodType.ServerStreaming), string.Empty, new CallOptions(), new HelloRequest { Name = "World" });
+            await call.ResponseAsync.DefaultTimeout();
+
+            // Assert
+            var log = testSink.Writes.Single(w => w.EventId.Name == "CallCommited");
+            Assert.AreEqual("Call commited. Reason: ResponseHeadersReceived", log.State.ToString());
+        }
+
+        [Test]
+        public async Task AsyncServerStreamingCall_NoMessagesSuccess_SuccussCommitLogged()
+        {
+            // Arrange
+            var testSink = new TestSink();
+            var services = new ServiceCollection();
+            services.AddLogging(b =>
+            {
+                b.AddProvider(new TestLoggerProvider(testSink));
+            });
+            services.AddNUnitLogger();
+            var provider = services.BuildServiceProvider();
+
+            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            {
+                var content = request.Content!;
+                await content.CopyToAsync(new MemoryStream());
+
+                return ResponseUtils.CreateHeadersOnlyResponse(HttpStatusCode.OK, StatusCode.OK);
+            });
+            var serviceConfig = ServiceConfigHelpers.CreateRetryServiceConfig();
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, loggerFactory: provider.GetRequiredService<ILoggerFactory>(), serviceConfig: serviceConfig);
+
+            // Act
+            var call = invoker.AsyncServerStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.GetServiceMethod(MethodType.ServerStreaming), string.Empty, new CallOptions(), new HelloRequest { Name = "World" });
+            var moveNextTask = call.ResponseStream.MoveNext(CancellationToken.None);
+
+            // Assert
+            Assert.IsFalse(await moveNextTask);
+
+            var log = testSink.Writes.Single(w => w.EventId.Name == "CallCommited");
+            Assert.AreEqual("Call commited. Reason: ResponseHeadersReceived", log.State.ToString());
+        }
+
+        [Test]
         public async Task AsyncServerStreamingCall_SuccessAfterRetry_RequestContentSent()
         {
             // Arrange

--- a/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
@@ -787,12 +787,47 @@ namespace Grpc.Net.Client.Tests.Retry
             var invoker = HttpClientCallInvokerFactory.Create(httpClient, loggerFactory: provider.GetRequiredService<ILoggerFactory>(), serviceConfig: serviceConfig);
 
             // Act
-            var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.GetServiceMethod(MethodType.ServerStreaming), string.Empty, new CallOptions(), new HelloRequest { Name = "World" });
+            var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.GetServiceMethod(MethodType.Unary), string.Empty, new CallOptions(), new HelloRequest { Name = "World" });
             await call.ResponseAsync.DefaultTimeout();
 
             // Assert
             var log = testSink.Writes.Single(w => w.EventId.Name == "CallCommited");
             Assert.AreEqual("Call commited. Reason: ResponseHeadersReceived", log.State.ToString());
+        }
+
+        [Test]
+        public async Task AsyncUnaryCall_NoMessagesSuccess_Failure()
+        {
+            // Arrange
+            var testSink = new TestSink();
+            var services = new ServiceCollection();
+            services.AddLogging(b =>
+            {
+                b.AddProvider(new TestLoggerProvider(testSink));
+            });
+            services.AddNUnitLogger();
+            var provider = services.BuildServiceProvider();
+
+            var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+            {
+                var content = request.Content!;
+                await content.CopyToAsync(new MemoryStream());
+
+                return ResponseUtils.CreateHeadersOnlyResponse(HttpStatusCode.OK, StatusCode.OK);
+            });
+            var serviceConfig = ServiceConfigHelpers.CreateRetryServiceConfig();
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, loggerFactory: provider.GetRequiredService<ILoggerFactory>(), serviceConfig: serviceConfig);
+
+            // Act
+            var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.GetServiceMethod(MethodType.Unary), string.Empty, new CallOptions(), new HelloRequest { Name = "World" });
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
+
+            // Assert
+            Assert.AreEqual("Failed to deserialize response message.", ex.Status.Detail);
+            Assert.AreEqual(StatusCode.Internal, ex.StatusCode);
+
+            var log = testSink.Writes.Single(w => w.EventId.Name == "CallCommited");
+            Assert.AreEqual("Call commited. Reason: FatalStatusCode", log.State.ToString());
         }
 
         [Test]


### PR DESCRIPTION
Fixes a bug I noticed while fixing https://github.com/grpc/grpc-dotnet/pull/1398

A call that doesn't return a message (e.g. a server streaming call that completes without streaming any messages) isn't recognized as successful.