### PR TITLE
Client handle server cancellation for deadline

### DIFF
--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -30,6 +30,8 @@
     <Compile Include="..\Shared\TrailingHeadersHelpers.cs" Link="Internal\Http\TrailingHeadersHelpers.cs" />
     <Compile Include="..\Shared\CompatibilityHelpers.cs" Link="Internal\CompatibilityHelpers.cs" />
     <Compile Include="..\Shared\NullableAttributes.cs" Link="Internal\NullableAttributes.cs" />
+    <Compile Include="..\Shared\Http2ErrorCode.cs" Link="Internal\Http2ErrorCode.cs" />
+    <Compile Include="..\Shared\Http3ErrorCode.cs" Link="Internal\Http3ErrorCode.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -650,7 +650,7 @@ namespace Grpc.Net.Client.Internal
                 // The server could exceed the deadline and return a CANCELLED status before the
                 // client's deadline timer is triggered. When CANCELLED is received check the
                 // deadline against the clock and change status to DEADLINE_EXCEEDED if required.
-                var deadlineExceeded = s.StatusCode == StatusCode.Cancelled && _deadline != DateTime.MaxValue && _deadline - Channel.Clock.UtcNow <= TimeSpan.Zero;
+                var deadlineExceeded = s.StatusCode == StatusCode.Cancelled && IsDeadlineExceeded();
                 if (deadlineExceeded)
                 {
                     s = new Status(StatusCode.DeadlineExceeded, s.Detail, s.DebugException);
@@ -769,7 +769,7 @@ namespace Grpc.Net.Client.Internal
                     // the client has processed that it has exceeded or not.
                     lock (this)
                     {
-                        if (_deadline <= Channel.Clock.UtcNow)
+                        if (IsDeadlineExceeded())
                         {
                             GrpcCallLog.DeadlineExceeded(Logger);
                             GrpcEventSource.Log.CallDeadlineExceeded();
@@ -810,6 +810,11 @@ namespace Grpc.Net.Client.Internal
             }
 
             return true;
+        }
+
+        private bool IsDeadlineExceeded()
+        {
+            return _deadline <= Channel.Clock.UtcNow;
         }
 
         private async Task ReadCredentials(HttpRequestMessage request)

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -448,11 +448,7 @@ namespace Grpc.Net.Client.Internal
                     }
                     catch (Exception ex)
                     {
-                        // Don't log OperationCanceledException if deadline has exceeded
-                        // or the call has been canceled.
-                        if (ex is OperationCanceledException &&
-                            _callTcs.Task.IsCompletedSuccessfully() &&
-                            (_callTcs.Task.Result.StatusCode == StatusCode.DeadlineExceeded || _callTcs.Task.Result.StatusCode == StatusCode.Cancelled))
+                        if (IsCancellationOrDeadlineException(ex))
                         {
                             throw;
                         }
@@ -594,6 +590,28 @@ namespace Grpc.Net.Client.Internal
             }
         }
 
+        private bool IsCancellationOrDeadlineException(Exception ex)
+        {
+            // Don't log OperationCanceledException if deadline has exceeded
+            // or the call has been canceled.
+            if (ex is OperationCanceledException &&
+                _callTcs.Task.IsCompletedSuccessfully() &&
+                (_callTcs.Task.Result.StatusCode == StatusCode.DeadlineExceeded || _callTcs.Task.Result.StatusCode == StatusCode.Cancelled))
+            {
+                return true;
+            }
+
+            // Exception may specify RST_STREAM or abort code that resolves to cancellation.
+            // If protocol error is cancellation and deadline has been exceeded then that
+            // means the server canceled and the local deadline timer hasn't triggered.
+            if (GrpcProtocolHelpers.ResolveRpcExceptionStatusCode(ex) == StatusCode.Cancelled)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Resolve the specified exception to an end-user exception that will be thrown from the client.
         /// The resolved exception is normally a RpcException. Returns true when the resolved exception is changed.
@@ -627,8 +645,19 @@ namespace Grpc.Net.Client.Internal
             }
             else
             {
-                status = GrpcProtocolHelpers.CreateStatusFromException(summary, ex);
-                resolvedException = CreateRpcException(status.Value);
+                var s = GrpcProtocolHelpers.CreateStatusFromException(summary, ex);
+
+                // The server could exceed the deadline and return a CANCELLED status before the
+                // client's deadline timer is triggered. When CANCELLED is received check the
+                // deadline against the clock and change status to DEADLINE_EXCEEDED if required.
+                var deadlineExceeded = s.StatusCode == StatusCode.Cancelled && _deadline != DateTime.MaxValue && _deadline - Channel.Clock.UtcNow <= TimeSpan.Zero;
+                if (deadlineExceeded)
+                {
+                    s = new Status(StatusCode.DeadlineExceeded, s.Detail, s.DebugException);
+                }
+
+                status = s;
+                resolvedException = CreateRpcException(s);
                 return true;
             }
 

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -510,6 +510,7 @@ namespace Grpc.Net.Client.Internal
 
             static StatusCode MapHttp2ErrorCodeToStatus(long protocolError)
             {
+                // Mapping from error codes to gRPC status codes is from the gRPC spec.
                 return protocolError switch
                 {
                     (long)Http2ErrorCode.NO_ERROR => StatusCode.Internal,
@@ -533,6 +534,7 @@ namespace Grpc.Net.Client.Internal
 #if NET6_0_OR_GREATER
             static StatusCode MapHttp3ErrorCodeToStatus(long protocolError)
             {
+                // Mapping from error codes to gRPC status codes is from the gRPC spec.
                 return protocolError switch
                 {
                     (long)Http3ErrorCode.H3_NO_ERROR => StatusCode.Internal,

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -419,8 +419,16 @@ namespace Grpc.Net.Client.Internal
             return true;
         }
 
+        /// <summary>
+        /// Resolve the exception from HttpClient to a gRPC status code.
+        /// <param name="ex">The <see cref="Exception"/> to resolve a <see cref="StatusCode"/> from.</param>
+        /// </summary>
         public static StatusCode ResolveRpcExceptionStatusCode(Exception ex)
         {
+            StatusCode? statusCode = null;
+            var hasIOException = false;
+            var hasSocketException = false;
+
             var current = ex;
             do
             {
@@ -431,19 +439,123 @@ namespace Grpc.Net.Client.Internal
                 {
                     // SocketError.ConnectionRefused happens when port is not available.
                     // SocketError.HostNotFound happens when unknown host is specified.
-                    return StatusCode.Unavailable;
+                    hasSocketException = true;
                 }
                 else if (current is IOException)
                 {
-                    // TODO(JamesNK): IOException is also returned for aborted requests.
-                    // Need to think about what is the best status for aborted requests.
-
                     // IOException happens if there is a protocol mismatch.
-                    return StatusCode.Unavailable;
+                    hasIOException = true;
                 }
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+                else if (current.GetType().FullName == "System.Net.Http.Http2StreamException")
+                {
+                    // Http2StreamException is private and there is no public API to get RST_STREAM error
+                    // code from public API. Parse error code from error message. This is the best option
+                    // until there is public API.
+                    if (TryGetProtocol(current.Message, out var e))
+                    {
+                        statusCode = MapHttp2ErrorCodeToStatus(e);
+                    }
+                }
+#endif
+#if NET6_0_OR_GREATER
+                else if (current.GetType().FullName == "System.Net.Quic.QuicStreamAbortedException")
+                {
+                    // QuicStreamAbortedException is private and there is no public API to get abort error
+                    // code from public API. Parse error code from error message. This is the best option
+                    // until there is public API.
+                    if (TryGetProtocol(current.Message, out var e))
+                    {
+                        statusCode = MapHttp3ErrorCodeToStatus(e);
+                    }
+                }
+#endif
             } while ((current = current.InnerException) != null);
 
-            return StatusCode.Internal;
+            if (statusCode == null && (hasSocketException || hasIOException))
+            {
+                statusCode = StatusCode.Unavailable;
+            }
+            
+            return statusCode ?? StatusCode.Internal;
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            static bool TryGetProtocol(string message, out long protocolError)
+            {
+                // Example content to parse:
+                // 1. "The HTTP/2 server reset the stream. HTTP/2 error code 'CANCEL' (0x8)."
+                // 2. "Stream aborted by peer (268)."
+                var startIndex = CompatibilityHelpers.IndexOf(message, '(', StringComparison.Ordinal);
+                var endIndex = CompatibilityHelpers.IndexOf(message, ')', StringComparison.Ordinal);
+                if (startIndex != -1 && endIndex != -1 && endIndex - startIndex > 0)
+                {
+                    var numberStyles = NumberStyles.Integer;
+                    var segment = message.Substring(startIndex + 1, endIndex - (startIndex + 1));
+                    if (segment.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                    {
+                        segment = segment.Substring(2);
+                        numberStyles = NumberStyles.HexNumber;
+                    }
+
+                    if (long.TryParse(segment, numberStyles, CultureInfo.InvariantCulture, out var i))
+                    {
+                        protocolError = i;
+                        return true;
+                    }
+                }
+
+                protocolError = -1;
+                return false;
+            }
+
+            static StatusCode MapHttp2ErrorCodeToStatus(long protocolError)
+            {
+                return protocolError switch
+                {
+                    (long)Http2ErrorCode.NO_ERROR => StatusCode.Internal,
+                    (long)Http2ErrorCode.PROTOCOL_ERROR => StatusCode.Internal,
+                    (long)Http2ErrorCode.INTERNAL_ERROR => StatusCode.Internal,
+                    (long)Http2ErrorCode.FLOW_CONTROL_ERROR => StatusCode.Internal,
+                    (long)Http2ErrorCode.SETTINGS_TIMEOUT => StatusCode.Internal,
+                    (long)Http2ErrorCode.STREAM_CLOSED => StatusCode.Internal,
+                    (long)Http2ErrorCode.FRAME_SIZE_ERROR => StatusCode.Internal,
+                    (long)Http2ErrorCode.REFUSED_STREAM => StatusCode.Unavailable,
+                    (long)Http2ErrorCode.CANCEL => StatusCode.Cancelled,
+                    (long)Http2ErrorCode.COMPRESSION_ERROR => StatusCode.Internal,
+                    (long)Http2ErrorCode.CONNECT_ERROR => StatusCode.Internal,
+                    (long)Http2ErrorCode.ENHANCE_YOUR_CALM => StatusCode.ResourceExhausted,
+                    (long)Http2ErrorCode.INADEQUATE_SECURITY => StatusCode.PermissionDenied,
+                    (long)Http2ErrorCode.HTTP_1_1_REQUIRED => StatusCode.Internal,
+                    _ => StatusCode.Internal
+                };
+            }
+#endif
+#if NET6_0_OR_GREATER
+            static StatusCode MapHttp3ErrorCodeToStatus(long protocolError)
+            {
+                return protocolError switch
+                {
+                    (long)Http3ErrorCode.H3_NO_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_GENERAL_PROTOCOL_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_INTERNAL_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_STREAM_CREATION_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_FRAME_UNEXPECTED => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_FRAME_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_EXCESSIVE_LOAD => StatusCode.ResourceExhausted,
+                    (long)Http3ErrorCode.H3_ID_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_SETTINGS_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_MISSING_SETTINGS => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_REQUEST_REJECTED => StatusCode.Unavailable,
+                    (long)Http3ErrorCode.H3_REQUEST_CANCELLED => StatusCode.Cancelled,
+                    (long)Http3ErrorCode.H3_REQUEST_INCOMPLETE => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_MESSAGE_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_CONNECT_ERROR => StatusCode.Internal,
+                    (long)Http3ErrorCode.H3_VERSION_FALLBACK => StatusCode.Internal,
+                    _ => StatusCode.Internal
+                };
+            }
+#endif
         }
 
         public static Status CreateStatusFromException(string summary, Exception ex, StatusCode? statusCode = null)

--- a/src/Grpc.Net.ClientFactory/Internal/TypeNameHelper.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/TypeNameHelper.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Grpc.Shared;
 
 namespace Grpc.Net.ClientFactory.Internal
 {
@@ -143,11 +144,7 @@ namespace Grpc.Net.ClientFactory.Internal
                 }
             }
 
-#if NETSTANDARD2_0
-            var genericPartIndex = type.Name.IndexOf('`');
-#else
-            var genericPartIndex = type.Name.IndexOf('`', StringComparison.Ordinal);
-#endif
+            var genericPartIndex = CompatibilityHelpers.IndexOf(type.Name, '`', StringComparison.Ordinal);
 
             if (genericPartIndex <= 0)
             {

--- a/src/Shared/CompatibilityHelpers.cs
+++ b/src/Shared/CompatibilityHelpers.cs
@@ -40,5 +40,14 @@ namespace Grpc.Shared
             return task.IsCompletedSuccessfully;
         }
 #endif
+
+        public static int IndexOf(string s, char value, StringComparison comparisonType)
+        {
+#if NETSTANDARD2_0
+            return s.IndexOf(value);
+#else
+            return s.IndexOf(value, comparisonType);
+#endif
+        }
     }
 }

--- a/src/Shared/Http2ErrorCode.cs
+++ b/src/Shared/Http2ErrorCode.cs
@@ -1,0 +1,38 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Grpc.Shared
+{
+    internal enum Http2ErrorCode : long
+    {
+        NO_ERROR = 0x0,
+        PROTOCOL_ERROR = 0x1,
+        INTERNAL_ERROR = 0x2,
+        FLOW_CONTROL_ERROR = 0x3,
+        SETTINGS_TIMEOUT = 0x4,
+        STREAM_CLOSED = 0x5,
+        FRAME_SIZE_ERROR = 0x6,
+        REFUSED_STREAM = 0x7,
+        CANCEL = 0x8,
+        COMPRESSION_ERROR = 0x9,
+        CONNECT_ERROR = 0xa,
+        ENHANCE_YOUR_CALM = 0xb,
+        INADEQUATE_SECURITY = 0xc,
+        HTTP_1_1_REQUIRED = 0xd,
+    }
+}

--- a/src/Shared/Http3ErrorCode.cs
+++ b/src/Shared/Http3ErrorCode.cs
@@ -1,0 +1,41 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Grpc.Shared
+{
+    internal enum Http3ErrorCode : long
+    {
+        H3_NO_ERROR = 0x100,
+        H3_GENERAL_PROTOCOL_ERROR = 0x101,
+        H3_INTERNAL_ERROR = 0x102,
+        H3_STREAM_CREATION_ERROR = 0x103,
+        H3_CLOSED_CRITICAL_STREAM = 0x104,
+        H3_FRAME_UNEXPECTED = 0x105,
+        H3_FRAME_ERROR = 0x106,
+        H3_EXCESSIVE_LOAD = 0x107,
+        H3_ID_ERROR = 0x108,
+        H3_SETTINGS_ERROR = 0x109,
+        H3_MISSING_SETTINGS = 0x10a,
+        H3_REQUEST_REJECTED = 0x10b,
+        H3_REQUEST_CANCELLED = 0x10c,
+        H3_REQUEST_INCOMPLETE = 0x10d,
+        H3_MESSAGE_ERROR = 0x10e,
+        H3_CONNECT_ERROR = 0x10f,
+        H3_VERSION_FALLBACK = 0x110,
+    }
+}

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -620,7 +620,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             await Task.Delay(100);
 
             var clientException = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
-            Assert.AreEqual(StatusCode.Unavailable, clientException.StatusCode);
+            Assert.AreEqual(StatusCode.Internal, clientException.StatusCode);
         }
 
         [TestCase(true)]
@@ -766,7 +766,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             await Task.Delay(100);
 
             var clientException = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.RequestStream.WriteAsync(new DataMessage())).DefaultTimeout();
-            Assert.AreEqual(StatusCode.Unavailable, clientException.StatusCode);
+            Assert.AreEqual(StatusCode.Internal, clientException.StatusCode);
         }
 
         [Test]


### PR DESCRIPTION
Handle the situation where the server exceeds deadline and sends RST_STREAM with status CANCELLED to the client, and the client receives it before its local timer executes.