### PR TITLE
Add more info to UserAgent header

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -22,8 +22,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using Grpc.Core;
 using Grpc.Net.Compression;
 
@@ -90,54 +88,11 @@ namespace Grpc.Net.Client.Internal
         static GrpcProtocolConstants()
         {
             UserAgentHeader = "User-Agent";
-            UserAgentHeaderValue = GetUserAgentString();
+            UserAgentHeaderValue = UserAgentGenerator.GetUserAgentString();
             TEHeader = "TE";
             TEHeaderValue = "trailers";
 
             DefaultMessageAcceptEncodingValue = GetMessageAcceptEncoding(DefaultCompressionProviders);
-        }
-
-        private static string GetUserAgentString()
-        {
-            var userAgent = "grpc-dotnet";
-
-            // Use the assembly file version in the user agent.
-            // We are not using `AssemblyInformationalVersionAttribute` because Source Link appends
-            // the git hash to it, and sending a long user agent has perf implications.
-            var assembly = typeof(GrpcProtocolConstants).Assembly;
-            var assemblyVersion = assembly
-                .GetCustomAttributes<AssemblyFileVersionAttribute>()
-                .FirstOrDefault();
-
-            Debug.Assert(assemblyVersion != null);
-
-            // Assembly file version attribute should always be present,
-            // but in case it isn't then don't include version in user-agent.
-            if (assemblyVersion != null)
-            {
-                // 1.24.0
-                userAgent += $"/{assemblyVersion.Version} ";
-            }
-
-            // (.NET 5.0.7;
-            userAgent += $"({RuntimeInformation.FrameworkDescription}; ";
-            // CLR 5.0.0;
-            userAgent += $"CLR {Environment.Version}; ";
-
-            // .NETCoreApp,Version=v6.0; 
-            var targetFramework = assembly
-                .GetCustomAttributes<TargetFrameworkAttribute>()
-                .FirstOrDefault()?
-                .FrameworkName;
-            if (!string.IsNullOrEmpty(targetFramework))
-            {
-                userAgent += $"{targetFramework}; ";
-            }
-
-            // x64)
-            userAgent += Environment.Is64BitProcess ? "x64)" : "x32)";
-
-            return userAgent;
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -22,6 +22,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Grpc.Core;
 using Grpc.Net.Compression;
 
@@ -87,13 +89,23 @@ namespace Grpc.Net.Client.Internal
 
         static GrpcProtocolConstants()
         {
+            UserAgentHeader = "User-Agent";
+            UserAgentHeaderValue = GetUserAgentString();
+            TEHeader = "TE";
+            TEHeaderValue = "trailers";
+
+            DefaultMessageAcceptEncodingValue = GetMessageAcceptEncoding(DefaultCompressionProviders);
+        }
+
+        private static string GetUserAgentString()
+        {
             var userAgent = "grpc-dotnet";
 
             // Use the assembly file version in the user agent.
             // We are not using `AssemblyInformationalVersionAttribute` because Source Link appends
             // the git hash to it, and sending a long user agent has perf implications.
-            var assemblyVersion = typeof(GrpcProtocolConstants)
-                .Assembly
+            var assembly = typeof(GrpcProtocolConstants).Assembly;
+            var assemblyVersion = assembly
                 .GetCustomAttributes<AssemblyFileVersionAttribute>()
                 .FirstOrDefault();
 
@@ -103,15 +115,29 @@ namespace Grpc.Net.Client.Internal
             // but in case it isn't then don't include version in user-agent.
             if (assemblyVersion != null)
             {
-                userAgent += "/" + assemblyVersion.Version;
+                // 1.24.0
+                userAgent += $"/{assemblyVersion.Version} ";
             }
 
-            UserAgentHeader = "User-Agent";
-            UserAgentHeaderValue = userAgent;
-            TEHeader = "TE";
-            TEHeaderValue = "trailers";
+            // (.NET 5.0.7;
+            userAgent += $"({RuntimeInformation.FrameworkDescription}; ";
+            // CLR 5.0.0;
+            userAgent += $"CLR {Environment.Version}; ";
 
-            DefaultMessageAcceptEncodingValue = GetMessageAcceptEncoding(DefaultCompressionProviders);
+            // .NETCoreApp,Version=v6.0; 
+            var targetFramework = assembly
+                .GetCustomAttributes<TargetFrameworkAttribute>()
+                .FirstOrDefault()?
+                .FrameworkName;
+            if (!string.IsNullOrEmpty(targetFramework))
+            {
+                userAgent += $"{targetFramework}; ";
+            }
+
+            // x64)
+            userAgent += Environment.Is64BitProcess ? "x64)" : "x32)";
+
+            return userAgent;
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/UserAgentGenerator.cs
+++ b/src/Grpc.Net.Client/Internal/UserAgentGenerator.cs
@@ -26,6 +26,8 @@ namespace Grpc.Net.Client.Internal
 {
     internal static class UserAgentGenerator
     {
+        internal static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+
         internal static string GetUserAgentString()
         {
             var assembly = typeof(GrpcProtocolConstants).Assembly;
@@ -42,7 +44,7 @@ namespace Grpc.Net.Client.Internal
             
             return GetUserAgentString(
                 processArch: RuntimeInformation.ProcessArchitecture,
-                runtimeVersion: IsMono() ? null : Environment.Version, 
+                runtimeVersion: IsMono ? null : Environment.Version, 
                 assemblyVersion: assemblyVersion,
                 // RuntimeInformation.FrameworkDescription is only supported for
                 // .NET Framework 4.7.1 and above. If targetting net461 or earlier,
@@ -51,10 +53,7 @@ namespace Grpc.Net.Client.Internal
                 runtimeInformation: RuntimeInformation.FrameworkDescription,
                 frameworkName: frameworkName,
                 operatingSystem: GetOS());
-
-            bool IsMono() => Type.GetType ("Mono.Runtime") != null;
         }
-
 
         // Factored out for testing
         internal static string GetUserAgentString(Architecture processArch, Version? runtimeVersion, string? assemblyVersion, string? runtimeInformation, string? frameworkName, string? operatingSystem)
@@ -74,9 +73,9 @@ namespace Grpc.Net.Client.Internal
             // x64)
             userAgent += $"{GetProcessArch(processArch)})";
 
-            string GetRuntimeVersion(Version? runtimeVersion) => runtimeVersion != null ? $"CLR {runtimeVersion}; " : string.Empty;
+            static string GetRuntimeVersion(Version? runtimeVersion) => runtimeVersion != null ? $"CLR {runtimeVersion}; " : string.Empty;
 
-            string GetProcessArch(Architecture processArch) => processArch.ToString().ToLowerInvariant();
+            static string GetProcessArch(Architecture processArch) => processArch.ToString().ToLowerInvariant();
 
             return userAgent;
         }

--- a/src/Grpc.Net.Client/Internal/UserAgentGenerator.cs
+++ b/src/Grpc.Net.Client/Internal/UserAgentGenerator.cs
@@ -1,0 +1,164 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Grpc.Net.Client.Internal
+{
+    internal static class UserAgentGenerator
+    {
+        internal static string GetUserAgentString()
+        {
+            var assembly = typeof(GrpcProtocolConstants).Assembly;
+
+            var assemblyVersion = assembly
+                .GetCustomAttributes<AssemblyInformationalVersionAttribute>()
+                .FirstOrDefault()?
+                .InformationalVersion;
+
+            var frameworkName = assembly
+                .GetCustomAttributes<TargetFrameworkAttribute>()
+                .FirstOrDefault()?
+                .FrameworkName;
+            
+            return GetUserAgentString(
+                processArch: RuntimeInformation.ProcessArchitecture,
+                runtimeVersion: IsMono() ? null : Environment.Version, 
+                assemblyVersion: assemblyVersion,
+                // RuntimeInformation.FrameworkDescription is only supported for
+                // .NET Framework 4.7.1 and above. If targetting net461 or earlier,
+                // the framework description will need to be resolved manually
+                // using reflection.
+                runtimeInformation: RuntimeInformation.FrameworkDescription,
+                frameworkName: frameworkName,
+                operatingSystem: GetOS());
+
+            bool IsMono() => Type.GetType ("Mono.Runtime") != null;
+        }
+
+
+        // Factored out for testing
+        internal static string GetUserAgentString(Architecture processArch, Version? runtimeVersion, string? assemblyVersion, string? runtimeInformation, string? frameworkName, string? operatingSystem)
+        {
+            var userAgent = "grpc-dotnet";
+
+            // /2.41.0-dev
+            userAgent += $"{GetGrpcDotNetVersion(assemblyVersion)} ";
+            // (.NET 5.0.7;
+            userAgent += $"({GetFrameworkDescription(runtimeInformation)}";
+            // CLR 5.0.0;
+            userAgent += GetRuntimeVersion(runtimeVersion);
+            // net6.0;
+            userAgent += GetFrameworkName(frameworkName);
+            // windows  
+            userAgent += $"{operatingSystem} ";
+            // x64)
+            userAgent += $"{GetProcessArch(processArch)})";
+
+            string GetRuntimeVersion(Version? runtimeVersion) => runtimeVersion != null ? $"CLR {runtimeVersion}; " : string.Empty;
+
+            string GetProcessArch(Architecture processArch) => processArch.ToString().ToLowerInvariant();
+
+            return userAgent;
+        }
+
+        private static string GetGrpcDotNetVersion(string? assemblyVersion)
+        {
+            // Assembly file version attribute should always be present,
+            // but in case it isn't then don't include version in user-agent.
+            if (!string.IsNullOrEmpty(assemblyVersion))
+            {
+                // Strip the git hash if there is one
+                int plusIndex = assemblyVersion!.IndexOf("+", StringComparison.Ordinal);
+                if (plusIndex != -1)
+                {
+                    assemblyVersion = assemblyVersion.Substring(0, plusIndex);
+                }
+                // /2.41.0-dev
+                return $"/{assemblyVersion}";
+            }
+
+            return string.Empty;
+        }
+
+        private static string GetOS()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "windows";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "osx";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "linux";
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        // Maps ".NETCoreApp,Version=v6.0;" to "net6.0"
+        private static string GetFrameworkName(string? frameworkName)
+        {
+            if (string.IsNullOrEmpty(frameworkName))
+            {
+                return string.Empty;
+            }
+
+            var splitFramework = frameworkName!.Split(',');
+            var version = Version.Parse(splitFramework[1].Substring("Version=v".Length));
+            var name = splitFramework[0] switch {
+                ".NETCoreApp" when version.Major < 5 => $"netcoreapp{version.ToString(2)}",
+                ".NETCoreApp" when version.Major >= 5 => $"net{version.ToString(2)}",
+#if !NETSTANDARD2_0
+                ".NETFramework" => $"net{version.ToString().Replace(".", string.Empty, StringComparison.OrdinalIgnoreCase)}",
+#else
+                ".NETFramework" => $"net{version.ToString().Replace(".", string.Empty)}",
+#endif
+                ".NETStandard" => $"netstandard{version.ToString(2)}",
+                _ => frameworkName
+            };
+
+            return $"{name}; ";
+        }
+
+        private static string GetFrameworkDescription(string? frameworkDescription)
+        {
+            if (!string.IsNullOrEmpty(frameworkDescription))
+            {
+                // FrameworkDescription is typically represented as {FrameworkName} {VersionString}
+                // where VersionString is optional and variable.
+                var splitFrameworkDescription = frameworkDescription!.Split(' ');
+                if (splitFrameworkDescription.Length == 1)
+                {
+                    return $"{splitFrameworkDescription[0]}; ";
+                }
+                return $"{splitFrameworkDescription[0]} {splitFrameworkDescription[1]}; ";
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Greet;
@@ -76,14 +77,18 @@ namespace Grpc.Net.Client.Tests
             Assert.AreEqual("identity,gzip", httpRequestMessage.Headers.GetValues(GrpcProtocolConstants.MessageAcceptEncodingHeader).Single());
             Assert.AreEqual(null, requestContentLength);
 
-            var userAgent = httpRequestMessage.Headers.UserAgent.Single()!;
-            Assert.AreEqual("grpc-dotnet", userAgent.Product?.Name);
-            Assert.IsTrue(!string.IsNullOrEmpty(userAgent.Product?.Version));
+            var grpcVersion = httpRequestMessage.Headers.UserAgent.First();
+            Assert.AreEqual("grpc-dotnet", grpcVersion.Product?.Name);
+            Assert.IsTrue(!string.IsNullOrEmpty(grpcVersion.Product?.Version));
 
             // Santity check that the user agent doesn't have the git hash in it and isn't too long.
             // Sending a long user agent with each call has performance implications.
-            Assert.IsFalse(userAgent.Product!.Version!.Contains('+'));
-            Assert.IsTrue(userAgent.Product!.Version!.Length <= 10);
+            Assert.IsFalse(grpcVersion.Product!.Version!.Contains('+'));
+            Assert.IsTrue(grpcVersion.Product!.Version!.Length <= 10);
+
+            var runtimeIdentifier = httpRequestMessage.Headers.UserAgent.Last()?.Comment;
+            Assert.IsNotEmpty(runtimeIdentifier); // Should be set
+            Assert.IsTrue(runtimeIdentifier!.Contains(RuntimeInformation.FrameworkDescription));
         }
 
         [Test]

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -85,10 +85,6 @@ namespace Grpc.Net.Client.Tests
             // Sending a long user agent with each call has performance implications.
             Assert.IsFalse(grpcVersion.Product!.Version!.Contains('+'));
             Assert.IsTrue(grpcVersion.Product!.Version!.Length <= 10);
-
-            var runtimeIdentifier = httpRequestMessage.Headers.UserAgent.Last()?.Comment;
-            Assert.IsNotEmpty(runtimeIdentifier); // Should be set
-            Assert.IsTrue(runtimeIdentifier!.Contains(RuntimeInformation.FrameworkDescription));
         }
 
         [Test]

--- a/test/Grpc.Net.Client.Tests/UserAgentGeneratorTests.cs
+++ b/test/Grpc.Net.Client.Tests/UserAgentGeneratorTests.cs
@@ -1,0 +1,134 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Runtime.InteropServices;
+using Grpc.Net.Client.Internal;
+using NUnit.Framework;
+
+namespace Grpc.Net.Client.Tests
+{
+    [TestFixture]
+    public class UserAgentGeneratorTests
+    {
+        [Test]
+        public void HandlesNetFrameworkTarget()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.X64,
+                runtimeVersion: Version.Parse("5.0.7"),
+                assemblyVersion: "2.4.1",
+                runtimeInformation: ".NET 5.0.7",
+                frameworkName: ".NETFramework,Version=v4.6.1",
+                operatingSystem: "osx");
+            Assert.AreEqual($"grpc-dotnet/2.4.1 (.NET 5.0.7; CLR 5.0.7; net461; osx x64)", userAgent);
+        }
+
+        [Test]
+        public void HandlesNetCoreAppTarget()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.X64,
+                runtimeVersion: Version.Parse("5.0.7"),
+                assemblyVersion: "2.4.1",
+                runtimeInformation: ".NET 5.0.7",
+                frameworkName: ".NETCoreApp,Version=v2.2",
+                operatingSystem: "osx");
+            Assert.AreEqual($"grpc-dotnet/2.4.1 (.NET 5.0.7; CLR 5.0.7; netcoreapp2.2; osx x64)", userAgent);
+        }
+
+        [Test]
+        public void HandlesNetStandardTarget()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.X64,
+                runtimeVersion: Version.Parse("5.0.7"),
+                assemblyVersion: "2.4.1",
+                runtimeInformation: ".NET 5.0.7",
+                frameworkName: ".NETStandard,Version=v2.0",
+                operatingSystem: "osx");
+            Assert.AreEqual($"grpc-dotnet/2.4.1 (.NET 5.0.7; CLR 5.0.7; netstandard2.0; osx x64)", userAgent);
+        }
+
+        [Test]
+        public void HandlesVersionWithGitHash()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.X64,
+                runtimeVersion: Version.Parse("5.0.7"),
+                assemblyVersion: "2.4.1-dev+5325faf",
+                runtimeInformation: ".NET 5.0.7",
+                frameworkName: ".NETStandard,Version=v2.0",
+                operatingSystem: "osx");
+            Assert.AreEqual($"grpc-dotnet/2.4.1-dev (.NET 5.0.7; CLR 5.0.7; netstandard2.0; osx x64)", userAgent);
+        }
+
+        [Test]
+        public void HandlesNoVersion()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.X64,
+                runtimeVersion: Version.Parse("5.0.7"),
+                assemblyVersion: string.Empty,
+                runtimeInformation: ".NET 5.0.7",
+                frameworkName: ".NETStandard,Version=v2.0",
+                operatingSystem: "osx");
+            Assert.AreEqual($"grpc-dotnet (.NET 5.0.7; CLR 5.0.7; netstandard2.0; osx x64)", userAgent);
+        }
+
+        [Test]
+        public void HandlesNoTargetFramework()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.X64,
+                runtimeVersion: Version.Parse("5.0.7"),
+                assemblyVersion: string.Empty,
+                runtimeInformation: ".NET 5.0.7",
+                frameworkName: string.Empty,
+                operatingSystem: "osx");
+            Assert.AreEqual($"grpc-dotnet (.NET 5.0.7; CLR 5.0.7; osx x64)", userAgent);
+        }
+
+        [Test]
+        public void HandlesNoRuntimeInfo()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.Arm64,
+                runtimeVersion: Version.Parse("5.0.7"),
+                assemblyVersion: string.Empty,
+                runtimeInformation: string.Empty,
+                frameworkName: string.Empty,
+                operatingSystem: "windows");
+            Assert.AreEqual($"grpc-dotnet (CLR 5.0.7; windows arm64)", userAgent);
+        }
+
+        [Test]
+        public void HandlesMonoRuntimeInfo()
+        {
+            var userAgent = UserAgentGenerator.GetUserAgentString(
+                processArch: Architecture.X64,
+                runtimeVersion: null,
+                assemblyVersion: string.Empty,
+                runtimeInformation: "Mono 6.12.0.140 (2020-02/51d876a041e Thu Apr 29 10:44:55 EDT 2021)",
+                frameworkName: string.Empty,
+                operatingSystem: "osx");
+            Assert.AreEqual($"grpc-dotnet (Mono 6.12.0.140; osx x64)", userAgent);
+            
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1392.

User agent string prior to this change: grpc-dotnet/2.41.0.0 
User agent string with this change: grpc-dotnet/2.4.1.0.0 (.NET 5.0.7; CLR 5.0.7; net461; osx x64)