### PR TITLE
Fix combining auth and retry

### DIFF
--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -60,151 +60,157 @@ namespace Grpc.Net.Client.Internal.Retry
 
         private async Task StartCall(Action<GrpcCall<TRequest, TResponse>> startCallFunc)
         {
-            GrpcCall<TRequest, TResponse> call;
-            lock (Lock)
-            {
-                if (CommitedCallTask.IsCompletedSuccessfully())
-                {
-                    // Call has already been commited. This could happen if written messages exceed
-                    // buffer limits, which causes the call to immediately become commited and to clear buffers.
-                    return;
-                }
+            GrpcCall<TRequest, TResponse>? call = null;
 
-                OnStartingAttempt();
-
-                call = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount);
-                _activeCalls.Add(call);
-
-                startCallFunc(call);
-
-                SetNewActiveCallUnsynchronized(call);
-            }
-
-            Status? responseStatus;
-
-            HttpResponseMessage? httpResponse = null;
             try
             {
-                if (call._httpResponseTask == null)
+                lock (Lock)
                 {
-                    // There is no response task if there was a preemptive cancel.
-                    CompatibilityHelpers.Assert(call.CancellationToken.IsCancellationRequested, "Request should have been made if call is not preemptively cancelled.");
-                    call.CancellationToken.ThrowIfCancellationRequested();
+                    if (CommitedCallTask.IsCompletedSuccessfully())
+                    {
+                        // Call has already been commited. This could happen if written messages exceed
+                        // buffer limits, which causes the call to immediately become commited and to clear buffers.
+                        return;
+                    }
+
+                    OnStartingAttempt();
+
+                    call = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount);
+                    _activeCalls.Add(call);
+
+                    startCallFunc(call);
+
+                    SetNewActiveCallUnsynchronized(call);
                 }
 
-                httpResponse = await call._httpResponseTask!.ConfigureAwait(false);
-                responseStatus = GrpcCall.ValidateHeaders(httpResponse, out _);
-            }
-            catch (RpcException ex)
-            {
-                // A "drop" result from the load balancer should immediately stop the call,
-                // including ignoring the retry policy.
-                var dropValue = ex.Trailers.GetValue(GrpcProtocolConstants.DropRequestTrailer);
-                if (dropValue != null && bool.TryParse(dropValue, out var isDrop) && isDrop)
+                Status? responseStatus;
+
+                HttpResponseMessage? httpResponse = null;
+                try
                 {
-                    CommitCall(call, CommitReason.Drop);
+                    httpResponse = await call.HttpResponseTask.ConfigureAwait(false);
+                    responseStatus = GrpcCall.ValidateHeaders(httpResponse, out _);
+                }
+                catch (RpcException ex)
+                {
+                    // A "drop" result from the load balancer should immediately stop the call,
+                    // including ignoring the retry policy.
+                    var dropValue = ex.Trailers.GetValue(GrpcProtocolConstants.DropRequestTrailer);
+                    if (dropValue != null && bool.TryParse(dropValue, out var isDrop) && isDrop)
+                    {
+                        CommitCall(call, CommitReason.Drop);
+                        return;
+                    }
+
+                    call.ResolveException(GrpcCall<TRequest, TResponse>.ErrorStartingCallMessage, ex, out responseStatus, out _);
+                }
+                catch (Exception ex)
+                {
+                    call.ResolveException(GrpcCall<TRequest, TResponse>.ErrorStartingCallMessage, ex, out responseStatus, out _);
+                }
+
+                if (CancellationTokenSource.IsCancellationRequested)
+                {
+                    if (IsDeadlineExceeded())
+                    {
+                        CommitCall(CreateStatusCall(new Status(StatusCode.DeadlineExceeded, string.Empty)), CommitReason.DeadlineExceeded);
+                    }
+                    else
+                    {
+                        CommitCall(CreateStatusCall(new Status(StatusCode.Cancelled, string.Empty)), CommitReason.Canceled);
+                    }
                     return;
                 }
 
-                call.ResolveException(GrpcCall<TRequest, TResponse>.ErrorStartingCallMessage, ex, out responseStatus, out _);
-            }
-            catch (Exception ex)
-            {
-                call.ResolveException(GrpcCall<TRequest, TResponse>.ErrorStartingCallMessage, ex, out responseStatus, out _);
-            }
-
-            if (CancellationTokenSource.IsCancellationRequested)
-            {
-                CommitCall(call, CommitReason.Canceled);
-                return;
-            }
-
-            // Check to see the response returned from the server makes the call commited
-            // Null status code indicates the headers were valid and a "Response-Headers" response
-            // was received from the server.
-            // https://github.com/grpc/proposal/blob/master/A6-client-retries.md#when-retries-are-valid
-            if (responseStatus == null)
-            {
-                // Headers were returned. We're commited.
-                CommitCall(call, CommitReason.ResponseHeadersReceived);
-
-                // Wait until the call has finished and then check its status code
-                // to update retry throttling tokens.
-                var status = await call.CallTask.ConfigureAwait(false);
-                if (status.StatusCode == StatusCode.OK)
+                // Check to see the response returned from the server makes the call commited
+                // Null status code indicates the headers were valid and a "Response-Headers" response
+                // was received from the server.
+                // https://github.com/grpc/proposal/blob/master/A6-client-retries.md#when-retries-are-valid
+                if (responseStatus == null)
                 {
-                    RetryAttemptCallSuccess();
-                }
-            }
-            else
-            {
-                var status = responseStatus.Value;
+                    // Headers were returned. We're commited.
+                    CommitCall(call, CommitReason.ResponseHeadersReceived);
 
-                var retryPushbackMS = GetRetryPushback(httpResponse);
-
-                if (retryPushbackMS < 0)
-                {
-                    RetryAttemptCallFailure();
-                }
-                else if (_hedgingPolicy.NonFatalStatusCodes.Contains(status.StatusCode))
-                {
-                    // Needs to happen before interrupt.
-                    RetryAttemptCallFailure();
-
-                    // No need to interrupt if we started with no delay and all calls
-                    // have already been made when hedging starting.
-                    if (_delayInterruptTcs != null)
+                    // Wait until the call has finished and then check its status code
+                    // to update retry throttling tokens.
+                    var status = await call.CallTask.ConfigureAwait(false);
+                    if (status.StatusCode == StatusCode.OK)
                     {
-                        lock (Lock)
+                        RetryAttemptCallSuccess();
+                    }
+                }
+                else
+                {
+                    var status = responseStatus.Value;
+
+                    var retryPushbackMS = GetRetryPushback(httpResponse);
+
+                    if (retryPushbackMS < 0)
+                    {
+                        RetryAttemptCallFailure();
+                    }
+                    else if (_hedgingPolicy.NonFatalStatusCodes.Contains(status.StatusCode))
+                    {
+                        // Needs to happen before interrupt.
+                        RetryAttemptCallFailure();
+
+                        // No need to interrupt if we started with no delay and all calls
+                        // have already been made when hedging starting.
+                        if (_delayInterruptTcs != null)
                         {
-                            if (retryPushbackMS >= 0)
+                            lock (Lock)
                             {
-                                _pushbackDelay = TimeSpan.FromMilliseconds(retryPushbackMS.GetValueOrDefault());
+                                if (retryPushbackMS >= 0)
+                                {
+                                    _pushbackDelay = TimeSpan.FromMilliseconds(retryPushbackMS.GetValueOrDefault());
+                                }
+                                _delayInterruptTcs.TrySetResult(null);
                             }
-                            _delayInterruptTcs.TrySetResult(null);
+                        }
+                    }
+                    else
+                    {
+                        CommitCall(call, CommitReason.FatalStatusCode);
+                    }
+                }
+
+                lock (Lock)
+                {
+                    if (IsDeadlineExceeded())
+                    {
+                        // Deadline has been exceeded so immediately commit call.
+                        CommitCall(call, CommitReason.DeadlineExceeded);
+                    }
+                    else if (_activeCalls.Count == 1 && AttemptCount >= MaxRetryAttempts)
+                    {
+                        // This is the last active call and no more will be made.
+                        CommitCall(call, CommitReason.ExceededAttemptCount);
+                    }
+                    else if (_activeCalls.Count == 1 && IsRetryThrottlingActive())
+                    {
+                        // This is the last active call and throttling is active.
+                        CommitCall(call, CommitReason.Throttled);
+                    }
+                    else
+                    {
+                        // Call isn't used and can be cancelled.
+                        // Note that the call could have already been removed and disposed if the
+                        // hedging call has been finalized or disposed.
+                        if (_activeCalls.Remove(call))
+                        {
+                            call.Dispose();
                         }
                     }
                 }
-                else
-                {
-                    CommitCall(call, CommitReason.FatalStatusCode);
-                }
             }
-
-            lock (Lock)
+            finally
             {
-                if (IsDeadlineExceeded())
+                if (CommitedCallTask.IsCompletedSuccessfully() && CommitedCallTask.Result == call)
                 {
-                    // Deadline has been exceeded so immediately commit call.
-                    CommitCall(call, CommitReason.DeadlineExceeded);
+                    // Wait until the commited call is finished and then clean up hedging call.
+                    await call.CallTask.ConfigureAwait(false);
+                    Cleanup();
                 }
-                else if (_activeCalls.Count == 1 && AttemptCount >= MaxRetryAttempts)
-                {
-                    // This is the last active call and no more will be made.
-                    CommitCall(call, CommitReason.ExceededAttemptCount);
-                }
-                else if (_activeCalls.Count == 1 && IsRetryThrottlingActive())
-                {
-                    // This is the last active call and throttling is active.
-                    CommitCall(call, CommitReason.Throttled);
-                }
-                else
-                {
-                    // Call isn't used and can be cancelled.
-                    // Note that the call could have already been removed and disposed if the
-                    // hedging call has been finalized or disposed.
-                    if (_activeCalls.Remove(call))
-                    {
-                        call.Dispose();
-                    }
-                }
-            }
-
-            if (CommitedCallTask.IsCompletedSuccessfully() && CommitedCallTask.Result == call)
-            {
-                // Wait until the commited call is finished and then clean up hedging call.
-                await call.CallTask.ConfigureAwait(false);
-                Cleanup();
             }
         }
 
@@ -275,7 +281,7 @@ namespace Grpc.Net.Client.Internal.Retry
 
                     if (IsDeadlineExceeded())
                     {
-                        CommitCall(new StatusGrpcCall<TRequest, TResponse>(new Status(StatusCode.DeadlineExceeded, string.Empty)), CommitReason.DeadlineExceeded);
+                        CommitCall(CreateStatusCall(new Status(StatusCode.DeadlineExceeded, string.Empty)), CommitReason.DeadlineExceeded);
                         break;
                     }
                     else

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -114,14 +114,14 @@ namespace Grpc.Net.Client.Internal.Retry
                         currentCall = _activeCall = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount);
                         startCallFunc(currentCall);
 
+                        SetNewActiveCallUnsynchronized(currentCall);
+
                         if (CommitedCallTask.IsCompletedSuccessfully())
                         {
                             // Call has already been commited. This could happen if written messages exceed
                             // buffer limits, which causes the call to immediately become commited and to clear buffers.
                             return;
                         }
-
-                        SetNewActiveCallUnsynchronized(currentCall);
                     }
 
                     Status? responseStatus;

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -129,14 +129,7 @@ namespace Grpc.Net.Client.Internal.Retry
                     HttpResponseMessage? httpResponse = null;
                     try
                     {
-                        if (currentCall._httpResponseTask == null)
-                        {
-                            // There is no response task if there was a preemptive cancel.
-                            CompatibilityHelpers.Assert(currentCall.CancellationToken.IsCancellationRequested, "Request should have been made if call is not preemptively cancelled.");
-                            currentCall.CancellationToken.ThrowIfCancellationRequested();
-                        }
-
-                        httpResponse = await currentCall._httpResponseTask!.ConfigureAwait(false);
+                        httpResponse = await currentCall.HttpResponseTask.ConfigureAwait(false);
                         responseStatus = GrpcCall.ValidateHeaders(httpResponse, out _);
                     }
                     catch (RpcException ex)

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -370,8 +370,7 @@ namespace Grpc.Net.Client.Internal.Retry
 
         protected void SetNewActiveCallUnsynchronized(IGrpcCall<TRequest, TResponse> call)
         {
-            Debug.Assert(!CommitedCallTask.IsCompletedSuccessfully());
-            Debug.Assert(Monitor.IsEntered(Lock));
+            Debug.Assert(Monitor.IsEntered(Lock), "Should be called with lock.");
 
             if (NewActiveCallTcs != null)
             {

--- a/test/Grpc.Net.Client.Tests/LoggingTests.cs
+++ b/test/Grpc.Net.Client.Tests/LoggingTests.cs
@@ -61,19 +61,21 @@ namespace Grpc.Net.Client.Tests
             // Assert
             Assert.AreEqual("Hello world", rs.Message);
 
-            var logs = testSink.Writes.Where(w => w.LogLevel >= Microsoft.Extensions.Logging.LogLevel.Debug).ToList();
+            var log = testSink.Writes.Single(w => w.EventId.Name == "StartingCall");
+            Assert.AreEqual("Starting gRPC call. Method type: 'Unary', URI: 'https://localhost/ServiceName/MethodName'.", log.State.ToString());
+            AssertScope(log);
 
-            Assert.AreEqual("Starting gRPC call. Method type: 'Unary', URI: 'https://localhost/ServiceName/MethodName'.", logs[0].State.ToString());
-            AssertScope(logs[0]);
+            log = testSink.Writes.Single(w => w.EventId.Name == "SendingMessage");
+            Assert.AreEqual("Sending message.", log.State.ToString());
+            AssertScope(log);
 
-            Assert.AreEqual("Sending message.", logs[1].State.ToString());
-            AssertScope(logs[1]);
+            log = testSink.Writes.Single(w => w.EventId.Name == "ReadingMessage");
+            Assert.AreEqual("Reading message.", log.State.ToString());
+            AssertScope(log);
 
-            Assert.AreEqual("Reading message.", logs[2].State.ToString());
-            AssertScope(logs[2]);
-
-            Assert.AreEqual("Finished gRPC call.", logs[3].State.ToString());
-            AssertScope(logs[3]);
+            log = testSink.Writes.Single(w => w.EventId.Name == "FinishedCall");
+            Assert.AreEqual("Finished gRPC call.", log.State.ToString());
+            AssertScope(log);
 
             static void AssertScope(WriteContext log)
             {

--- a/test/Grpc.Net.Client.Tests/Retry/HedgingTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/HedgingTests.cs
@@ -32,6 +32,9 @@ using Grpc.Net.Client.Internal;
 using Grpc.Net.Client.Internal.Http;
 using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using NUnit.Framework;
 
 namespace Grpc.Net.Client.Tests.Retry
@@ -279,6 +282,15 @@ namespace Grpc.Net.Client.Tests.Retry
         public async Task AsyncUnaryCall_ExceedDeadlineWithActiveCalls_Failure()
         {
             // Arrange
+            var testSink = new TestSink();
+            var services = new ServiceCollection();
+            services.AddLogging(b =>
+            {
+                b.AddProvider(new TestLoggerProvider(testSink));
+            });
+            services.AddNUnitLogger();
+            var provider = services.BuildServiceProvider();
+
             var tcs = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var callCount = 0;
@@ -288,7 +300,7 @@ namespace Grpc.Net.Client.Tests.Retry
                 return tcs.Task;
             });
             var serviceConfig = ServiceConfigHelpers.CreateHedgingServiceConfig(hedgingDelay: TimeSpan.FromMilliseconds(200));
-            var invoker = HttpClientCallInvokerFactory.Create(httpClient, serviceConfig: serviceConfig);
+            var invoker = HttpClientCallInvokerFactory.Create(httpClient, loggerFactory: provider.GetRequiredService<ILoggerFactory>(), serviceConfig: serviceConfig);
 
             // Act
             var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(deadline: DateTime.UtcNow.AddMilliseconds(100)), new HelloRequest { Name = "World" });
@@ -298,6 +310,9 @@ namespace Grpc.Net.Client.Tests.Retry
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
             Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
             Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+
+            var write = testSink.Writes.Single(w => w.EventId.Name == "CallCommited");
+            Assert.AreEqual("Call commited. Reason: DeadlineExceeded", write.State.ToString());
         }
 
         [Test]

--- a/test/Shared/TestHttpMessageHandler.cs
+++ b/test/Shared/TestHttpMessageHandler.cs
@@ -34,7 +34,15 @@ namespace Grpc.Tests.Shared
 
         public static TestHttpMessageHandler Create(Func<HttpRequestMessage, Task<HttpResponseMessage>> sendAsync)
         {
-            return new TestHttpMessageHandler((request, cancellationToken) => sendAsync(request));
+            var tcs = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            return new TestHttpMessageHandler(async (request, cancellationToken) =>
+            {
+                using var registration = cancellationToken.Register(() => tcs.TrySetCanceled());
+
+                var result = await Task.WhenAny(sendAsync(request), tcs.Task);
+                return await result;
+            });
         }
 
         public static TestHttpMessageHandler Create(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1406

Adds a `TaskCompletionSource<HttpResponseMessage>` so that the task to get the response is never null.

Best reviewed with hide whitespace enabled.