### PR TITLE
Allow libraries to access the gRPC request handlers without reflection

### DIFF
--- a/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddRouting();
             services.AddOptions();
             services.TryAddSingleton<GrpcMarkerService>();
-            services.TryAddSingleton(typeof(ServerCallHandlerFactory<>));
+            services.TryAddSingleton(typeof(IGrpcCallHandlerFactory<>), typeof(ServerCallHandlerFactory<>));
             services.TryAddSingleton(typeof(IGrpcServiceActivator<>), typeof(DefaultGrpcServiceActivator<>));
             services.TryAddSingleton(typeof(IGrpcInterceptorActivator<>), typeof(DefaultGrpcInterceptorActivator<>));
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<GrpcServiceOptions>, GrpcServiceOptionsSetup>());

--- a/src/Grpc.AspNetCore.Server/IGrpcCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/IGrpcCallHandlerFactory.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Grpc.AspNetCore.Server.Model;
+using Grpc.Core;
+using Grpc.Shared.Server;
+using Microsoft.AspNetCore.Http;
+
+namespace Grpc.AspNetCore.Server
+{
+    /// <summary>
+    /// Extension point allowing libraries to access the gRPC request handlers without reflection
+    /// </summary>
+    /// <typeparam name="TService">The service type</typeparam>
+    public interface IGrpcCallHandlerFactory<TService>
+        where TService : class
+    {
+        /// <summary>
+        /// Indicates whether unknown services are ignored
+        /// </summary>
+        bool IgnoreUnknownServices { get; }
+
+        /// <summary>
+        /// Indicates whether unknown methods are ignored
+        /// </summary>
+        bool IgnoreUnknownMethods { get; }
+
+        /// <summary>
+        /// Creates a request delegate for a unary method
+        /// </summary>
+        /// <typeparam name="TRequest">Request message type for this method.</typeparam>
+        /// <typeparam name="TResponse">Response message type for this method.</typeparam>
+        /// <param name="method">The method description.</param>
+        /// <param name="invoker">The method invoker that is executed when the method is called.</param>
+        /// <returns>An ASP.NET Core Request handler</returns>
+        RequestDelegate CreateUnary<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, UnaryServerMethod<TService, TRequest, TResponse> invoker)
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
+        /// Creates a request delegate for a server streaming method
+        /// </summary>
+        /// <typeparam name="TRequest">Request message type for this method.</typeparam>
+        /// <typeparam name="TResponse">Response message type for this method.</typeparam>
+        /// <param name="method">The method description.</param>
+        /// <param name="invoker">The method invoker that is executed when the method is called.</param>
+        /// <returns>An ASP.NET Core Request handler</returns>
+        RequestDelegate CreateServerStreaming<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, ServerStreamingServerMethod<TService, TRequest, TResponse> invoker)
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
+        /// Creates a request delegate for a client streaming method
+        /// </summary>
+        /// <typeparam name="TRequest">Request message type for this method.</typeparam>
+        /// <typeparam name="TResponse">Response message type for this method.</typeparam>
+        /// <param name="method">The method description.</param>
+        /// <param name="invoker">The method invoker that is executed when the method is called.</param>
+        /// <returns>An ASP.NET Core Request handler</returns>
+        RequestDelegate CreateClientStreaming<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, ClientStreamingServerMethod<TService, TRequest, TResponse> invoker)
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
+        /// Creates a request delegate for a duplex streaming method
+        /// </summary>
+        /// <typeparam name="TRequest">Request message type for this method.</typeparam>
+        /// <typeparam name="TResponse">Response message type for this method.</typeparam>
+        /// <param name="method">The method description.</param>
+        /// <param name="invoker">The method invoker that is executed when the method is called.</param>
+        /// <returns>An ASP.NET Core Request handler</returns>
+        RequestDelegate CreateDuplexStreaming<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TService, TRequest, TResponse> invoker)
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
+        /// Creates a request handler for an unimplemented method
+        /// </summary>
+        /// <returns>An ASP.NET Core Request handler</returns>
+        RequestDelegate CreateUnimplementedMethod();
+
+        /// <summary>
+        /// Creates a request handler for an unimplemented service
+        /// </summary>
+        /// <returns>An ASP.NET Core Request handler</returns>
+        RequestDelegate CreateUnimplementedService();
+    }
+}

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -32,7 +32,7 @@ namespace Grpc.AspNetCore.Server.Internal
     /// <summary>
     /// Creates server call handlers. Provides a place to get services that call handlers will use.
     /// </summary>
-    internal partial class ServerCallHandlerFactory<TService> where TService : class
+    internal partial class ServerCallHandlerFactory<TService> : IGrpcCallHandlerFactory<TService> where TService : class
     {
         private readonly ILoggerFactory _loggerFactory;
         private readonly IGrpcServiceActivator<TService> _serviceActivator;
@@ -57,44 +57,48 @@ namespace Grpc.AspNetCore.Server.Internal
             return MethodOptions.Create(new[] { _globalOptions, _serviceOptions });
         }
 
-        public UnaryServerCallHandler<TService, TRequest, TResponse> CreateUnary<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TService, TRequest, TResponse> invoker)
+        public RequestDelegate CreateUnary<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
             var options = CreateMethodOptions();
             var methodInvoker = new UnaryServerMethodInvoker<TService, TRequest, TResponse>(invoker, method, options, _serviceActivator);
 
-            return new UnaryServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            var handler = new UnaryServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            return handler.HandleCallAsync;
         }
 
-        public ClientStreamingServerCallHandler<TService, TRequest, TResponse> CreateClientStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TService, TRequest, TResponse> invoker)
+        public RequestDelegate CreateClientStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
             var options = CreateMethodOptions();
             var methodInvoker = new ClientStreamingServerMethodInvoker<TService, TRequest, TResponse>(invoker, method, options, _serviceActivator);
 
-            return new ClientStreamingServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            var handler = new ClientStreamingServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            return handler.HandleCallAsync;
         }
 
-        public DuplexStreamingServerCallHandler<TService, TRequest, TResponse> CreateDuplexStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TService, TRequest, TResponse> invoker)
+        public RequestDelegate CreateDuplexStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
             var options = CreateMethodOptions();
             var methodInvoker = new DuplexStreamingServerMethodInvoker<TService, TRequest, TResponse>(invoker, method, options, _serviceActivator);
 
-            return new DuplexStreamingServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            var handler = new DuplexStreamingServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            return handler.HandleCallAsync;
         }
 
-        public ServerStreamingServerCallHandler<TService, TRequest, TResponse> CreateServerStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TService, TRequest, TResponse> invoker)
+        public RequestDelegate CreateServerStreaming<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TService, TRequest, TResponse> invoker)
             where TRequest : class
             where TResponse : class
         {
             var options = CreateMethodOptions();
             var methodInvoker = new ServerStreamingServerMethodInvoker<TService, TRequest, TResponse>(invoker, method, options, _serviceActivator);
 
-            return new ServerStreamingServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            var handler = new ServerStreamingServerCallHandler<TService, TRequest, TResponse>(methodInvoker, _loggerFactory);
+            return handler.HandleCallAsync;
         }
 
         public RequestDelegate CreateUnimplementedMethod()

--- a/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
@@ -34,13 +34,13 @@ namespace Grpc.AspNetCore.Server.Model.Internal
     internal class ServiceRouteBuilder<TService> where TService : class
     {
         private readonly IEnumerable<IServiceMethodProvider<TService>> _serviceMethodProviders;
-        private readonly ServerCallHandlerFactory<TService> _serverCallHandlerFactory;
+        private readonly IGrpcCallHandlerFactory<TService> _serverCallHandlerFactory;
         private readonly ServiceMethodsRegistry _serviceMethodsRegistry;
         private readonly ILogger _logger;
 
         public ServiceRouteBuilder(
             IEnumerable<IServiceMethodProvider<TService>> serviceMethodProviders,
-            ServerCallHandlerFactory<TService> serverCallHandlerFactory,
+            IGrpcCallHandlerFactory<TService> serverCallHandlerFactory,
             ServiceMethodsRegistry serviceMethodsRegistry,
             ILoggerFactory loggerFactory)
         {
@@ -103,7 +103,7 @@ namespace Grpc.AspNetCore.Server.Model.Internal
         internal static void CreateUnimplementedEndpoints(
             IEndpointRouteBuilder endpointRouteBuilder,
             ServiceMethodsRegistry serviceMethodsRegistry,
-            ServerCallHandlerFactory<TService> serverCallHandlerFactory,
+            IGrpcCallHandlerFactory<TService> serverCallHandlerFactory,
             List<MethodModel> serviceMethods,
             List<IEndpointConventionBuilder> endpointConventionBuilders)
         {

--- a/src/Grpc.AspNetCore.Server/Model/ServiceMethodProviderContext.cs
+++ b/src/Grpc.AspNetCore.Server/Model/ServiceMethodProviderContext.cs
@@ -31,9 +31,9 @@ namespace Grpc.AspNetCore.Server.Model
     /// <typeparam name="TService">Service type for the context.</typeparam>
     public class ServiceMethodProviderContext<TService> where TService : class
     {
-        private readonly ServerCallHandlerFactory<TService> _serverCallHandlerFactory;
+        private readonly IGrpcCallHandlerFactory<TService> _serverCallHandlerFactory;
 
-        internal ServiceMethodProviderContext(ServerCallHandlerFactory<TService> serverCallHandlerFactory)
+        internal ServiceMethodProviderContext(IGrpcCallHandlerFactory<TService> serverCallHandlerFactory)
         {
             Methods = new List<MethodModel>();
             _serverCallHandlerFactory = serverCallHandlerFactory;
@@ -54,7 +54,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TResponse : class
         {
             var callHandler = _serverCallHandlerFactory.CreateUnary<TRequest, TResponse>(method, invoker);
-            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
+            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TResponse : class
         {
             var callHandler = _serverCallHandlerFactory.CreateServerStreaming<TRequest, TResponse>(method, invoker);
-            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
+            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TResponse : class
         {
             var callHandler = _serverCallHandlerFactory.CreateClientStreaming<TRequest, TResponse>(method, invoker);
-            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
+            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Grpc.AspNetCore.Server.Model
             where TResponse : class
         {
             var callHandler = _serverCallHandlerFactory.CreateDuplexStreaming<TRequest, TResponse>(method, invoker);
-            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler.HandleCallAsync);
+            AddMethod(method, RoutePatternFactory.Parse(method.FullName), metadata, callHandler);
         }
 
         /// <summary>

--- a/test/Grpc.AspNetCore.Server.Tests/ServerCallHandlerFactoryTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/ServerCallHandlerFactoryTests.cs
@@ -134,7 +134,7 @@ namespace Grpc.AspNetCore.Server.Tests
             services.AddLogging();
             var serviceProvider = services.BuildServiceProvider();
 
-            return serviceProvider.GetRequiredService<ServerCallHandlerFactory<object>>();
+            return (ServerCallHandlerFactory<object>)serviceProvider.GetRequiredService<IGrpcCallHandlerFactory<object>>();
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

The rationale of this PR is to allow libraries to add gRPC endpoints dynamically and not based on reflection.

### Background

I am the maintainer of a [code-first framework](https://gitlab.com/SiLA2/vendors/sila_tecan) supporting a standard in the field of laboratory automation called [SiLA2](https://sila-standard.com/), a standard essentially on top of ProtoBuf/gRPC. Because this standard puts some idioms on top of gRPC, I am not using the standard code generated by ProtoBuf but basically have my own code generator. With the native gRPC, this worked very well, but given the near end of support for the native version, I would like to support grpc-dotnet as well (although in our field, the support cycles of .NET Core generally tend to be much too short). However, in its current form, it is not possible to obtain the gRPC request handlers since the current code only allows access via reflection. To me, that is an overly complicated way of shooting yourself in the knee.

### Design

The main idea of this PR is to expose the functionality of the `ServerCallHandlerFactory` publicly. Because the actual request handler classes are internal, I slightly changed the API of that class to return the general ASP.NET Core `RequestDelegate` instead of the internal request handler classes in order to avoid having to make them public as well. The current implementation only uses these classes to build the request delegate from it, anyhow. However, as soon as the call handler factory gets publicly accessible, it is possible to obtain an instance via DI and then dynamically create request handlers as required.