### PR TITLE
Fix hardcoded SDK in get-dotnet.sh

### DIFF
--- a/build/get-dotnet.sh
+++ b/build/get-dotnet.sh
@@ -18,10 +18,7 @@ ensure_dir() {
 # main
 
 # resolve SDK version
-#sdk_version=$(jq -r .sdk.version $global_json_path)
-
-# TODO(JamesNK): Temporarily override global.json while using preview version
-sdk_version="6.0.100-rc.1.21380.19"
+sdk_version=$(jq -r .sdk.version $global_json_path)
 
 # download dotnet-install.sh
 ensure_dir $OBJDIR

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.6.21352.12",
+    "version": "6.0.100-rc.1.21463.6",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21463.6",
+    "version": "6.0.100-rc.1.21458.32",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1426

This can be fixed now that there are published docker images with RC1.