### PR TITLE
[v2.40.x] Update Google.Protobuf to 3.18.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
-    <GoogleProtobufPackageVersion>3.15.8</GoogleProtobufPackageVersion>
+    <GoogleProtobufPackageVersion>3.18.0</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.39.0-pre1</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.40.0</GrpcPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>6.0.0-rc.1.21367.4</MicrosoftAspNetCoreAppPackageVersion>


### PR DESCRIPTION
I want to update .NET SDK template to reference 2.40.0 and to use a recent Google.Protobuf. I noticed that the Google.Protobuf version referenced here is old.

I think this is a low-risk change. The only impact is to Grpc.AspNetCore so it brings in 3.18.0 instead of the old package version.