### PR TITLE
Enable preview features for HTTP/3

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -10,6 +10,9 @@
     <!-- Uncomment line below to automatically compile .proto files in the project directory -->
     <!-- <EnableDefaultProtoBufItems>true</EnableDefaultProtoBufItems> -->
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
+
+    <!-- Turn on preview features so we can use Http3. Can be removed in .NET 7 -->
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+
+    <!-- Turn on preview features so we can use Http3. Can be removed in .NET 7 -->
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
I noticed benchmarks were failing with the latest SDK:

> /tmp/benchmarks-agent/benchmarks-server-1/51d1ewdj.4d0/grpc-dotnet/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs(152,43): error CA2252: Using 'Http1AndHttp2AndHttp3' requires opting into preview features. See https://aka.ms/dotnet-warnings/preview-features for more information. [/tmp/benchmarks-agent/benchmarks-server-1/51d1ewdj.4d0/grpc-dotnet/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj]