### PR TITLE
Fix race by throwing response error after completing call

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -583,8 +583,8 @@ namespace Grpc.Net.Client.Internal
                     Cleanup(status.Value);
 
                     // Update response TCS after overall call status is resolved. This is required so that
-                    // the call is completed at the time someone catches the error from ResponseAsync.
-                    // call.GetStatus() will error if the call isn't complete.
+                    // the call is completed before an error is thrown from ResponseAsync. If it happens
+                    // afterwards then there is a chance GetStatus() will error because the call isn't complete.
                     _responseTcs?.TrySetException(resolvedException);
                 }
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -579,9 +579,13 @@ namespace Grpc.Net.Client.Internal
 
                     finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
                     _httpResponseTcs.TrySetException(resolvedException);
-                    _responseTcs?.TrySetException(resolvedException);
 
                     Cleanup(status.Value);
+
+                    // Update response TCS after overall call status is resolved. This is required so that
+                    // the call is completed at the time someone catches the error from ResponseAsync.
+                    // call.GetStatus() will error if the call isn't complete.
+                    _responseTcs?.TrySetException(resolvedException);
                 }
 
                 // Verify that FinishCall is called in every code path of this method.

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -578,13 +578,13 @@ namespace Grpc.Net.Client.Internal
                     ResolveException(ErrorStartingCallMessage, ex, out status, out var resolvedException);
 
                     finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
-                    _httpResponseTcs.TrySetException(resolvedException);
 
                     Cleanup(status.Value);
 
-                    // Update response TCS after overall call status is resolved. This is required so that
+                    // Update response TCSs after overall call status is resolved. This is required so that
                     // the call is completed before an error is thrown from ResponseAsync. If it happens
                     // afterwards then there is a chance GetStatus() will error because the call isn't complete.
+                    _httpResponseTcs.TrySetException(resolvedException);
                     _responseTcs?.TrySetException(resolvedException);
                 }
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -579,12 +579,15 @@ namespace Grpc.Net.Client.Internal
 
                     finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
 
+                    // Update HTTP response TCS before clean up. Needs to happen first because cleanup will
+                    // cancel the TCS for anyone still listening.
+                    _httpResponseTcs.TrySetException(resolvedException);
+
                     Cleanup(status.Value);
 
-                    // Update response TCSs after overall call status is resolved. This is required so that
+                    // Update response TCS after overall call status is resolved. This is required so that
                     // the call is completed before an error is thrown from ResponseAsync. If it happens
                     // afterwards then there is a chance GetStatus() will error because the call isn't complete.
-                    _httpResponseTcs.TrySetException(resolvedException);
                     _responseTcs?.TrySetException(resolvedException);
                 }
 

--- a/test/FunctionalTests/Client/DeadlineTests.cs
+++ b/test/FunctionalTests/Client/DeadlineTests.cs
@@ -98,5 +98,79 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
             Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
         }
+
+        [Test]
+        public async Task Unary_ServerResetCancellationStatusGetResponseHeaders_DeadlineStatus()
+        {
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            async Task<DataMessage> UnaryTimeout(DataMessage request, ServerCallContext context)
+            {
+                var httpContext = context.GetHttpContext();
+                var resetFeature = httpContext.Features.Get<IHttpResetFeature>()!;
+
+                await tcs.Task;
+
+                var cancelErrorCode = (httpContext.Request.Protocol == "HTTP/2") ? 0x8 : 0x10c;
+                resetFeature.Reset(cancelErrorCode);
+
+                return new DataMessage();
+            }
+
+            // Arrange
+            var method = Fixture.DynamicGrpc.AddUnaryMethod<DataMessage, DataMessage>(UnaryTimeout);
+
+            var channel = CreateChannel();
+            channel.DisableClientDeadline = true;
+
+            var client = TestClientFactory.Create(channel, method);
+            var deadline = TimeSpan.FromMilliseconds(300);
+
+            // Act
+            var call = client.UnaryCall(new DataMessage(), new CallOptions(deadline: DateTime.UtcNow.Add(deadline)));
+
+            await Task.Delay(deadline);
+            tcs.SetResult(null);
+
+            // Assert
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseHeadersAsync).DefaultTimeout();
+            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
+            Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+        }
+
+        [Test]
+        public async Task ServerStreaming_ServerResetCancellationStatus_DeadlineStatus()
+        {
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            async Task ServerStreamingTimeout(DataMessage request, IServerStreamWriter<DataMessage> responseStream, ServerCallContext context)
+            {
+                var httpContext = context.GetHttpContext();
+                var resetFeature = httpContext.Features.Get<IHttpResetFeature>()!;
+
+                await tcs.Task;
+
+                var cancelErrorCode = (httpContext.Request.Protocol == "HTTP/2") ? 0x8 : 0x10c;
+                resetFeature.Reset(cancelErrorCode);
+            }
+
+            // Arrange
+            var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingTimeout);
+
+            var channel = CreateChannel();
+            channel.DisableClientDeadline = true;
+
+            var client = TestClientFactory.Create(channel, method);
+            var deadline = TimeSpan.FromMilliseconds(300);
+
+            // Act
+            var call = client.ServerStreamingCall(new DataMessage(), new CallOptions(deadline: DateTime.UtcNow.Add(deadline)));
+
+            await Task.Delay(deadline);
+            tcs.SetResult(null);
+
+            // Assert
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
+            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
+            Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+        }
     }
 }

--- a/test/FunctionalTests/Client/DeadlineTests.cs
+++ b/test/FunctionalTests/Client/DeadlineTests.cs
@@ -23,7 +23,6 @@ using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Tests.Shared;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Streaming;
 
@@ -95,44 +94,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
             // Assert
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
-            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
-            Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
-        }
-
-        [Test]
-        public async Task Unary_ServerResetCancellationStatusGetResponseHeaders_DeadlineStatus()
-        {
-            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-            async Task<DataMessage> UnaryTimeout(DataMessage request, ServerCallContext context)
-            {
-                var httpContext = context.GetHttpContext();
-                var resetFeature = httpContext.Features.Get<IHttpResetFeature>()!;
-
-                await tcs.Task;
-
-                var cancelErrorCode = (httpContext.Request.Protocol == "HTTP/2") ? 0x8 : 0x10c;
-                resetFeature.Reset(cancelErrorCode);
-
-                return new DataMessage();
-            }
-
-            // Arrange
-            var method = Fixture.DynamicGrpc.AddUnaryMethod<DataMessage, DataMessage>(UnaryTimeout);
-
-            var channel = CreateChannel();
-            channel.DisableClientDeadline = true;
-
-            var client = TestClientFactory.Create(channel, method);
-            var deadline = TimeSpan.FromMilliseconds(300);
-
-            // Act
-            var call = client.UnaryCall(new DataMessage(), new CallOptions(deadline: DateTime.UtcNow.Add(deadline)));
-
-            await Task.Delay(deadline);
-            tcs.SetResult(null);
-
-            // Assert
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseHeadersAsync).DefaultTimeout();
             Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
             Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
         }

--- a/test/FunctionalTests/Client/DeadlineTests.cs
+++ b/test/FunctionalTests/Client/DeadlineTests.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
@@ -63,13 +64,17 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         [Test]
         public async Task Unary_ServerResetCancellationStatus_DeadlineStatus()
         {
-            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> tcs = null!;
             async Task<DataMessage> UnaryTimeout(DataMessage request, ServerCallContext context)
             {
                 var httpContext = context.GetHttpContext();
                 var resetFeature = httpContext.Features.Get<IHttpResetFeature>()!;
 
                 await tcs.Task;
+
+                // Reset needs to arrive in client after it has exceeded deadline.
+                // Delay can be imprecise. Wait extra time to ensure client has exceeded deadline.
+                await Task.Delay(50);
 
                 var cancelErrorCode = (httpContext.Request.Protocol == "HTTP/2") ? 0x8 : 0x10c;
                 resetFeature.Reset(cancelErrorCode);
@@ -86,28 +91,41 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             var client = TestClientFactory.Create(channel, method);
             var deadline = TimeSpan.FromMilliseconds(300);
 
-            // Act
-            var call = client.UnaryCall(new DataMessage(), new CallOptions(deadline: DateTime.UtcNow.Add(deadline)));
+            for (var i = 0; i < 5; i++)
+            {
+                tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await Task.Delay(deadline);
-            tcs.SetResult(null);
+                // Act
+                var headers = new Metadata
+                {
+                    { "remove-deadline", "true" }
+                };
+                var call = client.UnaryCall(new DataMessage(), new CallOptions(headers: headers, deadline: DateTime.UtcNow.Add(deadline)));
 
-            // Assert
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
-            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
-            Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+                await Task.Delay(deadline);
+                tcs.SetResult(null);
+
+                // Assert
+                var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
+                Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
+                Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+            }
         }
 
         [Test]
-        public async Task ServerStreaming_ServerResetCancellationStatus_DeadlineStatus()
+        public async Task AsyncUnaryCall_ExceedDeadlineWithActiveCalls_Failure()//(int i)
         {
-            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> tcs = null!;
             async Task ServerStreamingTimeout(DataMessage request, IServerStreamWriter<DataMessage> responseStream, ServerCallContext context)
             {
                 var httpContext = context.GetHttpContext();
                 var resetFeature = httpContext.Features.Get<IHttpResetFeature>()!;
 
                 await tcs.Task;
+
+                // Reset needs to arrive in client after it has exceeded deadline.
+                // Delay can be imprecise. Wait extra time to ensure client has exceeded deadline.
+                await Task.Delay(50);
 
                 var cancelErrorCode = (httpContext.Request.Protocol == "HTTP/2") ? 0x8 : 0x10c;
                 resetFeature.Reset(cancelErrorCode);
@@ -122,16 +140,25 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             var client = TestClientFactory.Create(channel, method);
             var deadline = TimeSpan.FromMilliseconds(300);
 
-            // Act
-            var call = client.ServerStreamingCall(new DataMessage(), new CallOptions(deadline: DateTime.UtcNow.Add(deadline)));
+            for (var i = 0; i < 5; i++)
+            {
+                tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await Task.Delay(deadline);
-            tcs.SetResult(null);
+                // Act
+                var headers = new Metadata
+                {
+                    { "remove-deadline", "true" }
+                };
+                var call = client.ServerStreamingCall(new DataMessage(), new CallOptions(headers: headers, deadline: DateTime.UtcNow.Add(deadline)));
 
-            // Assert
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
-            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
-            Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+                await Task.Delay(deadline);
+                tcs.SetResult(null);
+
+                // Assert
+                var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
+                Assert.AreEqual(StatusCode.DeadlineExceeded, ex.StatusCode);
+                Assert.AreEqual(StatusCode.DeadlineExceeded, call.GetStatus().StatusCode);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix race condition that caused flakey test failure:

```
  Failed Unary_ServerResetCancellationStatus_DeadlineStatus [316 ms]
  Error Message:
   System.InvalidOperationException : Unable to get the status because the call is not complete.
  Stack Trace:
     at Grpc.Net.Client.Internal.GrpcCall`2.GetStatus() in /home/runner/work/grpc-dotnet/grpc-dotnet/src/Grpc.Net.Client/Internal/GrpcCall.cs:line 332
   at Grpc.Net.Client.Internal.HttpClientCallInvoker.Callbacks`2.<>c.<.cctor>b__4_1(Object state) in /home/runner/work/grpc-dotnet/grpc-dotnet/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs:line 173
   at Grpc.Core.AsyncCallState.GetStatus()
   at Grpc.Core.AsyncUnaryCall`1.GetStatus()
   at Grpc.AspNetCore.FunctionalTests.Client.DeadlineTests.Unary_ServerResetCancellationStatus_DeadlineStatus() in /home/runner/work/grpc-dotnet/grpc-dotnet/test/FunctionalTests/Client/DeadlineTests.cs:line 99
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
  Standard Output Messages:
 0.000s GrpcTestContext - Information: Starting DeadlineTests.Unary_ServerResetCancellationStatus_DeadlineStatus
 0.002s SERVER Grpc.AspNetCore.Server.Model.Internal.ServiceRouteBuilder - Trace: Discovering gRPC methods for FunctionalTestsWebsite.Infrastructure.DynamicService.
 0.002s SERVER Grpc.AspNetCore.Server.Model.Internal.BinderServiceMethodProvider - Debug: Could not find bind method for FunctionalTestsWebsite.Infrastructure.DynamicService.
 0.002s SERVER Grpc.AspNetCore.Server.Model.Internal.ServiceRouteBuilder - Trace: Added gRPC method 'f8b4c348-4425-4d68-aad8-870fa2142f12' to service 'DynamicService'. Method type: 'Unary', route pattern: '/DynamicService/f8b4c348-4425-4d68-aad8-870fa2142f12'.
 0.002s Grpc.Net.Client.Internal.GrpcCall - Debug: Starting gRPC call. Method type: 'Unary', URI: 'http://127.0.0.1:50050/DynamicService/f8b4c348-4425-4d68-aad8-870fa2142f12'.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Connections - Debug: Connection id "0HMC7MCHT2FMG" accepted.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Connections - Debug: Connection id "0HMC7MCHT2FMG" started.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" sending SETTINGS frame for stream ID 0 with length 18 and flags NONE.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" sending WINDOW_UPDATE frame for stream ID 0 with length 4 and flags 0x0.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" received SETTINGS frame for stream ID 0 with length 12 and flags NONE.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" sending SETTINGS frame for stream ID 0 with length 0 and flags ACK.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" received WINDOW_UPDATE frame for stream ID 0 with length 4 and flags 0x0.
 0.004s Grpc.Net.Client.Internal.GrpcCall - Debug: Sending message.
 0.004s Grpc.Net.Client.Internal.GrpcCall - Trace: Serialized 'Streaming.DataMessage' to 0 byte message.
 0.004s Grpc.Net.Client.Internal.GrpcCall - Trace: Message sent.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" received HEADERS frame for stream ID 1 with length 311 and flags END_HEADERS.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" received DATA frame for stream ID 1 with length 5 and flags NONE.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" received DATA frame for stream ID 1 with length 0 and flags END_STREAM.
 0.004s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" received SETTINGS frame for stream ID 0 with length 0 and flags ACK.
 0.004s SERVER Microsoft.AspNetCore.Hosting.Diagnostics - Information: Request starting HTTP/2 POST http://127.0.0.1:50050/DynamicService/f8b4c348-4425-4d68-aad8-870fa2142f12 application/grpc -
 0.024s SERVER Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware - Debug: Request matched endpoint 'gRPC - /DynamicService/f8b4c348-4425-4d68-aad8-870fa2142f12'
 0.024s SERVER Microsoft.AspNetCore.Routing.EndpointMiddleware - Information: Executing endpoint 'gRPC - /DynamicService/f8b4c348-4425-4d68-aad8-870fa2142f12'
 0.026s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Trace: Request deadline timeout of 00:00:00.2990000 started.
 0.026s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Debug: Reading message.
 0.026s SERVER Microsoft.AspNetCore.Server.Kestrel - Debug: Connection id "0HMC7MCHT2FMG", Request id "0HMC7MCHT2FMG:00000001": started reading request body.
 0.026s SERVER Microsoft.AspNetCore.Server.Kestrel - Debug: Connection id "0HMC7MCHT2FMG", Request id "0HMC7MCHT2FMG:00000001": done reading request body.
 0.026s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Trace: Deserializing 0 byte message to 'Streaming.DataMessage'.
 0.026s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Trace: Received message.
 0.308s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Debug: Trace id "0HMC7MCHT2FMG:00000001": HTTP/2 stream error "CANCEL". A Reset is being sent to the stream.
 Microsoft.AspNetCore.Connections.ConnectionAbortedException: The HTTP/2 stream was reset by the application with error code CANCEL.
 0.308s SERVER Microsoft.AspNetCore.Server.Kestrel.Http2 - Trace: Connection id "0HMC7MCHT2FMG" sending RST_STREAM frame for stream ID 1 with length 4 and flags 0x0.
 0.311s Grpc.Net.Client.Internal.GrpcCall - Warning: gRPC call deadline exceeded.
 0.311s Grpc.Net.Client.Internal.GrpcCall - Information: Call failed with gRPC error status. Status code: 'DeadlineExceeded', Message: 'Error starting gRPC call. HttpRequestException: An error occurred while sending the request. IOException: The request was aborted. Http2StreamException: The HTTP/2 server reset the stream. HTTP/2 error code 'CANCEL' (0x8).'.
 0.311s Grpc.Net.Client.Internal.GrpcCall - Debug: Finished gRPC call.
 0.312s Grpc.Net.Client.Internal.GrpcCall - Debug: gRPC call canceled.
 0.313s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Debug: Sending message.
 0.313s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Trace: Serialized 'Streaming.DataMessage' to 0 byte message.
 0.313s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Trace: Message sent.
 0.313s SERVER Grpc.AspNetCore.Server.ServerCallHandler - Trace: Request deadline stopped.
 0.313s SERVER Microsoft.AspNetCore.Routing.EndpointMiddleware - Information: Executed endpoint 'gRPC - /DynamicService/f8b4c348-4425-4d68-aad8-870fa2142f12'
 0.313s SERVER Microsoft.AspNetCore.Hosting.Diagnostics - Information: Request finished HTTP/2 POST http://127.0.0.1:50050/DynamicService/f8b4c348-4425-4d68-aad8-870fa2142f12 application/grpc - - 200 - application/grpc 309.0698ms
 0.317s GrpcTestContext - Information: Finishing DeadlineTests.Unary_ServerResetCancellationStatus_DeadlineStatus
```