### PR TITLE
Ensure That Timer Callback Does not Call Method on Disposed Timer

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -225,7 +225,9 @@ namespace Grpc.Net.Client.Internal
             Channel.FinishActiveCall(this);
 
             _ctsRegistration?.Dispose();
-            _deadlineTimer?.Dispose();
+            var deadlineTimer = _deadlineTimer;
+            _deadlineTimer = null;
+            deadlineTimer?.Dispose();
             HttpResponse?.Dispose();
             ClientStreamReader?.Dispose();
             ClientStreamWriter?.Dispose();
@@ -965,7 +967,7 @@ namespace Grpc.Net.Client.Internal
                 GrpcCallLog.DeadlineTimerRescheduled(Logger, remaining);
 
                 var dueTime = CommonGrpcProtocolHelpers.GetTimerDueTime(remaining, Channel.MaxTimerDueTime);
-                _deadlineTimer!.Change(dueTime, Timeout.Infinite);
+                _deadlineTimer?.Change(dueTime, Timeout.Infinite);
             }
         }
 


### PR DESCRIPTION
We noticed recently that our test runs were crashing with an unhandled exception:
```
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.ObjectDisposedException: Cannot access a disposed object.
at System.Threading.TimerQueueTimer.Change(UInt32 dueTime, UInt32 period)
at Grpc.Net.Client.Internal.GrpcCall`2.DeadlineExceededCallback(Object state)
at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
at System.Threading.TimerQueueTimer.CallCallback(Boolean isThreadPool)
at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
at System.Threading.ThreadPoolWorkQueue.Dispatch() 
```

This appears to be because `System.Threading.Timer` does not cancel pending callbacks after disposal. I confirmed that behavior with a minimal reproduction:

```
Timer timer = null;
timer = new Timer(Callback, null, TimeSpan.FromMilliseconds(1), Timeout.InfiniteTimeSpan);
await Task.Delay(TimeSpan.FromMilliseconds(2));
timer.Dispose();

await Task.Delay(TimeSpan.FromMilliseconds(300));

void Callback(object state) {
	timer.Change(TimeSpan.FromMilliseconds(1), Timeout.InfiniteTimeSpan);
}
```