### PR TITLE
Add support for per-address attributes

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21458.32",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Grpc.Net.Client/Balancer/BalancerAddress.cs
+++ b/src/Grpc.Net.Client/Balancer/BalancerAddress.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if SUPPORT_LOAD_BALANCING
+using System.Net;
+
+namespace Grpc.Net.Client.Balancer
+{
+    /// <summary>
+    /// Represents a balancer address.
+    /// <para>
+    /// Note: Experimental API that can change or be removed without any prior notice.
+    /// </para>
+    /// </summary>
+    public sealed class BalancerAddress
+    {
+        private BalancerAttributes? _attributes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BalancerAddress"/> class with the specified <see cref="DnsEndPoint"/>.
+        /// </summary>
+        /// <param name="endPoint">The end point.</param>
+        public BalancerAddress(DnsEndPoint endPoint)
+        {
+            EndPoint = endPoint;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BalancerAddress"/> class with the specified host and port.
+        /// </summary>
+        /// <param name="host">The host.</param>
+        /// <param name="port">The port.</param>
+        public BalancerAddress(string host, int port) : this(new DnsEndPoint(host, port))
+        {
+        }
+
+        /// <summary>
+        /// Gets the address <see cref="DnsEndPoint"/>.
+        /// </summary>
+        public DnsEndPoint EndPoint { get; }
+
+        /// <summary>
+        /// Gets the address attributes.
+        /// </summary>
+        public BalancerAttributes Attributes => _attributes ??= new BalancerAttributes();
+
+        /// <summary>
+        /// Returns a string that reprsents the address.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{EndPoint.Host}:{EndPoint.Port}";
+        }
+    }
+}
+#endif

--- a/src/Grpc.Net.Client/Balancer/ChannelState.cs
+++ b/src/Grpc.Net.Client/Balancer/ChannelState.cs
@@ -34,7 +34,7 @@ namespace Grpc.Net.Client.Balancer
     public sealed class ChannelState
     {
         [DebuggerStepThrough]
-        internal ChannelState(Status status, IReadOnlyList<DnsEndPoint>? addresses, LoadBalancingConfig? loadBalancingConfig, BalancerAttributes attributes)
+        internal ChannelState(Status status, IReadOnlyList<BalancerAddress>? addresses, LoadBalancingConfig? loadBalancingConfig, BalancerAttributes attributes)
         {
             Addresses = addresses;
             LoadBalancingConfig = loadBalancingConfig;
@@ -45,7 +45,7 @@ namespace Grpc.Net.Client.Balancer
         /// <summary>
         /// Gets a collection of addresses. Will be <c>null</c> if <see cref="Status"/> has a non-OK value.
         /// </summary>
-        public IReadOnlyList<DnsEndPoint>? Addresses { get; }
+        public IReadOnlyList<BalancerAddress>? Addresses { get; }
 
         /// <summary>
         /// Gets an optional load balancing config.

--- a/src/Grpc.Net.Client/Balancer/CompletionContext.cs
+++ b/src/Grpc.Net.Client/Balancer/CompletionContext.cs
@@ -32,9 +32,9 @@ namespace Grpc.Net.Client.Balancer
     public sealed class CompletionContext
     {
         /// <summary>
-        /// Gets or sets the <see cref="DnsEndPoint"/> a call was made with. Required.
+        /// Gets or sets the <see cref="BalancerAddress"/> a call was made with. Required.
         /// </summary>
-        public DnsEndPoint? Address { get; set; }
+        public BalancerAddress? Address { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Exception"/> thrown when making the call.

--- a/src/Grpc.Net.Client/Balancer/DnsResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/DnsResolver.cs
@@ -146,7 +146,7 @@ namespace Grpc.Net.Client.Balancer
                 DnsResolverLog.ReceivedDnsResults(_logger, addresses.Length, _address, addresses);
 
                 var resolvedPort = _address.Port == -1 ? 80 : _address.Port;
-                var endpoints = addresses.Select(a => new BalancerAddress(new DnsEndPoint(a.ToString(), resolvedPort))).ToArray();
+                var endpoints = addresses.Select(a => new BalancerAddress(a.ToString(), resolvedPort)).ToArray();
                 var resolverResult = ResolverResult.ForResult(endpoints, serviceConfig: null);
                 _listener(resolverResult);
             }

--- a/src/Grpc.Net.Client/Balancer/DnsResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/DnsResolver.cs
@@ -146,7 +146,7 @@ namespace Grpc.Net.Client.Balancer
                 DnsResolverLog.ReceivedDnsResults(_logger, addresses.Length, _address, addresses);
 
                 var resolvedPort = _address.Port == -1 ? 80 : _address.Port;
-                var endpoints = addresses.Select(a => new DnsEndPoint(a.ToString(), resolvedPort)).ToArray();
+                var endpoints = addresses.Select(a => new BalancerAddress(new DnsEndPoint(a.ToString(), resolvedPort))).ToArray();
                 var resolverResult = ResolverResult.ForResult(endpoints, serviceConfig: null);
                 _listener(resolverResult);
             }

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerAddressEqualityComparer.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerAddressEqualityComparer.cs
@@ -1,0 +1,56 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if SUPPORT_LOAD_BALANCING
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Grpc.Net.Client.Balancer.Internal
+{
+    internal class BalancerAddressEqualityComparer : IEqualityComparer<BalancerAddress>
+    {
+        internal static readonly BalancerAddressEqualityComparer Instance = new BalancerAddressEqualityComparer();
+
+        public bool Equals(BalancerAddress? x, BalancerAddress? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            if (!x.EndPoint.Equals(y.EndPoint))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public int GetHashCode([DisallowNull] BalancerAddress obj)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}
+#endif

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
@@ -77,15 +77,16 @@ namespace Grpc.Net.Client.Balancer.Internal
             var pickContext = new PickContext { Request = request };
             var result = await _manager.PickAsync(pickContext, waitForReady, cancellationToken).ConfigureAwait(false);
             var address = result.Address!;
+            var addressEndpoint = address.EndPoint;
 
             // Update request host if required.
             if (!request.RequestUri.IsAbsoluteUri ||
-                request.RequestUri.Host != address.Host ||
-                request.RequestUri.Port != address.Port)
+                request.RequestUri.Host != addressEndpoint.Host ||
+                request.RequestUri.Port != addressEndpoint.Port)
             {
                 var uriBuilder = new UriBuilder(request.RequestUri);
-                uriBuilder.Host = address.Host;
-                uriBuilder.Port = address.Port;
+                uriBuilder.Host = addressEndpoint.Host;
+                uriBuilder.Port = addressEndpoint.Port;
                 request.RequestUri = uriBuilder.Uri;
             }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -290,7 +290,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         public async
 #if !NETSTANDARD2_0
-            ValueTask<(Subchannel Subchannel, DnsEndPoint Address, Action<CompletionContext> OnComplete)>
+            ValueTask<(Subchannel Subchannel, BalancerAddress Address, Action<CompletionContext> OnComplete)>
 #else
             Task<(Subchannel Subchannel, DnsEndPoint Address, Action<CompleteContext> OnComplete)>
 #endif
@@ -316,7 +316,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
                         if (address != null)
                         {
-                            ConnectionManagerLog.PickResultSuccessful(Logger, subchannel.Id, address);
+                            ConnectionManagerLog.PickResultSuccessful(Logger, subchannel.Id, address.EndPoint);
                             return (subchannel, address, result.Complete);
                         }
                         else

--- a/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
@@ -33,7 +33,7 @@ namespace Grpc.Net.Client.Balancer.Internal
     internal interface ISubchannelTransport : IDisposable
     {
         void OnRequestComplete(CompletionContext context);
-        DnsEndPoint? CurrentEndPoint { get; }
+        BalancerAddress? CurrentAddress { get; }
 
 #if NET5_0_OR_GREATER
         ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken);

--- a/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
@@ -35,14 +35,14 @@ namespace Grpc.Net.Client.Balancer.Internal
     internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
     {
         private readonly Subchannel _subchannel;
-        private DnsEndPoint? _currentEndPoint;
+        private BalancerAddress? _currentAddress;
 
         public PassiveSubchannelTransport(Subchannel subchannel)
         {
             _subchannel = subchannel;
         }
 
-        public DnsEndPoint? CurrentEndPoint => _currentEndPoint;
+        public BalancerAddress? CurrentAddress => _currentAddress;
 
         public void OnRequestComplete(CompletionContext context)
         {
@@ -50,7 +50,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         public void Disconnect()
         {
-            _currentEndPoint = null;
+            _currentAddress = null;
             _subchannel.UpdateConnectivityState(ConnectivityState.Idle, "Disconnected.");
         }
 
@@ -63,12 +63,12 @@ namespace Grpc.Net.Client.Balancer.Internal
             TryConnectAsync(CancellationToken cancellationToken)
         {
             Debug.Assert(_subchannel._addresses.Count == 1);
-            Debug.Assert(CurrentEndPoint == null);
+            Debug.Assert(CurrentAddress == null);
 
-            var currentEndPoint = _subchannel._addresses[0];
+            var currentAddress = _subchannel._addresses[0];
 
             _subchannel.UpdateConnectivityState(ConnectivityState.Connecting, "Passively connecting.");
-            _currentEndPoint = currentEndPoint;
+            _currentAddress = currentAddress;
             _subchannel.UpdateConnectivityState(ConnectivityState.Ready, "Passively connected.");
 
 #if !NETSTANDARD2_0
@@ -80,7 +80,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         public void Dispose()
         {
-            _currentEndPoint = null;
+            _currentAddress = null;
         }
 
 #if NET5_0_OR_GREATER

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -59,7 +59,7 @@ namespace Grpc.Net.Client.Balancer.Internal
         private Socket? _initialSocket;
         private DnsEndPoint? _initialSocketEndPoint;
         private bool _disposed;
-        private BalancerAddress? _currentEndPoint;
+        private BalancerAddress? _currentAddress;
 
         public SocketConnectivitySubchannelTransport(Subchannel subchannel, TimeSpan socketPingInterval, ILoggerFactory loggerFactory)
         {
@@ -71,7 +71,7 @@ namespace Grpc.Net.Client.Balancer.Internal
         }
 
         public object Lock => _subchannel.Lock;
-        public BalancerAddress? CurrentAddress => _currentEndPoint;
+        public BalancerAddress? CurrentAddress => _currentAddress;
         public bool HasStream { get; }
 
         // For testing. Take a copy under lock for thread-safety.
@@ -92,7 +92,7 @@ namespace Grpc.Net.Client.Balancer.Internal
                 _initialSocketEndPoint = null;
                 _lastEndPointIndex = 0;
                 _socketConnectedTimer.Change(TimeSpan.Zero, TimeSpan.Zero);
-                _currentEndPoint = null;
+                _currentAddress = null;
             }
             _subchannel.UpdateConnectivityState(ConnectivityState.Idle, "Disconnected.");
         }
@@ -125,7 +125,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
                     lock (Lock)
                     {
-                        _currentEndPoint = currentAddress;
+                        _currentAddress = currentAddress;
                         _lastEndPointIndex = currentIndex;
                         _initialSocket = socket;
                         _initialSocketEndPoint = currentAddress.EndPoint;
@@ -196,7 +196,7 @@ namespace Grpc.Net.Client.Balancer.Internal
                                 _initialSocket.Dispose();
                                 _initialSocket = null;
                                 _initialSocketEndPoint = null;
-                                _currentEndPoint = null;
+                                _currentAddress = null;
                                 _lastEndPointIndex = 0;
                             }
                         }

--- a/src/Grpc.Net.Client/Balancer/Resolver.cs
+++ b/src/Grpc.Net.Client/Balancer/Resolver.cs
@@ -99,7 +99,7 @@ namespace Grpc.Net.Client.Balancer
         private BalancerAttributes? _attributes;
 
         [DebuggerStepThrough]
-        private ResolverResult(Status status, IReadOnlyList<DnsEndPoint>? addresses, ServiceConfig? serviceConfig)
+        private ResolverResult(Status status, IReadOnlyList<BalancerAddress>? addresses, ServiceConfig? serviceConfig)
         {
             Status = status;
             Addresses = addresses;
@@ -114,7 +114,7 @@ namespace Grpc.Net.Client.Balancer
         /// <summary>
         /// Gets a collection of resolved addresses.
         /// </summary>
-        public IReadOnlyList<DnsEndPoint>? Addresses { get; }
+        public IReadOnlyList<BalancerAddress>? Addresses { get; }
 
         /// <summary>
         /// Gets an optional service config.
@@ -149,7 +149,7 @@ namespace Grpc.Net.Client.Balancer
         /// <param name="serviceConfig">An optional service config.</param>
         /// <returns>A resolver result.</returns>
         [DebuggerStepThrough]
-        public static ResolverResult ForResult(IReadOnlyList<DnsEndPoint> addresses, ServiceConfig? serviceConfig)
+        public static ResolverResult ForResult(IReadOnlyList<BalancerAddress> addresses, ServiceConfig? serviceConfig)
         {
             return new ResolverResult(Status.DefaultSuccess, addresses, serviceConfig);
         }

--- a/src/Grpc.Net.Client/Balancer/StaticResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/StaticResolver.cs
@@ -34,7 +34,7 @@ namespace Grpc.Net.Client.Balancer
     /// </summary>
     internal sealed class StaticResolver : Resolver
     {
-        private readonly List<DnsEndPoint> _addresses;
+        private readonly List<BalancerAddress> _addresses;
         private Action<ResolverResult>? _listener;
         private bool _disposed;
 
@@ -42,7 +42,7 @@ namespace Grpc.Net.Client.Balancer
         /// Initializes a new instance of the <see cref="StaticResolver"/> class with the specified addresses.
         /// </summary>
         /// <param name="addresses">The resolved addresses.</param>
-        public StaticResolver(IEnumerable<DnsEndPoint> addresses)
+        public StaticResolver(IEnumerable<BalancerAddress> addresses)
         {
             _addresses = addresses.ToList();
         }
@@ -95,7 +95,7 @@ namespace Grpc.Net.Client.Balancer
     /// </summary>
     public sealed class StaticResolverFactory : ResolverFactory
     {
-        private readonly Func<Uri, IEnumerable<DnsEndPoint>> _addressesCallback;
+        private readonly Func<Uri, IEnumerable<BalancerAddress>> _addressesCallback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StaticResolverFactory"/> class with a callback
@@ -104,7 +104,7 @@ namespace Grpc.Net.Client.Balancer
         /// <param name="addressesCallback">
         /// A callback that returns a collection of addresses for a target <see cref="Uri"/>.
         /// </param>
-        public StaticResolverFactory(Func<Uri, IEnumerable<DnsEndPoint>> addressesCallback)
+        public StaticResolverFactory(Func<Uri, IEnumerable<BalancerAddress>> addressesCallback)
         {
             _addressesCallback = addressesCallback;
         }

--- a/src/Grpc.Net.Client/Balancer/SubchannelOptions.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelOptions.cs
@@ -36,7 +36,7 @@ namespace Grpc.Net.Client.Balancer
         /// </summary>
         /// <param name="addresses">A collection of addresses.</param>
         [DebuggerStepThrough]
-        public SubchannelOptions(IReadOnlyList<DnsEndPoint> addresses)
+        public SubchannelOptions(IReadOnlyList<BalancerAddress> addresses)
         {
             Addresses = addresses;
         }
@@ -44,7 +44,7 @@ namespace Grpc.Net.Client.Balancer
         /// <summary>
         /// Gets a collection of addresses.
         /// </summary>
-        public IReadOnlyList<DnsEndPoint> Addresses { get; }
+        public IReadOnlyList<BalancerAddress> Addresses { get; }
     }
 }
 #endif

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -80,12 +80,12 @@ namespace Grpc.Net.Client.Balancer
             }
         }
 
-        private int? FindSubchannelByAddress(List<AddressSubchannel> addressSubchannels, DnsEndPoint endPoint)
+        private int? FindSubchannelByAddress(List<AddressSubchannel> addressSubchannels, BalancerAddress address)
         {
             for (var i = 0; i < addressSubchannels.Count; i++)
             {
                 var s = addressSubchannels[i];
-                if (Equals(s.Address, endPoint))
+                if (Equals(s.Address, address))
                 {
                     return i;
                 }
@@ -297,7 +297,7 @@ namespace Grpc.Net.Client.Balancer
         /// <returns>A subchannel picker.</returns>
         protected abstract SubchannelPicker CreatePicker(IReadOnlyList<Subchannel> readySubchannels);
 
-        private record AddressSubchannel(Subchannel Subchannel, DnsEndPoint Address);
+        private record AddressSubchannel(Subchannel Subchannel, BalancerAddress Address);
     }
 
     internal static class SubchannelsLoadBalancerLog

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -131,7 +131,7 @@ namespace Grpc.Net.Client
             // Even with just one address we still want to use the load balancing infrastructure. This enables
             // the connectivity APIs on channel like GrpcChannel.State and GrpcChannel.WaitForStateChanged.
             var resolver = IsHttpOrHttpsAddress()
-                ? new StaticResolver(new[] { new DnsEndPoint(Address.Host, Address.Port) })
+                ? new StaticResolver(new[] { new BalancerAddress(new DnsEndPoint(Address.Host, Address.Port)) })
                 : CreateResolver(channelOptions);
 
             ConnectionManager = new ConnectionManager(

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -131,7 +131,7 @@ namespace Grpc.Net.Client
             // Even with just one address we still want to use the load balancing infrastructure. This enables
             // the connectivity APIs on channel like GrpcChannel.State and GrpcChannel.WaitForStateChanged.
             var resolver = IsHttpOrHttpsAddress()
-                ? new StaticResolver(new[] { new BalancerAddress(new DnsEndPoint(Address.Host, Address.Port)) })
+                ? new StaticResolver(new[] { new BalancerAddress(Address.Host, Address.Port) })
                 : CreateResolver(channelOptions);
 
             ConnectionManager = new ConnectionManager(

--- a/test/FunctionalTests/Balancer/BalancerHelpers.cs
+++ b/test/FunctionalTests/Balancer/BalancerHelpers.cs
@@ -111,8 +111,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
         public static Task<GrpcChannel> CreateChannel(ILoggerFactory loggerFactory, LoadBalancingConfig? loadBalancingConfig, Uri[] endpoints, HttpMessageHandler? httpMessageHandler = null, bool? connect = null)
         {
             var resolver = new TestResolver();
-            var e = endpoints.Select(i => new DnsEndPoint(i.Host, i.Port)).ToList();
-            resolver.UpdateEndPoints(e);
+            var e = endpoints.Select(i => new BalancerAddress(i.Host, i.Port)).ToList();
+            resolver.UpdateAddresses(e);
 
             return CreateChannel(loggerFactory, loadBalancingConfig, resolver, httpMessageHandler, connect);
         }

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -76,8 +76,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             var services = new ServiceCollection();
             services.AddSingleton<ResolverFactory>(new StaticResolverFactory(_ => new[]
             {
-                new BalancerAddress(new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port)),
-                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
+                new BalancerAddress(endpoint1.Address.Host, endpoint1.Address.Port),
+                new BalancerAddress(endpoint2.Address.Host, endpoint2.Address.Port)
             }));
 
             var socketsHttpHandler = new SocketsHttpHandler
@@ -208,8 +208,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             var services = new ServiceCollection();
             services.AddSingleton<ResolverFactory>(new StaticResolverFactory(_ => new[]
             {
-                new BalancerAddress(new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port)),
-                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
+                new BalancerAddress(endpoint1.Address.Host, endpoint1.Address.Port),
+                new BalancerAddress(endpoint2.Address.Host, endpoint2.Address.Port)
             }));
             var socketsHttpHandler = new SocketsHttpHandler
             {

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -76,8 +76,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             var services = new ServiceCollection();
             services.AddSingleton<ResolverFactory>(new StaticResolverFactory(_ => new[]
             {
-                new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port),
-                new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port)
+                new BalancerAddress(new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port)),
+                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
             }));
 
             var socketsHttpHandler = new SocketsHttpHandler
@@ -208,8 +208,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             var services = new ServiceCollection();
             services.AddSingleton<ResolverFactory>(new StaticResolverFactory(_ => new[]
             {
-                new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port),
-                new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port)
+                new BalancerAddress(new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port)),
+                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
             }));
             var socketsHttpHandler = new SocketsHttpHandler
             {

--- a/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
@@ -382,7 +382,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
                 subChannel = picker.Subchannel;
                 Logger.LogInformation($"Current subchannel: {subChannel}");
 
-                return subChannel.CurrentAddress?.Port == expectedPort;
+                return subChannel.CurrentAddress?.EndPoint.Port == expectedPort;
             }, "Wait for all subconnections to be connected.");
 
             Logger.LogInformation($"Finished waiting for subchannel ready.");

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -269,7 +269,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             endpoint1.Dispose();
 
             var subChannels = (await WaitForSubChannelsToBeReady(channel, 1).DefaultTimeout()).Single();
-            Assert.AreEqual(50052, subChannels.CurrentAddress?.Port);
+            Assert.AreEqual(50052, subChannels.CurrentAddress?.EndPoint.Port);
 
             reply1 = await client.UnaryCall(new HelloRequest { Name = "Balancer" });
             Assert.AreEqual("Balancer", reply1.Message);
@@ -304,10 +304,10 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
                 await syncPoint.WaitToContinue().DefaultTimeout();
                 syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
             });
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port),
-                new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port)
+                new BalancerAddress(new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port)),
+                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
             });
 
             var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), resolver, connect: true);
@@ -322,9 +322,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             await waitForRefreshTask.DefaultTimeout();
 
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port)
+                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
             });
 
             syncPoint.Continue();

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -306,8 +306,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             });
             resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new BalancerAddress(new DnsEndPoint(endpoint1.Address.Host, endpoint1.Address.Port)),
-                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
+                new BalancerAddress(endpoint1.Address.Host, endpoint1.Address.Port),
+                new BalancerAddress(endpoint2.Address.Host, endpoint2.Address.Port)
             });
 
             var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), resolver, connect: true);
@@ -324,7 +324,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new BalancerAddress(new DnsEndPoint(endpoint2.Address.Host, endpoint2.Address.Port))
+                new BalancerAddress(endpoint2.Address.Host, endpoint2.Address.Port)
             });
 
             syncPoint.Continue();

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectivityStateTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectivityStateTests.cs
@@ -72,9 +72,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.IsFalse(responseTask.IsCompleted);
             Assert.IsNull(authority);
 
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 81)
+                new BalancerAddress("localhost", 81)
             });
 
             await responseTask.DefaultTimeout();

--- a/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
@@ -51,9 +51,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
@@ -76,16 +76,16 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
             Assert.AreEqual(ConnectivityState.Ready, subchannels[0].State);
 
-            resolver.UpdateEndPoints(new List<DnsEndPoint> { new DnsEndPoint("localhost", 81) });
+            resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 81) });
 
             var newSubchannels = channel.ConnectionManager.GetSubchannels();
             CollectionAssert.AreEqual(subchannels, newSubchannels);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 81), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 81), subchannels[0]._addresses[0].EndPoint);
             Assert.AreEqual(ConnectivityState.Ready, subchannels[0].State);
         }
 
@@ -97,7 +97,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) });
+            resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
             var transportFactory = new TestSubchannelTransportFactory();
             services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
@@ -120,7 +120,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
 
             // Wait for TryConnect to be called so state is connected
             await transportFactory.Transports.Single().TryConnectTask.DefaultTimeout();
@@ -146,9 +146,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             var transportFactory = new TestSubchannelTransportFactory((s, c) => Task.FromResult(ConnectivityState.TransientFailure));
@@ -172,7 +172,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
             Assert.AreEqual(ConnectivityState.TransientFailure, subchannels[0].State);
 
             resolver.UpdateError(new Status(StatusCode.Internal, "Error!", new Exception("Test exception!")));
@@ -193,9 +193,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             SyncPoint syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
@@ -240,7 +240,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
             Assert.AreEqual(ConnectivityState.Ready, subchannels[0].State);
         }
 
@@ -252,9 +252,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             var transportConnectCount = 0;
@@ -284,7 +284,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
             Assert.AreEqual(ConnectivityState.Ready, subchannels[0].State);
 
             var stateChangedTask = channel.WaitForStateChangedAsync(ConnectivityState.Ready);
@@ -305,7 +305,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) });
+            resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
             var transportConnectCount = 0;
             var transportFactory = new TestSubchannelTransportFactory((s, c) =>
@@ -350,7 +350,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) });
+            resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
             var transportConnectCount = 0;
             var transportFactory = new TestSubchannelTransportFactory((s, c) =>
@@ -387,8 +387,8 @@ namespace Grpc.Net.Client.Tests.Balancer
             await stateChangedTask.DefaultTimeout();
             Assert.AreEqual(ConnectivityState.Ready, channel.State);
             Assert.AreEqual(2, transportConnectCount);
-            Assert.AreEqual("localhost", pick.Address.Host);
-            Assert.AreEqual(80, pick.Address.Port);
+            Assert.AreEqual("localhost", pick.Address.EndPoint.Host);
+            Assert.AreEqual(80, pick.Address.EndPoint.Port);
         }
 
         [Test]
@@ -405,7 +405,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) });
+            resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
             ILogger? logger = null;
 
@@ -467,7 +467,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) });
+            resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
             ILogger? logger = null;
 

--- a/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
@@ -45,9 +45,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
@@ -78,9 +78,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var resolver = new TestResolver(() => tcs.Task);
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
@@ -137,7 +137,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var resolver = new TestResolver(() => tcs.Task);
-            var result = ResolverResult.ForResult(new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) }, resolvedServiceConfig);
+            var result = ResolverResult.ForResult(new List<BalancerAddress> { new BalancerAddress("localhost", 80) }, resolvedServiceConfig);
             resolver.UpdateResult(result);
 
             var createdCount = 0;
@@ -190,7 +190,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var resolver = new TestResolver(() => tcs.Task);
-            var result = ResolverResult.ForResult(new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) }, serviceConfig: null);
+            var result = ResolverResult.ForResult(new List<BalancerAddress> { new BalancerAddress("localhost", 80) }, serviceConfig: null);
             resolver.UpdateResult(result);
 
             TestLoadBalancer? firstLoadBalancer = null;
@@ -253,13 +253,13 @@ namespace Grpc.Net.Client.Tests.Balancer
             syncPoint!.Continue();
 
             var pick = await channel.ConnectionManager.PickAsync(new PickContext(), true, CancellationToken.None).AsTask().DefaultTimeout();
-            Assert.AreEqual(80, pick.Address.Port);
+            Assert.AreEqual(80, pick.Address.EndPoint.Port);
 
             // Create new SyncPoint so new load balancer is waiting to connect
             syncPoint = new SyncPoint(runContinuationsAsynchronously: false);
 
             result = ResolverResult.ForResult(
-                new List<DnsEndPoint> { new DnsEndPoint("localhost", 81) },
+                new List<BalancerAddress> { new BalancerAddress("localhost", 81) },
                 serviceConfig: new ServiceConfig
                 {
                     LoadBalancingConfigs = { new LoadBalancingConfig("custom") }
@@ -271,7 +271,7 @@ namespace Grpc.Net.Client.Tests.Balancer
 
             // Old address is still used because new load balancer is connecting
             pick = await channel.ConnectionManager.PickAsync(new PickContext(), true, CancellationToken.None).AsTask().DefaultTimeout();
-            Assert.AreEqual(80, pick.Address.Port);
+            Assert.AreEqual(80, pick.Address.EndPoint.Port);
 
             Assert.IsFalse(firstLoadBalancer!.Disposed);
 
@@ -279,7 +279,7 @@ namespace Grpc.Net.Client.Tests.Balancer
 
             // New address is used
             pick = await channel.ConnectionManager.PickAsync(new PickContext(), true, CancellationToken.None).AsTask().DefaultTimeout();
-            Assert.AreEqual(81, pick.Address.Port);
+            Assert.AreEqual(81, pick.Address.EndPoint.Port);
 
             Assert.IsTrue(firstLoadBalancer!.Disposed);
 
@@ -294,8 +294,8 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(
-                new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) },
+            resolver.UpdateAddresses(
+                new List<BalancerAddress> { new BalancerAddress("localhost", 80) },
                 new ServiceConfig
                 {
                     LoadBalancingConfigs = { new RoundRobinConfig() }
@@ -345,8 +345,8 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(
-                new List<DnsEndPoint> { new DnsEndPoint("localhost", 80) },
+            resolver.UpdateAddresses(
+                new List<BalancerAddress> { new BalancerAddress("localhost", 80) },
                 new ServiceConfig
                 {
                     LoadBalancingConfigs = { new LoadBalancingConfig("unknown!") }

--- a/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
@@ -48,9 +48,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             var transportFactory = new TestSubchannelTransportFactory();
@@ -75,15 +75,15 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
 
             // Wait for TryConnect to be called so state is connected
             await transportFactory.Transports.Single().TryConnectTask.DefaultTimeout();
             Assert.AreEqual(ConnectivityState.Ready, subchannels[0].State);
 
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 81)
+                new BalancerAddress("localhost", 81)
             });
             Assert.AreEqual(ConnectivityState.Shutdown, subchannels[0].State);
 
@@ -92,7 +92,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, newSubchannels.Count);
 
             Assert.AreEqual(1, newSubchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 81), newSubchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 81), newSubchannels[0]._addresses[0].EndPoint);
 
             await channel.ConnectionManager.PickAsync(new PickContext { Request = new HttpRequestMessage() }, waitForReady: false, CancellationToken.None).AsTask().DefaultTimeout();
             Assert.AreEqual(ConnectivityState.Ready, newSubchannels[0].State);
@@ -106,9 +106,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             var transportFactory = new TestSubchannelTransportFactory();
@@ -133,7 +133,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
 
             // Wait for TryConnect to be called so state is connected
             await transportFactory.Transports.Single().TryConnectTask.DefaultTimeout();
@@ -159,9 +159,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             services.AddNUnitLogger();
 
             var resolver = new TestResolver();
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             var transportFactory = new TestSubchannelTransportFactory((s, c) => Task.FromResult(ConnectivityState.TransientFailure));
@@ -186,7 +186,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
 
             await transportFactory.Transports.Single().TryConnectTask.DefaultTimeout();
             Assert.AreEqual(ConnectivityState.TransientFailure, subchannels[0].State);
@@ -215,9 +215,9 @@ namespace Grpc.Net.Client.Tests.Balancer
                 await syncPoint.WaitToContinue().DefaultTimeout();
                 syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
             });
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 80)
+                new BalancerAddress("localhost", 80)
             });
 
             var connectState = ConnectivityState.Ready;
@@ -247,7 +247,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.AreEqual(1, subchannels.Count);
 
             Assert.AreEqual(1, subchannels[0]._addresses.Count);
-            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0]);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
 
             await transportFactory.Transports.Single().TryConnectTask.DefaultTimeout();
             Assert.AreEqual(ConnectivityState.Ready, subchannels[0].State);

--- a/test/Grpc.Net.Client.Tests/Balancer/WaitForReadyTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/WaitForReadyTests.cs
@@ -79,9 +79,9 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.IsFalse(responseTask.IsCompleted);
             Assert.IsNull(authority);
 
-            resolver.UpdateEndPoints(new List<DnsEndPoint>
+            resolver.UpdateAddresses(new List<BalancerAddress>
             {
-                new DnsEndPoint("localhost", 81)
+                new BalancerAddress("localhost", 81)
             });
 
             await responseTask.DefaultTimeout();

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
@@ -36,7 +36,7 @@ namespace Grpc.Net.Client.Tests.Infrastructure.Balancer
 
         public Subchannel Subchannel { get; }
 
-        public DnsEndPoint? CurrentEndPoint { get; private set; }
+        public BalancerAddress? CurrentAddress { get; private set; }
 
         public Task TryConnectTask => _connectTcs.Task;
 
@@ -68,7 +68,7 @@ namespace Grpc.Net.Client.Tests.Infrastructure.Balancer
 
         public void Disconnect()
         {
-            CurrentEndPoint = null;
+            CurrentAddress = null;
             Subchannel.UpdateConnectivityState(ConnectivityState.Idle, "Disconnected.");
         }
 
@@ -82,7 +82,7 @@ namespace Grpc.Net.Client.Tests.Infrastructure.Balancer
         {
             var newState = await (_onTryConnect?.Invoke(cancellationToken) ?? Task.FromResult(ConnectivityState.Ready));
 
-            CurrentEndPoint = Subchannel._addresses[0];
+            CurrentAddress = Subchannel._addresses[0];
             Subchannel.UpdateConnectivityState(newState, Status.DefaultSuccess);
 
             _connectTcs.TrySetResult(null);

--- a/test/Shared/TestResolver.cs
+++ b/test/Shared/TestResolver.cs
@@ -39,9 +39,9 @@ namespace Grpc.Tests.Shared
             _onRefreshAsync = onRefreshAsync;
         }
 
-        public void UpdateEndPoints(List<DnsEndPoint> endPoints, ServiceConfig? serviceConfig = null)
+        public void UpdateAddresses(List<BalancerAddress> addresses, ServiceConfig? serviceConfig = null)
         {
-            UpdateResult(ResolverResult.ForResult(endPoints, serviceConfig));
+            UpdateResult(ResolverResult.ForResult(addresses, serviceConfig));
         }
 
         public void UpdateError(Status status)
@@ -62,7 +62,7 @@ namespace Grpc.Tests.Shared
 
         public override Task RefreshAsync(CancellationToken cancellationToken)
         {
-            _listener?.Invoke(_result ?? ResolverResult.ForResult(Array.Empty<DnsEndPoint>(), serviceConfig: null));
+            _listener?.Invoke(_result ?? ResolverResult.ForResult(Array.Empty<BalancerAddress>(), serviceConfig: null));
             return _onRefreshAsync?.Invoke() ?? Task.CompletedTask;
         }
 

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -5,6 +5,9 @@
     <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net5.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
+
+    <!-- Turn on preview features so we can use Http3. Can be removed in .NET 7 -->
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Feedback from load balancing proposal review.

Addresses have changed from DnsEndPoint to BalancerAddress. This allows an address to have attributes (aka metadata).