### PR TITLE
Resolver has separate error for fetching service config

### DIFF
--- a/src/Grpc.Net.Client/Balancer/DnsResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/DnsResolver.cs
@@ -147,7 +147,7 @@ namespace Grpc.Net.Client.Balancer
 
                 var resolvedPort = _address.Port == -1 ? 80 : _address.Port;
                 var endpoints = addresses.Select(a => new BalancerAddress(a.ToString(), resolvedPort)).ToArray();
-                var resolverResult = ResolverResult.ForResult(endpoints, serviceConfig: null);
+                var resolverResult = ResolverResult.ForResult(endpoints);
                 _listener(resolverResult);
             }
             catch (Exception ex)

--- a/src/Grpc.Net.Client/Balancer/StaticResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/StaticResolver.cs
@@ -59,7 +59,7 @@ namespace Grpc.Net.Client.Balancer
                 throw new InvalidOperationException("Resolver hasn't been started.");
             }
 
-            _listener(ResolverResult.ForResult(_addresses, serviceConfig: null));
+            _listener(ResolverResult.ForResult(_addresses));
             return Task.CompletedTask;
         }
 

--- a/test/Shared/TestResolver.cs
+++ b/test/Shared/TestResolver.cs
@@ -39,9 +39,9 @@ namespace Grpc.Tests.Shared
             _onRefreshAsync = onRefreshAsync;
         }
 
-        public void UpdateAddresses(List<BalancerAddress> addresses, ServiceConfig? serviceConfig = null)
+        public void UpdateAddresses(List<BalancerAddress> addresses, ServiceConfig? serviceConfig = null, Status? serviceConfigStatus = null)
         {
-            UpdateResult(ResolverResult.ForResult(addresses, serviceConfig));
+            UpdateResult(ResolverResult.ForResult(addresses, serviceConfig, serviceConfigStatus));
         }
 
         public void UpdateError(Status status)
@@ -62,7 +62,7 @@ namespace Grpc.Tests.Shared
 
         public override Task RefreshAsync(CancellationToken cancellationToken)
         {
-            _listener?.Invoke(_result ?? ResolverResult.ForResult(Array.Empty<BalancerAddress>(), serviceConfig: null));
+            _listener?.Invoke(_result ?? ResolverResult.ForResult(Array.Empty<BalancerAddress>(), serviceConfig: null, serviceConfigStatus: null));
             return _onRefreshAsync?.Invoke() ?? Task.CompletedTask;
         }
 


### PR DESCRIPTION
Address feedback from load balancing proposal. Resolver can resolve a service config as well as addresses. A separate error should be specified to allow fallback behavior when just the service config has an error.