### PR TITLE
Sanity check for user agent string length not useful

### DIFF
--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -81,10 +81,8 @@ namespace Grpc.Net.Client.Tests
             Assert.AreEqual("grpc-dotnet", grpcVersion.Product?.Name);
             Assert.IsTrue(!string.IsNullOrEmpty(grpcVersion.Product?.Version));
 
-            // Santity check that the user agent doesn't have the git hash in it and isn't too long.
-            // Sending a long user agent with each call has performance implications.
+            // Sanity check that the user agent doesn't have the git hash in it.
             Assert.IsFalse(grpcVersion.Product!.Version!.Contains('+'));
-            Assert.IsTrue(grpcVersion.Product!.Version!.Length <= 10);
         }
 
         [Test]


### PR DESCRIPTION
Length of user agent string isn't as important for performance as one could think.
The reason is that HTTP/2 uses HPACK compression for headers, so the long user agent string in actually sent only once per connection (subsequent RPCs only do a table lookup to get the user agent string value). In real life, the length of user agent string will have no effect on performance even for very high qps.

Context: https://github.com/grpc/grpc-dotnet/pull/1479#issuecomment-966065439