### PR TITLE
DNS resolver fix port usage

### DIFF
--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -138,6 +138,11 @@ namespace Grpc.AspNetCore.FunctionalTests
             });
         }
 
+        protected bool HasLogException(Func<Exception, bool> exceptionMatch)
+        {
+            return Logs.Any(x => x.Exception != null && exceptionMatch(x.Exception));
+        }
+
         protected void SetExpectedErrorsFilter(Func<LogRecord, bool> expectedErrorsFilter)
         {
             _testContext!.Scope.ExpectedErrorsFilter = expectedErrorsFilter;


### PR DESCRIPTION
Fixes problem with using port in DNS resolver.

Currently Port of address property is always -1 as `dns:///` is not parsed well. This PR uses only hostname for DNS resolution and allows port to be read from Uri. 

Test **DNS_Port_Works** failed before this PR

Maybe best option is to use // instead of /// for dns resolver