### PR TITLE
Refactor client load balancing resolver

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -517,9 +517,9 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         private static readonly Action<ILogger, Exception?> _pickWaiting =
             LoggerMessage.Define(LogLevel.Trace, new EventId(11, "PickWaiting"), "Waiting for a new picker.");
+
         private static readonly Action<ILogger, Status, Exception?> _resolverServiceConfigFallback =
             LoggerMessage.Define<Status>(LogLevel.Debug, new EventId(12, "ResolverServiceConfigFallback"), "Falling back to previously loaded service config. Resolver failure when retreiving or parsing service config with status: {Status}");
-
 
         public static void ResolverUnsupportedLoadBalancingConfig(ILogger logger, IList<LoadBalancingConfig> loadBalancingConfigs)
         {

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -25,7 +25,6 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
-using Grpc.Net.Client.Balancer.Internal;
 using Grpc.Net.Client.Configuration;
 using Grpc.Net.Client.Internal;
 using Grpc.Shared;
@@ -33,7 +32,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.Net.Client.Balancer.Internal
 {
-    internal class ConnectionManager : IDisposable, IChannelControlHelper
+    internal sealed class ConnectionManager : IDisposable, IChannelControlHelper
     {
         private static readonly ServiceConfig DefaultServiceConfig = new ServiceConfig();
 
@@ -43,13 +42,12 @@ namespace Grpc.Net.Client.Balancer.Internal
         private readonly ISubchannelTransportFactory _subchannelTransportFactory;
         private readonly List<Subchannel> _subchannels;
         private readonly List<StateWatcher> _stateWatchers;
-        private readonly CancellationTokenSource _cts;
+        private readonly TaskCompletionSource<object?> _resolverStartedTcs;
 
         // Internal for testing
         internal LoadBalancer? _balancer;
         internal SubchannelPicker? _picker;
-        private Task? _resolverRefreshTask;
-        private Task? _resolveTask;
+        private bool _resolverStarted;
         private TaskCompletionSource<SubchannelPicker> _nextPickerTcs;
         private int _currentSubchannelId;
         private ServiceConfig? _previousServiceConfig;
@@ -64,9 +62,9 @@ namespace Grpc.Net.Client.Balancer.Internal
             _lock = new object();
             _nextPickerLock = new SemaphoreSlim(1);
             _nextPickerTcs = new TaskCompletionSource<SubchannelPicker>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _cts = new CancellationTokenSource();
+            _resolverStartedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            Logger = loggerFactory.CreateLogger(GetType());
+            Logger = loggerFactory.CreateLogger<ConnectionManager>();
             LoggerFactory = loggerFactory;
 
             _subchannels = new List<Subchannel>();
@@ -117,31 +115,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         void IChannelControlHelper.RefreshResolver()
         {
-            lock (_lock)
-            {
-                ConnectionManagerLog.ResolverRefreshRequested(Logger);
-
-                if (_resolveTask == null || !_resolveTask.IsCompleted)
-                {
-                    _resolveTask = ResolveNowAsync(_cts.Token);
-                }
-                else
-                {
-                    ConnectionManagerLog.ResolverRefreshIgnored(Logger);
-                }
-            }
-        }
-
-        private async Task ResolveNowAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                await _resolver.RefreshAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                ConnectionManagerLog.ResolverRefreshError(Logger, ex);
-            }
+            _resolver.Refresh();
         }
 
         private void OnResolverResult(ResolverResult result)
@@ -217,12 +191,12 @@ namespace Grpc.Net.Client.Balancer.Internal
             lock (_lock)
             {
                 _balancer.UpdateChannelState(state);
+                _resolverStartedTcs.TrySetResult(null);
             }
         }
 
         public void Dispose()
         {
-            _cts.Cancel();
             _resolver.Dispose();
             _nextPickerLock.Dispose();
             lock (_lock)
@@ -279,19 +253,21 @@ namespace Grpc.Net.Client.Balancer.Internal
         {
             // Ensure that the resolver has started and has resolved at least once.
             // This ensures an inner load balancer has been created and is running.
-            if (_resolverRefreshTask == null)
+            if (!_resolverStarted)
             {
                 lock (_lock)
                 {
-                    if (_resolverRefreshTask == null)
+                    if (!_resolverStarted)
                     {
                         _resolver.Start(OnResolverResult);
-                        _resolverRefreshTask = _resolver.RefreshAsync(_cts.Token);
+                        _resolver.Refresh();
+
+                        _resolverStarted = true;
                     }
                 }
             }
 
-            return _resolverRefreshTask;
+            return _resolverStartedTcs.Task;
         }
 
         public void UpdateState(BalancerState state)
@@ -509,65 +485,41 @@ namespace Grpc.Net.Client.Balancer.Internal
 
     internal static class ConnectionManagerLog
     {
-        private static readonly Action<ILogger, Exception?> _resolverRefreshRequested =
-            LoggerMessage.Define(LogLevel.Trace, new EventId(1, "ResolverRefreshRequested"), "Resolver refresh requested.");
-
-        private static readonly Action<ILogger, Exception?> _resolverRefreshIgnored =
-            LoggerMessage.Define(LogLevel.Trace, new EventId(2, "ResolverRefreshIgnored"), "Resolver refresh ignored because resolve is already in progress.");
-
-        private static readonly Action<ILogger, Exception?> _resolverRefreshError =
-            LoggerMessage.Define(LogLevel.Error, new EventId(3, "ResolverRefreshError"), "Error refreshing resolver.");
-
         private static readonly Action<ILogger, string, Exception?> _resolverUnsupportedLoadBalancingConfig =
-            LoggerMessage.Define<string>(LogLevel.Warning, new EventId(4, "ResolverUnsupportedLoadBalancingConfig"), "Service config returned by the resolver contains unsupported load balancer policies: {LoadBalancingConfigs}. Load balancer unchanged.");
+            LoggerMessage.Define<string>(LogLevel.Warning, new EventId(1, "ResolverUnsupportedLoadBalancingConfig"), "Service config returned by the resolver contains unsupported load balancer policies: {LoadBalancingConfigs}. Load balancer unchanged.");
 
         private static readonly Action<ILogger, Exception?> _resolverServiceConfigNotUsed =
-            LoggerMessage.Define(LogLevel.Debug, new EventId(5, "ResolverServiceConfigNotUsed"), "Service config returned by the resolver not used.");
+            LoggerMessage.Define(LogLevel.Debug, new EventId(2, "ResolverServiceConfigNotUsed"), "Service config returned by the resolver not used.");
 
         private static readonly Action<ILogger, ConnectivityState, Exception?> _channelStateUpdated =
-            LoggerMessage.Define<ConnectivityState>(LogLevel.Debug, new EventId(6, "ChannelStateUpdated"), "Channel state updated to {State}.");
+            LoggerMessage.Define<ConnectivityState>(LogLevel.Debug, new EventId(3, "ChannelStateUpdated"), "Channel state updated to {State}.");
 
         private static readonly Action<ILogger, Exception?> _channelPickerUpdated =
-            LoggerMessage.Define(LogLevel.Debug, new EventId(7, "ChannelPickerUpdated"), "Channel picker updated.");
+            LoggerMessage.Define(LogLevel.Debug, new EventId(4, "ChannelPickerUpdated"), "Channel picker updated.");
 
         private static readonly Action<ILogger, Exception?> _pickStarted =
-            LoggerMessage.Define(LogLevel.Trace, new EventId(8, "PickStarted"), "Pick started.");
+            LoggerMessage.Define(LogLevel.Trace, new EventId(5, "PickStarted"), "Pick started.");
 
         private static readonly Action<ILogger, int, DnsEndPoint, Exception?> _pickResultSuccessful =
-            LoggerMessage.Define<int, DnsEndPoint>(LogLevel.Debug, new EventId(9, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}.");
+            LoggerMessage.Define<int, DnsEndPoint>(LogLevel.Debug, new EventId(6, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}.");
 
         private static readonly Action<ILogger, int, Exception?> _pickResultSubchannelNoCurrentAddress =
-            LoggerMessage.Define<int>(LogLevel.Debug, new EventId(10, "PickResultSubchannelNoCurrentAddress"), "Picked subchannel id '{SubchannelId}' doesn't have a current address.");
+            LoggerMessage.Define<int>(LogLevel.Debug, new EventId(7, "PickResultSubchannelNoCurrentAddress"), "Picked subchannel id '{SubchannelId}' doesn't have a current address.");
 
         private static readonly Action<ILogger, Exception?> _pickResultQueued =
-            LoggerMessage.Define(LogLevel.Debug, new EventId(11, "PickResultQueued"), "Picked queued.");
+            LoggerMessage.Define(LogLevel.Debug, new EventId(8, "PickResultQueued"), "Picked queued.");
 
         private static readonly Action<ILogger, Status, Exception?> _pickResultFailure =
-            LoggerMessage.Define<Status>(LogLevel.Debug, new EventId(12, "PickResultFailure"), "Picked failure with status: {Status}");
+            LoggerMessage.Define<Status>(LogLevel.Debug, new EventId(9, "PickResultFailure"), "Picked failure with status: {Status}");
 
         private static readonly Action<ILogger, Status, Exception?> _pickResultFailureWithWaitForReady =
-            LoggerMessage.Define<Status>(LogLevel.Debug, new EventId(13, "PickResultFailureWithWaitForReady"), "Picked failure with status: {Status}. Retrying because wait for ready is enabled.");
+            LoggerMessage.Define<Status>(LogLevel.Debug, new EventId(10, "PickResultFailureWithWaitForReady"), "Picked failure with status: {Status}. Retrying because wait for ready is enabled.");
 
         private static readonly Action<ILogger, Exception?> _pickWaiting =
-            LoggerMessage.Define(LogLevel.Trace, new EventId(14, "PickWaiting"), "Waiting for a new picker.");
-
+            LoggerMessage.Define(LogLevel.Trace, new EventId(11, "PickWaiting"), "Waiting for a new picker.");
         private static readonly Action<ILogger, Status, Exception?> _resolverServiceConfigFallback =
-            LoggerMessage.Define<Status>(LogLevel.Debug, new EventId(15, "ResolverServiceConfigFallback"), "Falling back to previously loaded service config. Resolver failure when retreiving or parsing service config with status: {Status}");
+            LoggerMessage.Define<Status>(LogLevel.Debug, new EventId(12, "ResolverServiceConfigFallback"), "Falling back to previously loaded service config. Resolver failure when retreiving or parsing service config with status: {Status}");
 
-        public static void ResolverRefreshRequested(ILogger logger)
-        {
-            _resolverRefreshRequested(logger, null);
-        }
-
-        public static void ResolverRefreshIgnored(ILogger logger)
-        {
-            _resolverRefreshIgnored(logger, null);
-        }
-
-        public static void ResolverRefreshError(ILogger logger, Exception ex)
-        {
-            _resolverRefreshError(logger, ex);
-        }
 
         public static void ResolverUnsupportedLoadBalancingConfig(ILogger logger, IList<LoadBalancingConfig> loadBalancingConfigs)
         {

--- a/src/Grpc.Net.Client/Balancer/Resolver.cs
+++ b/src/Grpc.Net.Client/Balancer/Resolver.cs
@@ -25,6 +25,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client.Configuration;
+using Grpc.Net.Client.Internal;
+using Microsoft.Extensions.Logging;
 
 namespace Grpc.Net.Client.Balancer
 {
@@ -38,7 +40,7 @@ namespace Grpc.Net.Client.Balancer
     /// </para>
     /// <para>
     /// A <see cref="Resolver"/> doesn't need to automatically re-resolve on failure. Instead, the callback
-    /// is responsible for eventually invoking <see cref="RefreshAsync(CancellationToken)"/>.
+    /// is responsible for eventually invoking <see cref="Refresh()"/>.
     /// </para>
     /// <para>
     /// Note: Experimental API that can change or be removed without any prior notice.
@@ -46,6 +48,33 @@ namespace Grpc.Net.Client.Balancer
     /// </summary>
     public abstract class Resolver : IDisposable
     {
+        private Task _resolveTask = Task.CompletedTask;
+        private Action<ResolverResult>? _listener;
+        private bool _disposed;
+
+        private readonly object _lock = new object();
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Gets the listener.
+        /// </summary>
+        protected Action<ResolverResult> Listener => _listener!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Resolver"/>.
+        /// </summary>
+        /// <param name="loggerFactory">The logger factory.</param>
+        protected Resolver(ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<Resolver>();
+        }
+
         /// <summary>
         /// Starts listening to resolver for results with the specified callback. Can only be called once.
         /// <para>
@@ -54,18 +83,96 @@ namespace Grpc.Net.Client.Balancer
         /// </para>
         /// </summary>
         /// <param name="listener">The callback used to receive updates on the target.</param>
-        public abstract void Start(Action<ResolverResult> listener);
+        public void Start(Action<ResolverResult> listener)
+        {
+            if (listener == null)
+            {
+                throw new ArgumentNullException(nameof(listener));
+            }
+
+            if (_listener != null)
+            {
+                throw new InvalidOperationException("Resolver has already been started.");
+            }
+
+            _listener = (result) =>
+            {
+                Log.ResolverResult(_logger, result.Status.StatusCode, result.Addresses?.Count ?? 0);
+                listener(result);
+            };
+
+            OnStarted();
+        }
 
         /// <summary>
-        /// Refresh resolution. Updated results are passed to the callback.
-        /// Can only be called after <see cref="Start(Action{ResolverResult})"/>.
+        /// Executes after the resolver starts.
+        /// </summary>
+        protected virtual void OnStarted()
+        {
+        }
+
+        /// <summary>
+        /// Refresh resolution. Can only be called after <see cref="Start(Action{ResolverResult})"/>.
+        /// <para>
+        /// This is only a hint. Implementation takes it as a signal but may not start resolution.
+        /// </para>
+        /// </summary>
+        public void Refresh()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(DnsResolver));
+            }
+            if (_listener == null)
+            {
+                throw new InvalidOperationException("Resolver hasn't been started.");
+            }
+
+            lock (_lock)
+            {
+                Log.ResolverRefreshRequested(_logger);
+
+                if (_resolveTask.IsCompleted)
+                {
+                    _resolveTask = ResolveNowAsync(_cts.Token);
+                }
+                else
+                {
+                    Log.ResolverRefreshIgnored(_logger);
+                }
+            }
+        }
+
+        private async Task ResolveNowAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await ResolveAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Ignore cancellation.
+            }
+            catch (Exception ex)
+            {
+                Log.ResolverRefreshError(_logger, ex);
+
+                var status = GrpcProtocolHelpers.CreateStatusFromException("Error refreshing resolver.", ex);
+                Listener(ResolverResult.ForFailure(status));
+            }
+        }
+
+        /// <summary>
+        /// Resolve the target <see cref="Uri"/>. Updated results are passed to the callback
+        /// registered by <see cref="Start(Action{ResolverResult})"/>. Can only be called
+        /// after the resolver has started.
         /// <para>
         /// This is only a hint. Implementation takes it as a signal but may not start resolution.
         /// </para>
         /// </summary>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task.</returns>
-        public abstract Task RefreshAsync(CancellationToken cancellationToken);
+        protected abstract Task ResolveAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Releases the unmanaged resources used by the <see cref="LoadBalancer"/> and optionally releases
@@ -76,6 +183,7 @@ namespace Grpc.Net.Client.Balancer
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
+            _cts.Cancel();
         }
 
         /// <summary>
@@ -85,6 +193,43 @@ namespace Grpc.Net.Client.Balancer
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+
+            _disposed = true;
+        }
+
+        internal static class Log
+        {
+            private static readonly Action<ILogger, Exception?> _resolverRefreshRequested =
+                LoggerMessage.Define(LogLevel.Trace, new EventId(1, "ResolverRefreshRequested"), "Resolver refresh requested.");
+
+            private static readonly Action<ILogger, Exception?> _resolverRefreshIgnored =
+                LoggerMessage.Define(LogLevel.Trace, new EventId(2, "ResolverRefreshIgnored"), "Resolver refresh ignored because resolve is already in progress.");
+
+            private static readonly Action<ILogger, Exception?> _resolverRefreshError =
+                LoggerMessage.Define(LogLevel.Error, new EventId(3, "ResolverRefreshError"), "Error refreshing resolver.");
+
+            private static readonly Action<ILogger, StatusCode, int, Exception?> _resolverResult =
+                LoggerMessage.Define<StatusCode, int>(LogLevel.Trace, new EventId(4, "ResolverResult"), "Resolver result with status code '{StatusCode}' and {AddressCount} addresses.");
+
+            public static void ResolverRefreshRequested(ILogger logger)
+            {
+                _resolverRefreshRequested(logger, null);
+            }
+
+            public static void ResolverRefreshIgnored(ILogger logger)
+            {
+                _resolverRefreshIgnored(logger, null);
+            }
+
+            public static void ResolverRefreshError(ILogger logger, Exception ex)
+            {
+                _resolverRefreshError(logger, ex);
+            }
+
+            public static void ResolverResult(ILogger logger, StatusCode statusCode, int addressCount)
+            {
+                _resolverResult(logger, statusCode, addressCount, null);
+            }
         }
     }
 

--- a/src/Grpc.Net.Client/Balancer/StaticResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/StaticResolver.cs
@@ -51,7 +51,7 @@ namespace Grpc.Net.Client.Balancer
         protected override void OnStarted()
         {
             // Send addresses to listener once. They will never change.
-            Listener(ResolverResult.ForResult(_addresses, serviceConfig: null));
+            Listener(ResolverResult.ForResult(_addresses, serviceConfig: null, serviceConfigStatus: null));
         }
 
         /// <inheritdoc />

--- a/src/Grpc.Net.Client/Balancer/StaticResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/StaticResolver.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Grpc.Net.Client.Balancer
 {
@@ -35,54 +36,28 @@ namespace Grpc.Net.Client.Balancer
     internal sealed class StaticResolver : Resolver
     {
         private readonly List<BalancerAddress> _addresses;
-        private Action<ResolverResult>? _listener;
-        private bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StaticResolver"/> class with the specified addresses.
         /// </summary>
         /// <param name="addresses">The resolved addresses.</param>
-        public StaticResolver(IEnumerable<BalancerAddress> addresses)
+        /// <param name="loggerFactory">The logger factory.</param>
+        public StaticResolver(IEnumerable<BalancerAddress> addresses, ILoggerFactory loggerFactory)
+            : base(loggerFactory)
         {
             _addresses = addresses.ToList();
         }
 
-        /// <inheritdoc />
-        public override Task RefreshAsync(CancellationToken cancellationToken)
+        protected override void OnStarted()
         {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(DnsResolver));
-            }
-            if (_listener == null)
-            {
-                throw new InvalidOperationException("Resolver hasn't been started.");
-            }
+            // Send addresses to listener once. They will never change.
+            Listener(ResolverResult.ForResult(_addresses, serviceConfig: null));
+        }
 
-            _listener(ResolverResult.ForResult(_addresses));
+        /// <inheritdoc />
+        protected override Task ResolveAsync(CancellationToken cancellationToken)
+        {
             return Task.CompletedTask;
-        }
-
-        /// <inheritdoc />
-        public override void Start(Action<ResolverResult> listener)
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(DnsResolver));
-            }
-            if (_listener != null)
-            {
-                throw new InvalidOperationException("Resolver has already been started.");
-            }
-
-            _listener = listener;
-        }
-
-        /// <inheritdoc />
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            _disposed = true;
         }
     }
 
@@ -115,7 +90,7 @@ namespace Grpc.Net.Client.Balancer
         /// <inheritdoc />
         public override Resolver Create(ResolverOptions options)
         {
-            return new StaticResolver(_addressesCallback(options.Address));
+            return new StaticResolver(_addressesCallback(options.Address), options.LoggerFactory);
         }
     }
 }

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -131,7 +131,7 @@ namespace Grpc.Net.Client
             // Even with just one address we still want to use the load balancing infrastructure. This enables
             // the connectivity APIs on channel like GrpcChannel.State and GrpcChannel.WaitForStateChanged.
             var resolver = IsHttpOrHttpsAddress()
-                ? new StaticResolver(new[] { new BalancerAddress(Address.Host, Address.Port) })
+                ? new StaticResolver(new[] { new BalancerAddress(Address.Host, Address.Port) }, LoggerFactory)
                 : CreateResolver(channelOptions);
 
             ConnectionManager = new ConnectionManager(

--- a/test/FunctionalTests/Client/TelemetryTests.cs
+++ b/test/FunctionalTests/Client/TelemetryTests.cs
@@ -25,6 +25,7 @@ using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Net.Client;
+using Grpc.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
@@ -95,7 +96,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             using (DiagnosticListener.AllListeners.Subscribe(allSubscription))
 #endif
             {
-                await client.UnaryCall(new HelloRequest());
+                await client.UnaryCall(new HelloRequest()).ResponseAsync.DefaultTimeout();
             }
 
             // Assert

--- a/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncUnaryCallTests.cs
@@ -111,7 +111,8 @@ namespace Grpc.Net.Client.Tests
             var invoker = HttpClientCallInvokerFactory.Create(winHttpHandler, "https://localhost");
 
             // Act
-            var rs = await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "Hello world" });
+            var rs = await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(
+                ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "Hello world" }).ResponseAsync.DefaultTimeout();
 
             // Assert
             Assert.AreEqual("Hello world", rs.Message);
@@ -142,7 +143,8 @@ namespace Grpc.Net.Client.Tests
             var invoker = HttpClientCallInvokerFactory.Create(handler, "http://localhost");
 
             // Act
-            var rs = await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "World" });
+            var rs = await invoker.AsyncUnaryCall<HelloRequest, HelloReply>(
+                ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "World" }).ResponseAsync.DefaultTimeout();
 
             // Assert
             Assert.AreEqual("Hello world", rs.Message);

--- a/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
@@ -254,6 +254,9 @@ namespace Grpc.Net.Client.Tests.Balancer
 
             tcs.SetResult(null);
 
+            // Ensure that channel has processed results
+            await resolver.HasResolvedTask.DefaultTimeout();
+
             var subchannels = channel.ConnectionManager.GetSubchannels();
             Assert.AreEqual(1, subchannels.Count);
             Assert.AreEqual(ConnectivityState.Connecting, subchannels[0].State);

--- a/test/Grpc.Net.Client.Tests/CompressionTests.cs
+++ b/test/Grpc.Net.Client.Tests/CompressionTests.cs
@@ -197,7 +197,7 @@ namespace Grpc.Net.Client.Tests
             });
 
             // Assert
-            var response = await call.ResponseAsync;
+            var response = await call.ResponseAsync.DefaultTimeout();
             Assert.IsNotNull(response);
             Assert.AreEqual("Hello world", response.Message);
         }

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -206,7 +206,7 @@ namespace Grpc.Net.Client.Tests
             var client = new Greeter.GreeterClient(channel);
 
             // Act
-            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(async () => await client.SayHelloAsync(new HelloRequest()));
+            var ex = await ExceptionAssert.ThrowsAsync<RpcException>(async () => await client.SayHelloAsync(new HelloRequest())).DefaultTimeout();
 
             // Assert
             Assert.AreEqual("HttpHandler", ex.Status.DebugException.Message);
@@ -803,18 +803,17 @@ namespace Grpc.Net.Client.Tests
 
             public override Resolver Create(ResolverOptions options)
             {
-                return new ChannelTestResolver();
+                return new ChannelTestResolver(options.LoggerFactory);
             }
         }
 
         public class ChannelTestResolver : Resolver
         {
-            public override Task RefreshAsync(CancellationToken cancellationToken)
+            public ChannelTestResolver(ILoggerFactory loggerFactory) : base(loggerFactory)
             {
-                throw new NotImplementedException();
             }
 
-            public override void Start(Action<ResolverResult> listener)
+            protected override Task ResolveAsync(CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }

--- a/test/Shared/TestResolver.cs
+++ b/test/Shared/TestResolver.cs
@@ -59,12 +59,7 @@ namespace Grpc.Tests.Shared
             Listener?.Invoke(result);
         }
 
-        protected override void Dispose(bool disposing)
-        {
-            _listener = null;
-        }
-
-        public override Task RefreshAsync(CancellationToken cancellationToken)
+        protected override async Task ResolveAsync(CancellationToken cancellationToken)
         {
             if (_onRefreshAsync != null)
             {
@@ -73,12 +68,6 @@ namespace Grpc.Tests.Shared
 
             Listener(_result ?? ResolverResult.ForResult(Array.Empty<BalancerAddress>(), serviceConfig: null, serviceConfigStatus: null));
             _hasResolvedTcs.TrySetResult(null);
-
-        }
-
-        public override void Start(Action<ResolverResult> listener)
-        {
-            _listener = listener;
         }
     }
 }

--- a/test/Shared/TestResolver.cs
+++ b/test/Shared/TestResolver.cs
@@ -25,18 +25,22 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client.Balancer;
 using Grpc.Net.Client.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Grpc.Tests.Shared
 {
     internal class TestResolver : Resolver
     {
         private readonly Func<Task>? _onRefreshAsync;
+        private readonly TaskCompletionSource<object?> _hasResolvedTcs;
         private ResolverResult? _result;
-        private Action<ResolverResult>? _listener;
 
-        public TestResolver(Func<Task>? onRefreshAsync = null)
+        public Task HasResolvedTask => _hasResolvedTcs.Task;
+
+        public TestResolver(Func<Task>? onRefreshAsync = null) : base(NullLoggerFactory.Instance)
         {
             _onRefreshAsync = onRefreshAsync;
+            _hasResolvedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         public void UpdateAddresses(List<BalancerAddress> addresses, ServiceConfig? serviceConfig = null, Status? serviceConfigStatus = null)
@@ -52,7 +56,7 @@ namespace Grpc.Tests.Shared
         public void UpdateResult(ResolverResult result)
         {
             _result = result;
-            _listener?.Invoke(result);
+            Listener?.Invoke(result);
         }
 
         protected override void Dispose(bool disposing)
@@ -62,8 +66,14 @@ namespace Grpc.Tests.Shared
 
         public override Task RefreshAsync(CancellationToken cancellationToken)
         {
-            _listener?.Invoke(_result ?? ResolverResult.ForResult(Array.Empty<BalancerAddress>(), serviceConfig: null, serviceConfigStatus: null));
-            return _onRefreshAsync?.Invoke() ?? Task.CompletedTask;
+            if (_onRefreshAsync != null)
+            {
+                await _onRefreshAsync();
+            }
+
+            Listener(_result ?? ResolverResult.ForResult(Array.Empty<BalancerAddress>(), serviceConfig: null, serviceConfigStatus: null));
+            _hasResolvedTcs.TrySetResult(null);
+
         }
 
         public override void Start(Action<ResolverResult> listener)


### PR DESCRIPTION
The main change is `RefreshAsync` -> `Refresh` and add a protected `ResolveAsync` method. CancellationToken is based on dispose.
