### PR TITLE
DNS resolver fix port usage

### DIFF
--- a/src/Grpc.Net.Client/Balancer/ResolverOptions.cs
+++ b/src/Grpc.Net.Client/Balancer/ResolverOptions.cs
@@ -33,9 +33,10 @@ namespace Grpc.Net.Client.Balancer
         /// <summary>
         /// Initializes a new instance of the <see cref="ResolverOptions"/> class.
         /// </summary>
-        internal ResolverOptions(Uri address, bool disableServiceConfig, ILoggerFactory loggerFactory)
+        internal ResolverOptions(Uri address, int defaultPort, bool disableServiceConfig, ILoggerFactory loggerFactory)
         {
             Address = address;
+            DefaultPort = defaultPort;
             DisableServiceConfig = disableServiceConfig;
             LoggerFactory = loggerFactory;
         }
@@ -44,6 +45,11 @@ namespace Grpc.Net.Client.Balancer
         /// Gets the address.
         /// </summary>
         public Uri Address { get; }
+
+        /// <summary>
+        /// Gets the default port. This port is used when the resolver address doesn't specify a port.
+        /// </summary>
+        public int DefaultPort { get; }
 
         /// <summary>
         /// Gets a flag indicating whether the resolver should disable resolving a service config.

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -138,6 +138,11 @@ namespace Grpc.AspNetCore.FunctionalTests
             });
         }
 
+        protected bool HasLogException(Func<Exception, bool> exceptionMatch)
+        {
+            return Logs.Any(x => x.Exception != null && exceptionMatch(x.Exception));
+        }
+
         protected void SetExpectedErrorsFilter(Func<LogRecord, bool> expectedErrorsFilter)
         {
             _testContext!.Scope.ExpectedErrorsFilter = expectedErrorsFilter;


### PR DESCRIPTION
Replaces https://github.com/grpc/grpc-dotnet/pull/1489

* Preserve the original address
* Move parsing to the DnsResolver constructor rather than per-resolve.
* Add default port to resolver args

@vasicvuk