### PR TITLE
Log BalancerAddress instead of DnsEndPoint in load balancing

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -302,13 +302,7 @@ namespace Grpc.Net.Client.Balancer.Internal
             }
         }
 
-        public async
-#if !NETSTANDARD2_0
-            ValueTask<(Subchannel Subchannel, BalancerAddress Address, Action<CompletionContext> OnComplete)>
-#else
-            Task<(Subchannel Subchannel, DnsEndPoint Address, Action<CompleteContext> OnComplete)>
-#endif
-            PickAsync(PickContext context, bool waitForReady, CancellationToken cancellationToken)
+        public async ValueTask<(Subchannel Subchannel, BalancerAddress Address, Action<CompletionContext> OnComplete)> PickAsync(PickContext context, bool waitForReady, CancellationToken cancellationToken)
         {
             SubchannelPicker? previousPicker = null;
 
@@ -330,7 +324,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
                         if (address != null)
                         {
-                            ConnectionManagerLog.PickResultSuccessful(Logger, subchannel.Id, address.EndPoint);
+                            ConnectionManagerLog.PickResultSuccessful(Logger, subchannel.Id, address);
                             return (subchannel, address, result.Complete);
                         }
                         else
@@ -500,8 +494,8 @@ namespace Grpc.Net.Client.Balancer.Internal
         private static readonly Action<ILogger, Exception?> _pickStarted =
             LoggerMessage.Define(LogLevel.Trace, new EventId(5, "PickStarted"), "Pick started.");
 
-        private static readonly Action<ILogger, int, DnsEndPoint, Exception?> _pickResultSuccessful =
-            LoggerMessage.Define<int, DnsEndPoint>(LogLevel.Debug, new EventId(6, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}.");
+        private static readonly Action<ILogger, int, BalancerAddress, Exception?> _pickResultSuccessful =
+            LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(6, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}.");
 
         private static readonly Action<ILogger, int, Exception?> _pickResultSubchannelNoCurrentAddress =
             LoggerMessage.Define<int>(LogLevel.Debug, new EventId(7, "PickResultSubchannelNoCurrentAddress"), "Picked subchannel id '{SubchannelId}' doesn't have a current address.");
@@ -550,7 +544,7 @@ namespace Grpc.Net.Client.Balancer.Internal
             _pickStarted(logger, null);
         }
 
-        public static void PickResultSuccessful(ILogger logger, int subchannelId, DnsEndPoint currentAddress)
+        public static void PickResultSuccessful(ILogger logger, int subchannelId, BalancerAddress currentAddress)
         {
             _pickResultSuccessful(logger, subchannelId, currentAddress, null);
         }

--- a/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
@@ -36,7 +36,7 @@ namespace Grpc.Net.Client.Balancer.Internal
         BalancerAddress? CurrentAddress { get; }
 
 #if NET5_0_OR_GREATER
-        ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken);
+        ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken);
 #endif
 
 #if !NETSTANDARD2_0

--- a/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
@@ -84,7 +84,7 @@ namespace Grpc.Net.Client.Balancer.Internal
         }
 
 #if NET5_0_OR_GREATER
-        public ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken)
+        public ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -49,15 +49,17 @@ namespace Grpc.Net.Client.Balancer.Internal
     /// </summary>
     internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDisposable
     {
+        internal record struct ActiveStream(BalancerAddress Address, Socket Socket, Stream? Stream);
+
         private readonly ILogger _logger;
         private readonly Subchannel _subchannel;
         private readonly TimeSpan _socketPingInterval;
-        private readonly List<(DnsEndPoint EndPoint, Socket Socket, Stream? Stream)> _activeStreams;
+        private readonly List<ActiveStream> _activeStreams;
         private readonly Timer _socketConnectedTimer;
 
         private int _lastEndPointIndex;
         private Socket? _initialSocket;
-        private DnsEndPoint? _initialSocketEndPoint;
+        private BalancerAddress? _initialSocketEndPoint;
         private bool _disposed;
         private BalancerAddress? _currentAddress;
 
@@ -66,7 +68,7 @@ namespace Grpc.Net.Client.Balancer.Internal
             _logger = loggerFactory.CreateLogger<SocketConnectivitySubchannelTransport>();
             _subchannel = subchannel;
             _socketPingInterval = socketPingInterval;
-            _activeStreams = new List<(DnsEndPoint, Socket, Stream?)>();
+            _activeStreams = new List<ActiveStream>();
             _socketConnectedTimer = new Timer(OnCheckSocketConnection, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         }
 
@@ -75,7 +77,7 @@ namespace Grpc.Net.Client.Balancer.Internal
         public bool HasStream { get; }
 
         // For testing. Take a copy under lock for thread-safety.
-        internal IReadOnlyList<(DnsEndPoint EndPoint, Socket Socket, Stream? Stream)> GetActiveStreams()
+        internal IReadOnlyList<ActiveStream> GetActiveStreams()
         {
             lock (Lock)
             {
@@ -119,16 +121,16 @@ namespace Grpc.Net.Client.Balancer.Internal
 
                 try
                 {
-                    SocketConnectivitySubchannelTransportLog.ConnectingSocket(_logger, currentAddress.EndPoint);
+                    SocketConnectivitySubchannelTransportLog.ConnectingSocket(_logger, currentAddress);
                     await socket.ConnectAsync(currentAddress.EndPoint, cancellationToken).ConfigureAwait(false);
-                    SocketConnectivitySubchannelTransportLog.ConnectedSocket(_logger, currentAddress.EndPoint);
+                    SocketConnectivitySubchannelTransportLog.ConnectedSocket(_logger, currentAddress);
 
                     lock (Lock)
                     {
                         _currentAddress = currentAddress;
                         _lastEndPointIndex = currentIndex;
                         _initialSocket = socket;
-                        _initialSocketEndPoint = currentAddress.EndPoint;
+                        _initialSocketEndPoint = currentAddress;
                         _socketConnectedTimer.Change(_socketPingInterval, _socketPingInterval);
                     }
 
@@ -137,7 +139,7 @@ namespace Grpc.Net.Client.Balancer.Internal
                 }
                 catch (Exception ex)
                 {
-                    SocketConnectivitySubchannelTransportLog.ErrorConnectingSocket(_logger, currentAddress.EndPoint, ex);
+                    SocketConnectivitySubchannelTransportLog.ErrorConnectingSocket(_logger, currentAddress, ex);
 
                     if (firstConnectionError == null)
                     {
@@ -210,16 +212,16 @@ namespace Grpc.Net.Client.Balancer.Internal
             }
         }
 
-        public async ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken)
+        public async ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken)
         {
-            SocketConnectivitySubchannelTransportLog.CreatingStream(_logger, endPoint);
+            SocketConnectivitySubchannelTransportLog.CreatingStream(_logger, address);
 
             Socket? socket = null;
             lock (Lock)
             {
                 if (_initialSocket != null &&
                     _initialSocketEndPoint != null &&
-                    Equals(_initialSocketEndPoint, endPoint))
+                    Equals(_initialSocketEndPoint, address))
                 {
                     socket = _initialSocket;
                     _initialSocket = null;
@@ -242,7 +244,7 @@ namespace Grpc.Net.Client.Balancer.Internal
             if (socket == null)
             {
                 socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
-                await socket.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
+                await socket.ConnectAsync(address.EndPoint, cancellationToken).ConfigureAwait(false);
             }
 
             var networkStream = new NetworkStream(socket, ownsSocket: true);
@@ -252,7 +254,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
             lock (Lock)
             {
-                _activeStreams.Add((endPoint, socket, stream));
+                _activeStreams.Add(new ActiveStream(address, socket, stream));
             }
 
             return stream;
@@ -282,7 +284,7 @@ namespace Grpc.Net.Client.Balancer.Internal
                     if (t.Stream == streamWrapper)
                     {
                         _activeStreams.RemoveAt(i);
-                        SocketConnectivitySubchannelTransportLog.DisposingStream(_logger, t.EndPoint);
+                        SocketConnectivitySubchannelTransportLog.DisposingStream(_logger, t.Address);
 
                         // If the last active streams is removed then there is no active connection.
                         disconnect = _activeStreams.Count == 0;
@@ -318,51 +320,51 @@ namespace Grpc.Net.Client.Balancer.Internal
 
     internal static class SocketConnectivitySubchannelTransportLog
     {
-        private static readonly Action<ILogger, DnsEndPoint, Exception?> _connectingSocket =
-            LoggerMessage.Define<DnsEndPoint>(LogLevel.Trace, new EventId(1, "ConnectingSocket"), "Connecting socket to '{Address}'.");
+        private static readonly Action<ILogger, BalancerAddress, Exception?> _connectingSocket =
+            LoggerMessage.Define<BalancerAddress>(LogLevel.Trace, new EventId(1, "ConnectingSocket"), "Connecting socket to '{Address}'.");
 
-        private static readonly Action<ILogger, DnsEndPoint, Exception?> _connectedSocket =
-            LoggerMessage.Define<DnsEndPoint>(LogLevel.Debug, new EventId(2, "ConnectedSocket"), "Connected to socket '{Address}'.");
+        private static readonly Action<ILogger, BalancerAddress, Exception?> _connectedSocket =
+            LoggerMessage.Define<BalancerAddress>(LogLevel.Debug, new EventId(2, "ConnectedSocket"), "Connected to socket '{Address}'.");
 
-        private static readonly Action<ILogger, DnsEndPoint, Exception?> _errorConnectingSocket =
-            LoggerMessage.Define<DnsEndPoint>(LogLevel.Error, new EventId(3, "ErrorConnectingSocket"), "Error connecting to socket '{Address}'.");
+        private static readonly Action<ILogger, BalancerAddress, Exception?> _errorConnectingSocket =
+            LoggerMessage.Define<BalancerAddress>(LogLevel.Error, new EventId(3, "ErrorConnectingSocket"), "Error connecting to socket '{Address}'.");
 
-        private static readonly Action<ILogger, DnsEndPoint, Exception?> _checkingSocket =
-            LoggerMessage.Define<DnsEndPoint>(LogLevel.Trace, new EventId(4, "CheckingSocket"), "Checking socket '{Address}'.");
+        private static readonly Action<ILogger, BalancerAddress, Exception?> _checkingSocket =
+            LoggerMessage.Define<BalancerAddress>(LogLevel.Trace, new EventId(4, "CheckingSocket"), "Checking socket '{Address}'.");
 
-        private static readonly Action<ILogger, DnsEndPoint, Exception?> _errorCheckingSocket =
-            LoggerMessage.Define<DnsEndPoint>(LogLevel.Error, new EventId(5, "ErrorCheckingSocket"), "Error checking socket '{Address}'.");
+        private static readonly Action<ILogger, BalancerAddress, Exception?> _errorCheckingSocket =
+            LoggerMessage.Define<BalancerAddress>(LogLevel.Error, new EventId(5, "ErrorCheckingSocket"), "Error checking socket '{Address}'.");
 
         private static readonly Action<ILogger, Exception?> _errorSocketTimer =
-            LoggerMessage.Define(LogLevel.Error, new EventId(1, "ErrorSocketTimer"), "Unexpected error in check socket timer.");
+            LoggerMessage.Define(LogLevel.Error, new EventId(6, "ErrorSocketTimer"), "Unexpected error in check socket timer.");
 
-        private static readonly Action<ILogger, DnsEndPoint, Exception?> _creatingStream =
-            LoggerMessage.Define<DnsEndPoint>(LogLevel.Trace, new EventId(6, "CreatingStream"), "Creating stream for '{Address}'.");
+        private static readonly Action<ILogger, BalancerAddress, Exception?> _creatingStream =
+            LoggerMessage.Define<BalancerAddress>(LogLevel.Trace, new EventId(7, "CreatingStream"), "Creating stream for '{Address}'.");
 
-        private static readonly Action<ILogger, DnsEndPoint, Exception?> _disposingStream =
-            LoggerMessage.Define<DnsEndPoint>(LogLevel.Trace, new EventId(7, "DisposingStream"), "Disposing stream for '{Address}'.");
+        private static readonly Action<ILogger, BalancerAddress, Exception?> _disposingStream =
+            LoggerMessage.Define<BalancerAddress>(LogLevel.Trace, new EventId(8, "DisposingStream"), "Disposing stream for '{Address}'.");
 
-        public static void ConnectingSocket(ILogger logger, DnsEndPoint address)
+        public static void ConnectingSocket(ILogger logger, BalancerAddress address)
         {
             _connectingSocket(logger, address, null);
         }
 
-        public static void ConnectedSocket(ILogger logger, DnsEndPoint address)
+        public static void ConnectedSocket(ILogger logger, BalancerAddress address)
         {
             _connectedSocket(logger, address, null);
         }
 
-        public static void ErrorConnectingSocket(ILogger logger, DnsEndPoint address, Exception ex)
+        public static void ErrorConnectingSocket(ILogger logger, BalancerAddress address, Exception ex)
         {
             _errorConnectingSocket(logger, address, ex);
         }
 
-        public static void CheckingSocket(ILogger logger, DnsEndPoint address)
+        public static void CheckingSocket(ILogger logger, BalancerAddress address)
         {
             _checkingSocket(logger, address, null);
         }
 
-        public static void ErrorCheckingSocket(ILogger logger, DnsEndPoint address, Exception ex)
+        public static void ErrorCheckingSocket(ILogger logger, BalancerAddress address, Exception ex)
         {
             _errorCheckingSocket(logger, address, ex);
         }
@@ -372,12 +374,12 @@ namespace Grpc.Net.Client.Balancer.Internal
             _errorSocketTimer(logger, ex);
         }
 
-        public static void CreatingStream(ILogger logger, DnsEndPoint address)
+        public static void CreatingStream(ILogger logger, BalancerAddress address)
         {
             _creatingStream(logger, address, null);
         }
 
-        public static void DisposingStream(ILogger logger, DnsEndPoint address)
+        public static void DisposingStream(ILogger logger, BalancerAddress address)
         {
             _disposingStream(logger, address, null);
         }

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -157,7 +157,7 @@ namespace Grpc.Net.Client.Balancer
                         if (currentAddress != null && !_addresses.Contains(currentAddress))
                         {
                             requireReconnect = true;
-                            SubchannelLog.ConnectedAddressNotInUpdatedAddresses(_logger, Id, currentAddress.EndPoint);
+                            SubchannelLog.ConnectedAddressNotInUpdatedAddresses(_logger, Id, currentAddress);
                         }
                         break;
                     case ConnectivityState.Shutdown:
@@ -365,8 +365,8 @@ namespace Grpc.Net.Client.Balancer
         private static readonly Action<ILogger, int, Exception?> _addressesUpdatedWhileConnecting =
             LoggerMessage.Define<int>(LogLevel.Debug, new EventId(2, "AddressesUpdatedWhileConnecting"), "Subchannel id '{SubchannelId}' is connecting when its addresses are updated. Restarting connect.");
 
-        private static readonly Action<ILogger, int, DnsEndPoint, Exception?> _connectedAddressNotInUpdatedAddresses =
-            LoggerMessage.Define<int, DnsEndPoint>(LogLevel.Debug, new EventId(3, "ConnectedAddressNotInUpdatedAddresses"), "Subchannel id '{SubchannelId}' current address '{CurrentAddress}' is not in the updated addresses.");
+        private static readonly Action<ILogger, int, BalancerAddress, Exception?> _connectedAddressNotInUpdatedAddresses =
+            LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(3, "ConnectedAddressNotInUpdatedAddresses"), "Subchannel id '{SubchannelId}' current address '{CurrentAddress}' is not in the updated addresses.");
 
         private static readonly Action<ILogger, int, Exception?> _connectionRequested =
             LoggerMessage.Define<int>(LogLevel.Trace, new EventId(4, "ConnectionRequested"), "Subchannel id '{SubchannelId}' connection requested.");
@@ -406,7 +406,7 @@ namespace Grpc.Net.Client.Balancer
             _addressesUpdatedWhileConnecting(logger, subchannelId, null);
         }
 
-        public static void ConnectedAddressNotInUpdatedAddresses(ILogger logger, int subchannelId, DnsEndPoint currentAddress)
+        public static void ConnectedAddressNotInUpdatedAddresses(ILogger logger, int subchannelId, BalancerAddress currentAddress)
         {
             _connectedAddressNotInUpdatedAddresses(logger, subchannelId, currentAddress, null);
         }

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -123,7 +123,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             }, "Wait for connections to start.");
             foreach (var t in activeStreams)
             {
-                Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), t.EndPoint);
+                Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), t.Address.EndPoint);
             }
 
             // Act
@@ -144,7 +144,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
                 activeStreams = transport.GetActiveStreams();
                 return activeStreams.Count == 11;
             }, "Wait for connections to start.");
-            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams.Last().EndPoint);
+            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams.Last().Address.EndPoint);
 
             tcs.SetResult(null);
 
@@ -184,7 +184,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             activeStreams = transport.GetActiveStreams();
             Assert.AreEqual(1, activeStreams.Count);
-            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].EndPoint);
+            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].Address.EndPoint);
         }
 
         [Test]

--- a/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
@@ -320,8 +320,8 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             // Assert
             Assert.AreEqual(2, activeStreams.Count);
-            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams[0].EndPoint);
-            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams[1].EndPoint);
+            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams[0].Address.EndPoint);
+            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams[1].Address.EndPoint);
 
             tcs.SetResult(null);
 
@@ -334,7 +334,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             await TestHelpers.AssertIsTrueRetryAsync(() =>
             {
                 activeStreams = transport.GetActiveStreams();
-                Logger.LogInformation($"Current active stream endpoints: {string.Join(", ", activeStreams.Select(s => s.EndPoint))}");
+                Logger.LogInformation($"Current active stream addresses: {string.Join(", ", activeStreams.Select(s => s.Address))}");
                 return activeStreams.Count == 0;
             }, "Active streams removed.", Logger).DefaultTimeout();
 
@@ -344,7 +344,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
 
             activeStreams = transport.GetActiveStreams();
             Assert.AreEqual(1, activeStreams.Count);
-            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].EndPoint);
+            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].Address.EndPoint);
         }
 
         [Test]

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -131,11 +131,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
             var serverAbortedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
             async Task ServerStreamingEcho(ServerStreamingEchoRequest request, IServerStreamWriter<ServerStreamingEchoResponse> responseStream, ServerCallContext context)
             {
+                Logger.LogInformation("Server call started");
+
                 var httpContext = context.GetHttpContext();
                 httpContext.RequestAborted.Register(() => serverAbortedTcs.SetResult(null));
 
                 for (var i = 0; i < request.MessageCount; i++)
                 {
+                    Logger.LogInformation($"Server writing message {i}");
                     await responseStream.WriteAsync(new ServerStreamingEchoResponse
                     {
                         Message = request.Message

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
@@ -57,7 +57,7 @@ namespace Grpc.Net.Client.Tests.Infrastructure.Balancer
         {
         }
 
-        public ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken)
+        public ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken)
         {
             return new ValueTask<Stream>(new MemoryStream());
         }


### PR DESCRIPTION
Log `BalancerAddress` instead of `DnsEndPoint` because it has a more friendly ToString

Before:
> Successfully picked subchannel id '1' with address Undefined/127.0.0.1:50051.

After:
> Successfully picked subchannel id '1' with address 127.0.0.1:50051.