### PR TITLE
Change InteropTestClient to net5.0

### DIFF
--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net6.0;net5.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of diagnosing https://github.com/grpc/grpc-dotnet/issues/1511

Lets see if the tests start passing after going back to net5.0