### PR TITLE
Update Grpc.Core.Api dependency to 2.42.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
     <GoogleProtobufPackageVersion>3.18.0</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.41.0-pre1</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
-    <GrpcPackageVersion>2.41.0</GrpcPackageVersion>
+    <GrpcPackageVersion>2.42.0</GrpcPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>6.0.0</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>
     <MicrosoftAspNetCoreApp31PackageVersion>3.1.3</MicrosoftAspNetCoreApp31PackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
-    <GoogleProtobufPackageVersion>3.18.0</GoogleProtobufPackageVersion>
+    <GoogleProtobufPackageVersion>3.18.1</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.41.0-pre1</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.42.0</GrpcPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>6.0.0</MicrosoftAspNetCoreAppPackageVersion>


### PR DESCRIPTION
I'll cut the 2.42.x release branch right after this gets merged (let me know if there's any blockers).