### PR TITLE
Fix client with custom ConnectCallback

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
@@ -35,16 +35,19 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         private readonly ConnectionManager _manager;
 
-        public BalancerHttpHandler(HttpMessageHandler innerHandler, ConnectionManager manager)
+        public BalancerHttpHandler(HttpMessageHandler innerHandler, GrpcChannel channel, ConnectionManager manager)
             : base(innerHandler)
         {
             _manager = manager;
 
 #if NET5_0_OR_GREATER
-            var socketsHttpHandler = HttpRequestHelpers.GetHttpHandlerType<SocketsHttpHandler>(innerHandler);
-            if (socketsHttpHandler != null)
+            if (channel.HttpHandlerType == HttpHandlerType.SocketsHttpHandler)
             {
-                socketsHttpHandler.ConnectCallback = OnConnect;
+                var socketsHttpHandler = HttpRequestHelpers.GetHttpHandlerType<SocketsHttpHandler>(innerHandler);
+                if (socketsHttpHandler != null)
+                {
+                    socketsHttpHandler.ConnectCallback = OnConnect;
+                }
             }
 #endif
         }

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
@@ -35,19 +35,18 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         private readonly ConnectionManager _manager;
 
-        public BalancerHttpHandler(HttpMessageHandler innerHandler, GrpcChannel channel, ConnectionManager manager)
+        public BalancerHttpHandler(HttpMessageHandler innerHandler, HttpHandlerType httpHandlerType, ConnectionManager manager)
             : base(innerHandler)
         {
             _manager = manager;
 
 #if NET5_0_OR_GREATER
-            if (channel.HttpHandlerType == HttpHandlerType.SocketsHttpHandler)
+            if (httpHandlerType == HttpHandlerType.SocketsHttpHandler)
             {
                 var socketsHttpHandler = HttpRequestHelpers.GetHttpHandlerType<SocketsHttpHandler>(innerHandler);
-                if (socketsHttpHandler != null)
-                {
-                    socketsHttpHandler.ConnectCallback = OnConnect;
-                }
+                CompatibilityHelpers.Assert(socketsHttpHandler != null, "Should have handler with this handler type.");
+
+                socketsHttpHandler.ConnectCallback = OnConnect;
             }
 #endif
         }

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -339,7 +339,7 @@ namespace Grpc.Net.Client
 #endif
 
 #if SUPPORT_LOAD_BALANCING
-            handler = new BalancerHttpHandler(handler, this, ConnectionManager);
+            handler = new BalancerHttpHandler(handler, HttpHandlerType, ConnectionManager);
 #endif
 
             // Use HttpMessageInvoker instead of HttpClient because it is faster

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -339,7 +339,7 @@ namespace Grpc.Net.Client
 #endif
 
 #if SUPPORT_LOAD_BALANCING
-            handler = new BalancerHttpHandler(handler, ConnectionManager);
+            handler = new BalancerHttpHandler(handler, this, ConnectionManager);
 #endif
 
             // Use HttpMessageInvoker instead of HttpClient because it is faster

--- a/test/FunctionalTests/Client/ConnectionTests.cs
+++ b/test/FunctionalTests/Client/ConnectionTests.cs
@@ -16,11 +16,14 @@
 
 #endregion
 
+using System.Net;
+using System.Net.Sockets;
 using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Tests.Shared;
+using Microsoft.AspNetCore.Connections.Features;
 using NUnit.Framework;
 
 namespace Grpc.AspNetCore.FunctionalTests.Client
@@ -64,7 +67,19 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
         [Test]
         public async Task UnixDomainSockets()
         {
+            Task<HelloReply> UnaryUds(HelloRequest request, ServerCallContext context)
+            {
+#if NET6_0_OR_GREATER
+                var endPoint = (UnixDomainSocketEndPoint)context.GetHttpContext().Features.Get<IConnectionSocketFeature>()!.Socket.LocalEndPoint!;
+                Assert.NotNull(endPoint);
+#endif
+
+                return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+            }
+
             // Arrange
+            var method = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(UnaryUds);
+
             var http = Fixture.CreateHandler(TestServerEndpointName.UnixDomainSocket);
 
             var channel = GrpcChannel.ForAddress(http.address, new GrpcChannelOptions
@@ -73,17 +88,18 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 HttpHandler = http.handler
             });
 
-            var client = new Greeter.GreeterClient(channel);
+            var client = TestClientFactory.Create(channel, method);
 
             // Act
-            var response = await client.SayHelloAsync(new HelloRequest { Name = "John" }).ResponseAsync.DefaultTimeout();
+            var response = await client.UnaryCall(new HelloRequest { Name = "John" }).ResponseAsync.DefaultTimeout();
 
+            // Assert
             Assert.AreEqual("Hello John", response.Message);
         }
 #endif
 
 #if NET6_0_OR_GREATER
-        [Test]
+                [Test]
         [RequireHttp3]
         public async Task Http3()
         {
@@ -101,6 +117,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             // Act
             var response = await client.SayHelloAsync(new HelloRequest { Name = "John" }).ResponseAsync.DefaultTimeout();
 
+            // Assert
             Assert.AreEqual("Hello John", response.Message);
         }
 #endif

--- a/test/FunctionalTests/Client/ConnectionTests.cs
+++ b/test/FunctionalTests/Client/ConnectionTests.cs
@@ -99,7 +99,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 #endif
 
 #if NET6_0_OR_GREATER
-                [Test]
+        [Test]
         [RequireHttp3]
         public async Task Http3()
         {

--- a/test/FunctionalTests/Client/ConnectionTests.cs
+++ b/test/FunctionalTests/Client/ConnectionTests.cs
@@ -60,7 +60,29 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 #endif
         }
 
-#if NET6_0
+#if NET5_0_OR_GREATER
+        [Test]
+        public async Task UnixDomainSockets()
+        {
+            // Arrange
+            var http = Fixture.CreateHandler(TestServerEndpointName.UnixDomainSocket);
+
+            var channel = GrpcChannel.ForAddress(http.address, new GrpcChannelOptions
+            {
+                LoggerFactory = LoggerFactory,
+                HttpHandler = http.handler
+            });
+
+            var client = new Greeter.GreeterClient(channel);
+
+            // Act
+            var response = await client.SayHelloAsync(new HelloRequest { Name = "John" }).ResponseAsync.DefaultTimeout();
+
+            Assert.AreEqual("Hello John", response.Message);
+        }
+#endif
+
+#if NET6_0_OR_GREATER
         [Test]
         [RequireHttp3]
         public async Task Http3()

--- a/test/FunctionalTests/Infrastructure/TestServerEndpointName.cs
+++ b/test/FunctionalTests/Infrastructure/TestServerEndpointName.cs
@@ -24,6 +24,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
         Http1,
         Http2WithTls,
         Http1WithTls,
+#if NET5_0_OR_GREATER
+        UnixDomainSocket,
+#endif
 #if NET6_0_OR_GREATER
         Http3WithTls,
 #endif

--- a/test/FunctionalTests/Infrastructure/UnixDomainSocketConnectionFactory.cs
+++ b/test/FunctionalTests/Infrastructure/UnixDomainSocketConnectionFactory.cs
@@ -1,0 +1,56 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if NET5_0_OR_GREATER
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Grpc.AspNetCore.FunctionalTests.Infrastructure
+{
+    public class UnixDomainSocketConnectionFactory
+    {
+        private readonly EndPoint _endPoint;
+
+        public UnixDomainSocketConnectionFactory(EndPoint endPoint)
+        {
+            _endPoint = endPoint;
+        }
+
+        public async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext _, CancellationToken cancellationToken = default)
+        {
+            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+
+            try
+            {
+                await socket.ConnectAsync(_endPoint, cancellationToken).ConfigureAwait(false);
+                return new NetworkStream(socket, true);
+            }
+            catch (Exception ex)
+            {
+                socket.Dispose();
+                throw new HttpRequestException($"Error connecting to '{_endPoint}'.", ex);
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1536

@jtattermusch Regression from client-side load balancing. I'd like to include this fix in the next release