### PR TITLE
Fix load balancing subchannel compare and dispose error

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
     <GoogleProtobufPackageVersion>3.18.1</GoogleProtobufPackageVersion>
-    <GrpcDotNetPackageVersion>2.41.0-pre1</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
+    <GrpcDotNetPackageVersion>2.42.0-pre1</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.42.0</GrpcPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>6.0.0</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -165,8 +165,8 @@ namespace Grpc.Net.Client.Balancer
                     default:
                         throw new ArgumentOutOfRangeException("state", _state, "Unexpected state.");
                 }
-
             }
+
             if (requireReconnect)
             {
                 _connectCts?.Cancel();

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -85,7 +85,7 @@ namespace Grpc.Net.Client.Balancer
             for (var i = 0; i < addressSubchannels.Count; i++)
             {
                 var s = addressSubchannels[i];
-                if (Equals(s.Address, address))
+                if (Equals(s.Address.EndPoint, address.EndPoint))
                 {
                     return i;
                 }

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -301,7 +301,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             SyncPoint? syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
             syncPoint.Continue();
 
-            var resolver = new TestResolver(async () =>
+            var resolver = new TestResolver(LoggerFactory, async () =>
             {
                 await syncPoint.WaitToContinue().DefaultTimeout();
                 syncPoint = new SyncPoint(runContinuationsAsynchronously: true);

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -53,7 +53,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var serviceProvider = services.BuildServiceProvider();
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
-            var resolver = new TestResolver();
+            var resolver = new TestResolver(loggerFactory);
             resolver.UpdateAddresses(new List<BalancerAddress>
             {
                 new BalancerAddress("localhost", 80)
@@ -112,7 +112,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var serviceProvider = services.BuildServiceProvider();
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
-            var resolver = new TestResolver();
+            var resolver = new TestResolver(loggerFactory);
             resolver.UpdateAddresses(new List<BalancerAddress>
             {
                 new BalancerAddress("localhost", 80)
@@ -152,11 +152,9 @@ namespace Grpc.Net.Client.Tests.Balancer
 
             var services = new ServiceCollection();
             services.AddNUnitLogger();
-
-            var resolver = new TestResolver();
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             DropLoadBalancer? loadBalancer = null;
-
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
             services.AddSingleton<LoadBalancerFactory>(new DropLoadBalancerFactory(c =>
             {
                 loadBalancer = new DropLoadBalancer(c);
@@ -216,11 +214,9 @@ namespace Grpc.Net.Client.Tests.Balancer
 
             var services = new ServiceCollection();
             services.AddNUnitLogger();
-
-            var resolver = new TestResolver();
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             DropLoadBalancer? loadBalancer = null;
-
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
             services.AddSingleton<LoadBalancerFactory>(new DropLoadBalancerFactory(c =>
             {
                 loadBalancer = new DropLoadBalancer(c);
@@ -271,7 +267,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
             var testLogger = loggerFactory.CreateLogger(GetType());
 
-            var resolver = new TestResolver();
+            var resolver = new TestResolver(loggerFactory);
             resolver.UpdateAddresses(new List<BalancerAddress>
             {
                 new BalancerAddress("localhost", 80)

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectivityStateTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectivityStateTests.cs
@@ -52,16 +52,15 @@ namespace Grpc.Net.Client.Tests.Balancer
             });
 
             var services = new ServiceCollection();
-
-            var resolver = new TestResolver();
-
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory());
+            var serviceProvider = services.BuildServiceProvider();
 
             var invoker = HttpClientCallInvokerFactory.Create(testMessageHandler, "test:///localhost", configure: o =>
             {
                 o.Credentials = ChannelCredentials.Insecure;
-                o.ServiceProvider = services.BuildServiceProvider();
+                o.ServiceProvider = serviceProvider;
             });
 
             // Act
@@ -72,6 +71,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             Assert.IsFalse(responseTask.IsCompleted);
             Assert.IsNull(authority);
 
+            var resolver = serviceProvider.GetRequiredService<TestResolver>();
             resolver.UpdateAddresses(new List<BalancerAddress>
             {
                 new BalancerAddress("localhost", 81)
@@ -93,8 +93,8 @@ namespace Grpc.Net.Client.Tests.Balancer
             });
 
             var services = new ServiceCollection();
-            var resolver = new TestResolver();
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory());
 
             var invoker = HttpClientCallInvokerFactory.Create(testMessageHandler, "test:///localhost", configure: o =>
@@ -125,8 +125,8 @@ namespace Grpc.Net.Client.Tests.Balancer
             });
 
             var services = new ServiceCollection();
-            var resolver = new TestResolver();
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory());
 
             var invoker = HttpClientCallInvokerFactory.Create(testMessageHandler, "test:///localhost", configure: o =>

--- a/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
@@ -81,7 +81,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
             var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var resolver = new TestResolver(() => tcs.Task);
+            var resolver = new TestResolver(NullLoggerFactory.Instance, () => tcs.Task);
             resolver.UpdateAddresses(new List<BalancerAddress>
             {
                 new BalancerAddress("localhost", 80)
@@ -146,7 +146,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
             var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var resolver = new TestResolver(() => tcs.Task);
+            var resolver = new TestResolver(NullLoggerFactory.Instance, () => tcs.Task);
             var result = ResolverResult.ForResult(new List<BalancerAddress> { new BalancerAddress("localhost", 80) }, resolvedServiceConfig, serviceConfigStatus: null);
             resolver.UpdateResult(result);
 
@@ -199,7 +199,7 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
             var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var resolver = new TestResolver(() => tcs.Task);
+            var resolver = new TestResolver(NullLoggerFactory.Instance, () => tcs.Task);
             var result = ResolverResult.ForResult(new List<BalancerAddress> { new BalancerAddress("localhost", 80) }, serviceConfig: null, serviceConfigStatus: null);
             resolver.UpdateResult(result);
 

--- a/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
@@ -33,6 +33,7 @@ using Grpc.Net.Client.Tests.Infrastructure.Balancer;
 using Grpc.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace Grpc.Net.Client.Tests.Balancer
@@ -47,24 +48,26 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
             services.AddNUnitLogger();
 
-            var resolver = new TestResolver();
-            resolver.UpdateAddresses(new List<BalancerAddress>
-            {
-                new BalancerAddress("localhost", 80)
-            });
-
             var transportFactory = new TestSubchannelTransportFactory();
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             services.AddSingleton<ISubchannelTransportFactory>(transportFactory);
+            var serviceProvider = services.BuildServiceProvider();
 
             var handler = new TestHttpMessageHandler((r, ct) => default!);
             var channelOptions = new GrpcChannelOptions
             {
                 Credentials = ChannelCredentials.Insecure,
                 ServiceConfig = new ServiceConfig { LoadBalancingConfigs = { new RoundRobinConfig() } },
-                ServiceProvider = services.BuildServiceProvider(),
+                ServiceProvider = serviceProvider,
                 HttpHandler = handler
             };
+
+            var resolver = serviceProvider.GetRequiredService<TestResolver>();
+            resolver.UpdateAddresses(new List<BalancerAddress>
+            {
+                new BalancerAddress("localhost", 80)
+            });
 
             // Act
             var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
@@ -105,24 +108,26 @@ namespace Grpc.Net.Client.Tests.Balancer
             var services = new ServiceCollection();
             services.AddNUnitLogger();
 
-            var resolver = new TestResolver();
-            resolver.UpdateAddresses(new List<BalancerAddress>
-            {
-                new BalancerAddress("localhost", 80)
-            });
-
             var transportFactory = new TestSubchannelTransportFactory();
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             services.AddSingleton<ISubchannelTransportFactory>(transportFactory);
+            var serviceProvider = services.BuildServiceProvider();
 
             var handler = new TestHttpMessageHandler((r, ct) => default!);
             var channelOptions = new GrpcChannelOptions
             {
                 Credentials = ChannelCredentials.Insecure,
                 ServiceConfig = new ServiceConfig { LoadBalancingConfigs = { new RoundRobinConfig() } },
-                ServiceProvider = services.BuildServiceProvider(),
+                ServiceProvider = serviceProvider,
                 HttpHandler = handler
             };
+
+            var resolver = serviceProvider.GetRequiredService<TestResolver>();
+            resolver.UpdateAddresses(new List<BalancerAddress>
+            {
+                new BalancerAddress("localhost", 80)
+            });
 
             // Act
             var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
@@ -157,25 +162,26 @@ namespace Grpc.Net.Client.Tests.Balancer
             // Arrange
             var services = new ServiceCollection();
             services.AddNUnitLogger();
-
-            var resolver = new TestResolver();
-            resolver.UpdateAddresses(new List<BalancerAddress>
-            {
-                new BalancerAddress("localhost", 80)
-            });
-
+            services.AddSingleton<TestResolver>();
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             var transportFactory = new TestSubchannelTransportFactory((s, c) => Task.FromResult(ConnectivityState.TransientFailure));
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
             services.AddSingleton<ISubchannelTransportFactory>(transportFactory);
+            var serviceProvider = services.BuildServiceProvider();
 
             var handler = new TestHttpMessageHandler((r, ct) => default!);
             var channelOptions = new GrpcChannelOptions
             {
                 Credentials = ChannelCredentials.Insecure,
                 ServiceConfig = new ServiceConfig { LoadBalancingConfigs = { new RoundRobinConfig() } },
-                ServiceProvider = services.BuildServiceProvider(),
+                ServiceProvider = serviceProvider,
                 HttpHandler = handler
             };
+
+            var resolver = serviceProvider.GetRequiredService<TestResolver>();
+            resolver.UpdateAddresses(new List<BalancerAddress>
+            {
+                new BalancerAddress("localhost", 80)
+            });
 
             // Act
             var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
@@ -210,30 +216,37 @@ namespace Grpc.Net.Client.Tests.Balancer
 
             SyncPoint? syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
 
-            var resolver = new TestResolver(async () =>
-            {
-                await syncPoint.WaitToContinue().DefaultTimeout();
-                syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
-            });
-            resolver.UpdateAddresses(new List<BalancerAddress>
-            {
-                new BalancerAddress("localhost", 80)
-            });
-
             var connectState = ConnectivityState.Ready;
 
             var transportFactory = new TestSubchannelTransportFactory((s, c) => Task.FromResult(connectState));
-            services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
+            services.AddSingleton<TestResolver>(s =>
+            {
+                return new TestResolver(
+                    s.GetRequiredService<ILoggerFactory>(),
+                    async () =>
+                    {
+                        await syncPoint.WaitToContinue().DefaultTimeout();
+                        syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+                    });
+            });
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
             services.AddSingleton<ISubchannelTransportFactory>(transportFactory);
+            var serviceProvider = services.BuildServiceProvider();
 
             var handler = new TestHttpMessageHandler((r, ct) => default!);
             var channelOptions = new GrpcChannelOptions
             {
                 Credentials = ChannelCredentials.Insecure,
                 ServiceConfig = new ServiceConfig { LoadBalancingConfigs = { new RoundRobinConfig() } },
-                ServiceProvider = services.BuildServiceProvider(),
+                ServiceProvider = serviceProvider,
                 HttpHandler = handler
             };
+
+            var resolver = serviceProvider.GetRequiredService<TestResolver>();
+            resolver.UpdateAddresses(new List<BalancerAddress>
+            {
+                new BalancerAddress("localhost", 80)
+            });
 
             // Act
             var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
@@ -258,6 +271,84 @@ namespace Grpc.Net.Client.Tests.Balancer
             // Transport will refresh resolver after some failures
             await syncPoint!.WaitForSyncPoint().DefaultTimeout();
             syncPoint.Continue();
+        }
+
+        [Test]
+        public async Task HasSubchannels_ResolverRefresh_MatchingSubchannelUnchanged()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddNUnitLogger();
+
+            SyncPoint? syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+
+            var connectState = ConnectivityState.Ready;
+
+            var transportFactory = new TestSubchannelTransportFactory((s, c) => Task.FromResult(connectState));
+            services.AddSingleton<TestResolver>(s =>
+            {
+                return new TestResolver(
+                    s.GetRequiredService<ILoggerFactory>(),
+                    async () =>
+                    {
+                        await syncPoint.WaitToContinue().DefaultTimeout();
+                        syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+                    });
+            });
+            services.AddSingleton<ResolverFactory, TestResolverFactory>();
+            services.AddSingleton<ISubchannelTransportFactory>(transportFactory);
+            var serviceProvider = services.BuildServiceProvider();
+
+            var handler = new TestHttpMessageHandler((r, ct) => default!);
+            var channelOptions = new GrpcChannelOptions
+            {
+                Credentials = ChannelCredentials.Insecure,
+                ServiceConfig = new ServiceConfig { LoadBalancingConfigs = { new RoundRobinConfig() } },
+                ServiceProvider = serviceProvider,
+                HttpHandler = handler
+            };
+
+            var resolver = serviceProvider.GetRequiredService<TestResolver>();
+            resolver.UpdateAddresses(new List<BalancerAddress>
+            {
+                new BalancerAddress("localhost", 80),
+                new BalancerAddress("localhost", 81)
+            });
+
+            // Act
+            var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
+            var connectTask = channel.ConnectAsync();
+
+            // Assert
+            syncPoint!.Continue();
+            await connectTask.DefaultTimeout();
+
+            var subchannels = channel.ConnectionManager.GetSubchannels();
+            Assert.AreEqual(2, subchannels.Count);
+
+            Assert.AreEqual(1, subchannels[0]._addresses.Count);
+            Assert.AreEqual(new DnsEndPoint("localhost", 80), subchannels[0]._addresses[0].EndPoint);
+            Assert.AreEqual(1, subchannels[1]._addresses.Count);
+            Assert.AreEqual(new DnsEndPoint("localhost", 81), subchannels[1]._addresses[0].EndPoint);
+
+            // Preserved because port 81 is in both refresh results
+            var preservedSubchannel = subchannels[1];
+
+            resolver.UpdateAddresses(new List<BalancerAddress>
+            {
+                new BalancerAddress("localhost", 81),
+                new BalancerAddress("localhost", 82)
+            });
+
+            subchannels = channel.ConnectionManager.GetSubchannels();
+            Assert.AreEqual(2, subchannels.Count);
+
+            Assert.AreEqual(1, subchannels[0]._addresses.Count);
+            Assert.AreEqual(new DnsEndPoint("localhost", 81), subchannels[0]._addresses[0].EndPoint);
+            Assert.AreEqual(1, subchannels[1]._addresses.Count);
+            Assert.AreEqual(new DnsEndPoint("localhost", 82), subchannels[1]._addresses[0].EndPoint);
+
+            Assert.AreSame(preservedSubchannel, subchannels[0]);
         }
     }
 }

--- a/test/Shared/TestResolver.cs
+++ b/test/Shared/TestResolver.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client.Balancer;
 using Grpc.Net.Client.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Grpc.Tests.Shared
@@ -37,7 +38,11 @@ namespace Grpc.Tests.Shared
 
         public Task HasResolvedTask => _hasResolvedTcs.Task;
 
-        public TestResolver(Func<Task>? onRefreshAsync = null) : base(NullLoggerFactory.Instance)
+        public TestResolver(ILoggerFactory loggerFactory) : this(loggerFactory, null)
+        {
+        }
+
+        public TestResolver(ILoggerFactory? loggerFactory = null, Func<Task>? onRefreshAsync = null) : base(loggerFactory ?? NullLoggerFactory.Instance)
         {
             _onRefreshAsync = onRefreshAsync;
             _hasResolvedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Regression in 2.42.0 related to not correctly comparing subchannel addresses. The regression results in subchannels being recreated each time a resolver returns new addresses. Correct behavior is to recognize that a subchannel with an address already exists and continue to use it.

Note that most changes are related to logging. I noticed this when updating container example to use latest version and added more logging to help follow logic.

Should be backported to the 2.42.0 branch before the final version is released.