### PR TITLE
Remove Subchannel.State and track state inside load balancer

### DIFF
--- a/src/Grpc.Net.Client/Balancer/PickResult.cs
+++ b/src/Grpc.Net.Client/Balancer/PickResult.cs
@@ -83,7 +83,7 @@ namespace Grpc.Net.Client.Balancer
         /// A result created with a <see cref="Balancer.Subchannel"/> won't necessarily be used by a gRPC call.
         /// The subchannel's state may change at the same time the picker is making a decision. That means the
         /// decision may be made with outdated information. For example, a picker may return a subchannel
-        /// with a <see cref="Subchannel.State"/> that is <see cref="ConnectivityState.Ready"/>, but
+        /// with a state that is <see cref="ConnectivityState.Ready"/>, but
         /// becomes <see cref="ConnectivityState.Idle"/> when the subchannel is about to be used. In that situation
         /// the gRPC call waits for the load balancer to react to the new state and create a new picker.
         /// </para>

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -47,6 +47,12 @@ namespace Grpc.Net.Client.Balancer
         internal readonly object Lock;
         internal ISubchannelTransport Transport { get; set; } = default!;
         internal int Id { get; }
+        /// <summary>
+        /// Connectivity state is internal rather than public because it can be updated at any time.
+        /// Load balancers that care about multiple subchannels should track state by subscribing to
+        /// Subchannel.OnStateChanged and storing results.
+        /// </summary>
+        internal ConnectivityState State => _state;
 
         private readonly ConnectionManager _manager;
         private readonly ILogger _logger;
@@ -59,11 +65,6 @@ namespace Grpc.Net.Client.Balancer
         /// Gets the current connected address.
         /// </summary>
         public BalancerAddress? CurrentAddress => Transport.CurrentAddress;
-
-        /// <summary>
-        /// Gets the connectivity state.
-        /// </summary>
-        public ConnectivityState State => _state;
 
         /// <summary>
         /// Gets the metadata attributes.
@@ -327,7 +328,7 @@ namespace Grpc.Net.Client.Balancer
         {
             lock (Lock)
             {
-                return $"Id: {Id}, Addresses: {string.Join(", ", _addresses)}, State: {State}, Current address: {CurrentAddress}";
+                return $"Id: {Id}, Addresses: {string.Join(", ", _addresses)}, State: {_state}, Current address: {CurrentAddress}";
             }
         }
 
@@ -345,7 +346,7 @@ namespace Grpc.Net.Client.Balancer
 
         /// <summary>
         /// Disposes the <see cref="Subchannel"/>.
-        /// The subchannel <see cref="State"/> is updated to <see cref="ConnectivityState.Shutdown"/>.
+        /// The subchannel state is updated to <see cref="ConnectivityState.Shutdown"/>.
         /// After dispose the subchannel should no longer be returned by the latest <see cref="SubchannelPicker"/>.
         /// </summary>
         public void Dispose()

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -47,8 +47,10 @@ namespace Grpc.Net.Client.Balancer
         internal readonly object Lock;
         internal ISubchannelTransport Transport { get; set; } = default!;
         internal int Id { get; }
+
         /// <summary>
-        /// Connectivity state is internal rather than public because it can be updated at any time.
+        /// Connectivity state is internal rather than public because it can be updated by multiple threads while
+        /// a load balancer is building the picker.
         /// Load balancers that care about multiple subchannels should track state by subscribing to
         /// Subchannel.OnStateChanged and storing results.
         /// </summary>

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -150,7 +150,7 @@ namespace Grpc.Net.Client.Balancer
                     c.OnStateChanged(s => UpdateSubchannelState(c, s));
 
                     newSubchannels.Add(c);
-                    newOrCurrentSubConnection = new AddressSubchannel(c, address, ConnectivityState.Idle);
+                    newOrCurrentSubConnection = new AddressSubchannel(c, address);
                 }
 
                 allUpdatedSubchannels.Add(newOrCurrentSubConnection);
@@ -302,11 +302,11 @@ namespace Grpc.Net.Client.Balancer
         {
             private ConnectivityState _lastKnownState;
 
-            public AddressSubchannel(Subchannel subchannel, BalancerAddress address, ConnectivityState lastknownState)
+            public AddressSubchannel(Subchannel subchannel, BalancerAddress address)
             {
                 Subchannel = subchannel;
                 Address = address;
-                _lastKnownState = lastknownState;
+                _lastKnownState = ConnectivityState.Idle;
             }
 
             // Track connectivity state that has been updated to load balancer.

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -94,14 +94,14 @@ namespace Grpc.Net.Client.Balancer
             return null;
         }
 
-        private int? FindSubchannel(List<AddressSubchannel> addressSubchannels, Subchannel subchannel)
+        private AddressSubchannel? FindSubchannel(List<AddressSubchannel> addressSubchannels, Subchannel subchannel)
         {
             for (var i = 0; i < addressSubchannels.Count; i++)
             {
                 var s = addressSubchannels[i];
                 if (Equals(s.Subchannel, subchannel))
                 {
-                    return i;
+                    return s;
                 }
             }
 
@@ -150,7 +150,7 @@ namespace Grpc.Net.Client.Balancer
                     c.OnStateChanged(s => UpdateSubchannelState(c, s));
 
                     newSubchannels.Add(c);
-                    newOrCurrentSubConnection = new AddressSubchannel(c, address);
+                    newOrCurrentSubConnection = new AddressSubchannel(c, address, ConnectivityState.Idle);
                 }
 
                 allUpdatedSubchannels.Add(newOrCurrentSubConnection);
@@ -189,7 +189,7 @@ namespace Grpc.Net.Client.Balancer
             for (var i = 0; i < _addressSubchannels.Count; i++)
             {
                 var addressSubchannel = _addressSubchannels[i];
-                if (addressSubchannel.Subchannel.State == ConnectivityState.Ready)
+                if (addressSubchannel.KnownState == ConnectivityState.Ready)
                 {
                     readySubchannels.Add(addressSubchannel.Subchannel);
                 }
@@ -201,7 +201,7 @@ namespace Grpc.Net.Client.Balancer
                 var isConnecting = false;
                 foreach (var subchannel in _addressSubchannels)
                 {
-                    var state = subchannel.Subchannel.State;
+                    var state = subchannel.KnownState;
 
                     if (state == ConnectivityState.Connecting || state == ConnectivityState.Idle)
                     {
@@ -239,12 +239,14 @@ namespace Grpc.Net.Client.Balancer
 
         private void UpdateSubchannelState(Subchannel subchannel, SubchannelState state)
         {
-            var index = FindSubchannel(_addressSubchannels, subchannel);
-            if (index == null)
+            var addressSubchannel = FindSubchannel(_addressSubchannels, subchannel);
+            if (addressSubchannel == null)
             {
                 SubchannelsLoadBalancerLog.IgnoredSubchannelStateChange(_logger, subchannel.Id);
                 return;
             }
+
+            addressSubchannel.UpdateKnownState(state.State);
 
             SubchannelsLoadBalancerLog.ProcessingSubchannelStateChanged(_logger, subchannel.Id, state.State, state.Status);
 
@@ -297,7 +299,27 @@ namespace Grpc.Net.Client.Balancer
         /// <returns>A subchannel picker.</returns>
         protected abstract SubchannelPicker CreatePicker(IReadOnlyList<Subchannel> readySubchannels);
 
-        private record AddressSubchannel(Subchannel Subchannel, BalancerAddress Address);
+        private class AddressSubchannel
+        {
+            public AddressSubchannel(Subchannel subchannel, BalancerAddress address, ConnectivityState knownState)
+            {
+                Subchannel = subchannel;
+                Address = address;
+                KnownState = knownState;
+            }
+
+            // Track connectivity state that has been updated to load balancer.
+            // This is used instead of state on subchannel because subchannel state
+            // can be updated at any time.
+            public ConnectivityState KnownState { get; private set; }
+            public Subchannel Subchannel { get; }
+            public BalancerAddress Address { get; }
+
+            public void UpdateKnownState(ConnectivityState knownState)
+            {
+                KnownState = knownState;
+            }
+        }
     }
 
     internal static class SubchannelsLoadBalancerLog

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -247,7 +247,6 @@ namespace Grpc.Net.Client.Balancer
             }
 
             addressSubchannel.UpdateKnownState(state.State);
-
             SubchannelsLoadBalancerLog.ProcessingSubchannelStateChanged(_logger, subchannel.Id, state.State, state.Status);
 
             UpdateBalancingState(state.Status);

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -232,22 +232,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             }
         }
 
-        private static IEnumerable<TestCaseData> AddBrowserConfs()
-        {
-            return Enumerable.Range(0, 1).Select(i => new TestCaseData(i));
-        }
-
-        [Test, TestCaseSource("AddBrowserConfs")]
-        //[Parallelizable(ParallelScope.All)]
-        public async Task UnaryCall_UnavailableAddress_FallbackToWorkingAddress(int j)
+        [Test]
+        public async Task UnaryCall_UnavailableAddress_FallbackToWorkingAddress()
         {
             // Ignore errors
             SetExpectedErrorsFilter(writeContext =>
             {
                 return true;
             });
-
-            Console.WriteLine(j);
 
             string? host = null;
             Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -232,14 +232,22 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
             }
         }
 
-        [Test]
-        public async Task UnaryCall_UnavailableAddress_FallbackToWorkingAddress()
+        private static IEnumerable<TestCaseData> AddBrowserConfs()
+        {
+            return Enumerable.Range(0, 1).Select(i => new TestCaseData(i));
+        }
+
+        [Test, TestCaseSource("AddBrowserConfs")]
+        //[Parallelizable(ParallelScope.All)]
+        public async Task UnaryCall_UnavailableAddress_FallbackToWorkingAddress(int j)
         {
             // Ignore errors
             SetExpectedErrorsFilter(writeContext =>
             {
                 return true;
             });
+
+            Console.WriteLine(j);
 
             string? host = null;
             Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)


### PR DESCRIPTION
A load balancer shouldn't use Subchannel.State because it can be updated from other threads while a load balancer is building the picker. Instead, a load balancer should track its own copy of states.

Public API change is ok because this isn't final yet.