### PR TITLE
Complete Interceptor example

### DIFF
--- a/examples/Interceptor/Client/ClientLoggerInterceptor.cs
+++ b/examples/Interceptor/Client/ClientLoggerInterceptor.cs
@@ -25,6 +25,17 @@ namespace Client
 {
     public class ClientLoggerInterceptor : Interceptor
     {
+        public override TResponse BlockingUnaryCall<TRequest, TResponse>(
+            TRequest request,
+            ClientInterceptorContext<TRequest, TResponse> context,
+            BlockingUnaryCallContinuation<TRequest, TResponse> continuation)
+        {
+            LogCall(context.Method);
+            AddCallerMetadata(ref context);
+
+            return continuation(request, context);
+        }
+
         public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
             TRequest request,
             ClientInterceptorContext<TRequest, TResponse> context,

--- a/examples/Interceptor/Client/Program.cs
+++ b/examples/Interceptor/Client/Program.cs
@@ -30,7 +30,7 @@ namespace Client
     {
         static async Task Main(string[] args)
         {
-            using var channel = GrpcChannel.ForAddress("https://localhost:5001");
+            using var channel = GrpcChannel.ForAddress("http://localhost:5001");
             var invoker = channel.Intercept(new ClientLoggerInterceptor());
 
             var client = new Greeter.GreeterClient(invoker);
@@ -97,11 +97,6 @@ namespace Client
         private static async Task BidirectionalCallExample(Greeter.GreeterClient client)
         {
             using var call = client.SayHellosToLotsOfBuddies();
-            for (var i = 0; i < 3; i++)
-            {
-                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i}" });
-            }
-
             var readTask = Task.Run(async () =>
             {
                 await foreach (var message in call.ResponseStream.ReadAllAsync())
@@ -109,6 +104,11 @@ namespace Client
                     Console.WriteLine("Greeting: " + message.Message);
                 }
             });
+
+            for (var i = 0; i < 3; i++)
+            {
+                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i}" });
+            }
 
             await call.RequestStream.CompleteAsync();
             await readTask;

--- a/examples/Interceptor/Client/Program.cs
+++ b/examples/Interceptor/Client/Program.cs
@@ -30,7 +30,7 @@ namespace Client
     {
         static async Task Main(string[] args)
         {
-            using var channel = GrpcChannel.ForAddress("http://localhost:5001");
+            using var channel = GrpcChannel.ForAddress("https://localhost:5001");
             var invoker = channel.Intercept(new ClientLoggerInterceptor());
 
             var client = new Greeter.GreeterClient(invoker);

--- a/examples/Interceptor/Client/Program.cs
+++ b/examples/Interceptor/Client/Program.cs
@@ -35,13 +35,25 @@ namespace Client
 
             var client = new Greeter.GreeterClient(invoker);
 
+            BlockingUnaryCallExample(client);
+
             await UnaryCallExample(client);
 
             await ServerStreamingCallExample(client);
 
+            await ClientStreamingCallExample(client);
+
+            await BidirectionalCallExample(client);
+
             Console.WriteLine("Shutting down");
             Console.WriteLine("Press any key to exit...");
             Console.ReadKey();
+        }
+
+        private static void BlockingUnaryCallExample(Greeter.GreeterClient client)
+        {
+            var reply = client.SayHello(new HelloRequest { Name = "GreeterClient" });
+            Console.WriteLine("Greeting: " + reply.Message);
         }
 
         private static async Task UnaryCallExample(Greeter.GreeterClient client)
@@ -67,6 +79,39 @@ namespace Client
             {
                 Console.WriteLine("Stream cancelled.");
             }
+        }
+
+        private static async Task ClientStreamingCallExample(Greeter.GreeterClient client)
+        {
+            using var call = client.SayHelloToLotsOfBuddies();
+            for (var i = 0; i < 3; i++)
+            {
+                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i}" });
+            }
+
+            await call.RequestStream.CompleteAsync();
+            var reply = await call;
+            Console.WriteLine("Greeting: " + reply.Message);
+        }
+
+        private static async Task BidirectionalCallExample(Greeter.GreeterClient client)
+        {
+            using var call = client.SayHellosToLotsOfBuddies();
+            for (var i = 0; i < 3; i++)
+            {
+                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i}" });
+            }
+
+            var readTask = Task.Run(async () =>
+            {
+                await foreach (var message in call.ResponseStream.ReadAllAsync())
+                {
+                    Console.WriteLine("Greeting: " + message.Message);
+                }
+            });
+
+            await call.RequestStream.CompleteAsync();
+            await readTask;
         }
     }
 }

--- a/examples/Interceptor/Client/Program.cs
+++ b/examples/Interceptor/Client/Program.cs
@@ -86,7 +86,7 @@ namespace Client
             using var call = client.SayHelloToLotsOfBuddies();
             for (var i = 0; i < 3; i++)
             {
-                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i}" });
+                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i + 1}" });
             }
 
             await call.RequestStream.CompleteAsync();
@@ -107,7 +107,7 @@ namespace Client
 
             for (var i = 0; i < 3; i++)
             {
-                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i}" });
+                await call.RequestStream.WriteAsync(new HelloRequest { Name = $"GreeterClient{i + 1}" });
             }
 
             await call.RequestStream.CompleteAsync();

--- a/examples/Interceptor/Proto/greet.proto
+++ b/examples/Interceptor/Proto/greet.proto
@@ -21,6 +21,8 @@ service Greeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply);
   rpc SayHellos (HelloRequest) returns (stream HelloReply);
+  rpc SayHelloToLotsOfBuddies (stream HelloRequest) returns (HelloReply);
+  rpc SayHellosToLotsOfBuddies (stream HelloRequest) returns (stream HelloReply);
 }
 
 // The request message containing the user's name.

--- a/examples/Interceptor/Server/Services/GreeterService.cs
+++ b/examples/Interceptor/Server/Services/GreeterService.cs
@@ -53,5 +53,27 @@ namespace Server
                 await Task.Delay(1000);
             }
         }
+
+        public override async Task<HelloReply> SayHelloToLotsOfBuddies(IAsyncStreamReader<HelloRequest> requestStream, ServerCallContext context)
+        {
+            var message = "Hello";
+            await foreach (var request in requestStream.ReadAllAsync())
+            {
+                message += $" {request.Name},";
+            }
+
+            message = message.Remove(message.Length - 1);
+
+            _logger.LogInformation($"Sending greeting {message}.");
+            return new HelloReply { Message = message };
+        }
+
+        public override async Task SayHellosToLotsOfBuddies(IAsyncStreamReader<HelloRequest> requestStream, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            await foreach (var request in requestStream.ReadAllAsync())
+            {
+                await responseStream.WriteAsync(new HelloReply { Message = "Hello " + request.Name });
+            }
+        }
     }
 }

--- a/examples/Interceptor/Server/Services/GreeterService.cs
+++ b/examples/Interceptor/Server/Services/GreeterService.cs
@@ -56,13 +56,13 @@ namespace Server
 
         public override async Task<HelloReply> SayHelloToLotsOfBuddies(IAsyncStreamReader<HelloRequest> requestStream, ServerCallContext context)
         {
-            var message = "Hello";
+            var names = new List<string>();
             await foreach (var request in requestStream.ReadAllAsync())
             {
-                message += $" {request.Name},";
+                names.Add(request.Name);
             }
 
-            message = message.Remove(message.Length - 1);
+            var message = $"Hello {string.Join(", ", names)}";
 
             _logger.LogInformation($"Sending greeting {message}.");
             return new HelloReply { Message = message };


### PR DESCRIPTION
Interceptor example lacked an example of `BlockingUnaryCall`. Also lacked exemplary client and bidirectional streaming RPCs. Add `BlockingUnaryCall` implementation to `ClientLoggerInterceptor` and add missing exemplary methods.

Loosely coupled with ongoing work on documentation for gRPC interceptors on .NET (https://github.com/dotnet/AspNetCore.Docs/issues/24720).