### PR TITLE
NuGet readme clean up and fixes

### DIFF
--- a/src/Grpc.AspNetCore.Server/README.md
+++ b/src/Grpc.AspNetCore.Server/README.md
@@ -17,7 +17,6 @@ public class Startup
         services.AddGrpc();
     }
 
-    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
         if (env.IsDevelopment())

--- a/src/Grpc.AspNetCore/README.md
+++ b/src/Grpc.AspNetCore/README.md
@@ -21,7 +21,6 @@ public class Startup
         services.AddGrpc();
     }
 
-    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
         if (env.IsDevelopment())

--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -7,6 +7,7 @@
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
@@ -22,6 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+
     <Compile Include="..\Shared\CommonGrpcProtocolHelpers.cs" Link="Internal\CommonGrpcProtocolHelpers.cs" />
     <Compile Include="..\Shared\DefaultDeserializationContext.cs" Link="Internal\DefaultDeserializationContext.cs" />
     <Compile Include="..\Shared\HttpHandlerFactory.cs" Link="Internal\Http\HttpHandlerFactory.cs" />


### PR DESCRIPTION
I took a look at changes from https://github.com/grpc/grpc-dotnet/pull/1570 on the preview NuGet packages and there are a couple of fixes/improvements:

* Add missing metadata on one project
* Remove unnecessary long comments that wrap on the website