### PR TITLE
[v2.43.x]  Bump version to 2.43.0

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.43.0-pre1</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.43.0</GrpcDotnetVersion>
     
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>


### PR DESCRIPTION
@JamesNK  what's remaining to be able to publish the 2.43.0 stable release?

should we disable LB again?

I'll only merge this PR once I get a green light from you to proceed with the release.