### PR TITLE
Narrow GrpcWebMiddleware rules to only rewrite POST requests

### DIFF
--- a/src/Grpc.AspNetCore.Web/Internal/GrpcWebMiddleware.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/GrpcWebMiddleware.cs
@@ -113,11 +113,13 @@ namespace Grpc.AspNetCore.Web.Internal
 
         internal static ServerGrpcWebContext GetGrpcWebContext(HttpContext httpContext)
         {
+            // gRPC requests are always POST.
             if (!HttpMethods.IsPost(httpContext.Request.Method))
             {
                 return default;
             }
 
+            // Only run middleware for 'application/grpc-web' or 'application/grpc-web-text'.
             if (!TryGetWebMode(httpContext.Request.ContentType, out var requestMode))
             {
                 return default;
@@ -125,6 +127,8 @@ namespace Grpc.AspNetCore.Web.Internal
 
             if (TryGetWebMode(httpContext.Request.Headers["Accept"], out var responseMode))
             {
+                // gRPC-Web request and response types are typically the same.
+                // That means 'application/grpc-web-text' requests also have an 'accept' header value of 'application/grpc-web-text'.
                 return new ServerGrpcWebContext(requestMode, responseMode);
             }
             else

--- a/src/Grpc.AspNetCore.Web/Internal/GrpcWebMiddleware.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/GrpcWebMiddleware.cs
@@ -113,6 +113,11 @@ namespace Grpc.AspNetCore.Web.Internal
 
         internal static ServerGrpcWebContext GetGrpcWebContext(HttpContext httpContext)
         {
+            if (!HttpMethods.IsPost(httpContext.Request.Method))
+            {
+                return default;
+            }
+
             if (!TryGetWebMode(httpContext.Request.ContentType, out var requestMode))
             {
                 return default;

--- a/test/Grpc.AspNetCore.Server.Tests/Web/GrpcWebMiddlewareTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/Web/GrpcWebMiddlewareTests.cs
@@ -101,6 +101,22 @@ namespace Grpc.AspNetCore.Server.Tests.Web
         }
 
         [Test]
+        public void GetGrpcWebMode_NonPost_NotMatched()
+        {
+            // Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Method = HttpMethods.Options;
+            httpContext.Request.ContentType = GrpcWebProtocolConstants.GrpcWebContentType;
+
+            // Act
+            var grpcWebContext = GrpcWebMiddleware.GetGrpcWebContext(httpContext);
+
+            // Assert
+            Assert.AreEqual(ServerGrpcWebMode.None, grpcWebContext.Request);
+            Assert.AreEqual(ServerGrpcWebMode.None, grpcWebContext.Response);
+        }
+
+        [Test]
         public async Task Invoke_GrpcWebContentTypeAndNotEnabled_NotProcessed()
         {
             // Arrange


### PR DESCRIPTION
User reporting an issue when combing gRPC-Web with CORS - https://github.com/dotnet/AspNetCore.Docs/issues/25046

I'm not sure how they interfere with each other. gRPC-Web middleware should only trigger when content-type = "application/grpc-web".

My only theory is content-type is incorrectly being set on OPTIONS preflight request. This PR updates middleware to only modify the request when it a POST (all gRPC requests are POST)