### PR TITLE
Log DebugException from RpcException if present

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServerLog.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServerLog.cs
@@ -129,9 +129,9 @@ namespace Grpc.AspNetCore.Server.Internal
             _errorExecutingServiceMethod(logger, serviceMethod, ex);
         }
 
-        public static void RpcConnectionError(ILogger logger, StatusCode statusCode, string detail)
+        public static void RpcConnectionError(ILogger logger, StatusCode statusCode, string detail, Exception? debugException)
         {
-            _rpcConnectionError(logger, statusCode, detail, null);
+            _rpcConnectionError(logger, statusCode, detail, debugException);
         }
 
         public static void EncodingNotInAcceptEncoding(ILogger logger, string grpcEncoding)

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -179,8 +179,9 @@ namespace Grpc.AspNetCore.Server.Internal
             if (ex is RpcException rpcException)
             {
                 // RpcException is thrown by client code to modify the status returned from the server.
-                // Log the status and detail. Don't log the exception to reduce log verbosity.
-                GrpcServerLog.RpcConnectionError(Logger, rpcException.StatusCode, rpcException.Status.Detail);
+                // Log the status, detail and debug exception (if present).
+                // Don't log the RpcException itself to reduce log verbosity. All of its information is already captured.
+                GrpcServerLog.RpcConnectionError(Logger, rpcException.StatusCode, rpcException.Status.Detail, rpcException.Status.DebugException);
 
                 // There are two sources of metadata entries on the server-side:
                 // 1. serverCallContext.ResponseTrailers


### PR DESCRIPTION
PR https://github.com/grpc/grpc-dotnet/pull/1436 removed logging the exception but there can still be useful information in the optional debug exception.