### PR TITLE
Log HTTP method when adding endpoint

### DIFF
--- a/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
@@ -68,6 +68,7 @@ namespace Grpc.AspNetCore.Server.Model.Internal
                 foreach (var method in serviceMethodProviderContext.Methods)
                 {
                     var endpointBuilder = endpointRouteBuilder.Map(method.Pattern, method.RequestDelegate);
+                    var httpMethod = method.Metadata.OfType<HttpMethodMetadata>().LastOrDefault();
 
                     endpointBuilder.Add(ep =>
                     {
@@ -82,7 +83,13 @@ namespace Grpc.AspNetCore.Server.Model.Internal
 
                     endpointConventionBuilders.Add(endpointBuilder);
 
-                    Log.AddedServiceMethod(_logger, method.Method.Name, method.Method.ServiceName, method.Method.Type, method.Pattern.RawText ?? string.Empty);
+                    Log.AddedServiceMethod(
+                        _logger,
+                        method.Method.Name,
+                        method.Method.ServiceName,
+                        method.Method.Type,
+                        httpMethod?.HttpMethods ?? Array.Empty<string>(),
+                        method.Pattern.RawText ?? string.Empty);
                 }
             }
             else
@@ -189,8 +196,8 @@ namespace Grpc.AspNetCore.Server.Model.Internal
 
     internal static class ServiceRouteBuilderLog
     {
-        private static readonly Action<ILogger, string, string, MethodType, string, Exception?> _addedServiceMethod =
-            LoggerMessage.Define<string, string, MethodType, string>(LogLevel.Trace, new EventId(1, "AddedServiceMethod"), "Added gRPC method '{MethodName}' to service '{ServiceName}'. Method type: '{MethodType}', route pattern: '{RoutePattern}'.");
+        private static readonly Action<ILogger, string, string, MethodType, string, string, Exception?> _addedServiceMethod =
+            LoggerMessage.Define<string, string, MethodType, string, string>(LogLevel.Trace, new EventId(1, "AddedServiceMethod"), "Added gRPC method '{MethodName}' to service '{ServiceName}'. Method type: {MethodType}, HTTP method: {HttpMethod}, route pattern: '{RoutePattern}'.");
 
         private static readonly Action<ILogger, Type, Exception?> _discoveringServiceMethods =
             LoggerMessage.Define<Type>(LogLevel.Trace, new EventId(2, "DiscoveringServiceMethods"), "Discovering gRPC methods for {ServiceType}.");
@@ -198,9 +205,15 @@ namespace Grpc.AspNetCore.Server.Model.Internal
         private static readonly Action<ILogger, Type, Exception?> _noServiceMethodsDiscovered =
             LoggerMessage.Define<Type>(LogLevel.Debug, new EventId(3, "NoServiceMethodsDiscovered"), "No gRPC methods discovered for {ServiceType}.");
 
-        public static void AddedServiceMethod(ILogger logger, string methodName, string serviceName, MethodType methodType, string routePattern)
+        public static void AddedServiceMethod(ILogger logger, string methodName, string serviceName, MethodType methodType, IReadOnlyList<string> httpMethods, string routePattern)
         {
-            _addedServiceMethod(logger, methodName, serviceName, methodType, routePattern, null);
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                // There should be one HTTP method here, but concat in case someone has overriden metadata.
+                var allHttpMethods = string.Join(',', httpMethods);
+
+                _addedServiceMethod(logger, methodName, serviceName, methodType, allHttpMethods, routePattern, null);
+            }
         }
 
         public static void DiscoveringServiceMethods(ILogger logger, Type serviceType)

--- a/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
@@ -68,7 +68,6 @@ namespace Grpc.AspNetCore.Server.Model.Internal
                 foreach (var method in serviceMethodProviderContext.Methods)
                 {
                     var endpointBuilder = endpointRouteBuilder.Map(method.Pattern, method.RequestDelegate);
-                    var httpMethod = method.Metadata.OfType<HttpMethodMetadata>().LastOrDefault();
 
                     endpointBuilder.Add(ep =>
                     {
@@ -82,6 +81,9 @@ namespace Grpc.AspNetCore.Server.Model.Internal
                     });
 
                     endpointConventionBuilders.Add(endpointBuilder);
+
+                    // Report the last HttpMethodMetadata added. It's the metadata used by routing.
+                    var httpMethod = method.Metadata.OfType<HttpMethodMetadata>().LastOrDefault();
 
                     Log.AddedServiceMethod(
                         _logger,

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -144,10 +144,10 @@ namespace Grpc.AspNetCore.Server.Tests
             Assert.AreEqual("Discovering gRPC methods for Grpc.AspNetCore.Server.Tests.TestObjects.Services.WithAttribute.GreeterWithAttributeService.", s1);
 
             var s2 = writes[1].State.ToString();
-            Assert.AreEqual("Added gRPC method 'SayHello' to service 'greet.Greeter'. Method type: 'Unary', route pattern: '/greet.Greeter/SayHello'.", s2);
+            Assert.AreEqual("Added gRPC method 'SayHello' to service 'greet.Greeter'. Method type: Unary, HTTP method: POST, route pattern: '/greet.Greeter/SayHello'.", s2);
 
             var s3 = writes[2].State.ToString();
-            Assert.AreEqual("Added gRPC method 'SayHellos' to service 'greet.Greeter'. Method type: 'ServerStreaming', route pattern: '/greet.Greeter/SayHellos'.", s3);
+            Assert.AreEqual("Added gRPC method 'SayHellos' to service 'greet.Greeter'. Method type: ServerStreaming, HTTP method: POST, route pattern: '/greet.Greeter/SayHellos'.", s3);
         }
 
         [Test]


### PR DESCRIPTION
Custom service method provider can override the HTTP method of gRPC service. For example, gRPC transcoding.

Include HTTP method in log for debugging.