### PR TITLE
Support WriteAsync cancellation token

### DIFF
--- a/perf/Grpc.AspNetCore.Microbenchmarks/Internal/MessageHelpers.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Internal/MessageHelpers.cs
@@ -30,7 +30,7 @@ namespace Grpc.AspNetCore.Microbenchmarks.Internal
         {
             var pipeWriter = PipeWriter.Create(stream);
 
-            PipeExtensions.WriteMessageAsync(pipeWriter, message, callContext ?? HttpContextServerCallContextHelper.CreateServerCallContext(), (r, c) => c.Complete(r.ToByteArray()), canFlush: true).GetAwaiter().GetResult();
+            PipeExtensions.WriteStreamedMessageAsync(pipeWriter, message, callContext ?? HttpContextServerCallContextHelper.CreateServerCallContext(), (r, c) => c.Complete(r.ToByteArray())).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
@@ -75,7 +75,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             }
 
             var responseBodyWriter = httpContext.Response.BodyWriter;
-            await responseBodyWriter.WriteMessageAsync(response, serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer, canFlush: false);
+            await responseBodyWriter.WriteSingleMessageAsync(response, serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer);
         }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
@@ -64,7 +64,7 @@ namespace Grpc.AspNetCore.Server.Internal.CallHandlers
             }
 
             var responseBodyWriter = httpContext.Response.BodyWriter;
-            await responseBodyWriter.WriteMessageAsync(response, serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer, canFlush: false);
+            await responseBodyWriter.WriteSingleMessageAsync(response, serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer);
         }
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -476,6 +476,11 @@ namespace Grpc.AspNetCore.Server.Internal
                 await completionFeature.CompleteAsync();
             }
 
+            CancelRequest();
+        }
+
+        internal void CancelRequest()
+        {
             // HttpResetFeature should always be set on context,
             // but in case it isn't, fall back to HttpContext.Abort.
             // Abort will send error code INTERNAL_ERROR.

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -64,6 +64,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 throw new ArgumentNullException(nameof(message));
             }
 
+            // Register cancellation token early to ensure request is canceled if cancellation is requested.
             CancellationTokenRegistration? registration = null;
             if (cancellationToken.CanBeCanceled)
             {
@@ -90,7 +91,7 @@ namespace Grpc.AspNetCore.Server.Internal
                     }
 
                     // Save write task to track whether it is complete. Must be set inside lock.
-                    _writeTask = _context.HttpContext.Response.BodyWriter.WriteMessageAsync(message, _context, _serializer, canFlush: true);
+                    _writeTask = _context.HttpContext.Response.BodyWriter.WriteStreamedMessageAsync(message, _context, _serializer, cancellationToken);
                 }
 
                 await _writeTask;

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -17,6 +17,8 @@
 #endregion
 
 using Grpc.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal
 {
@@ -44,29 +46,59 @@ namespace Grpc.AspNetCore.Server.Internal
 
         public Task WriteAsync(TResponse message)
         {
+            return WriteCoreAsync(message, CancellationToken.None);
+        }
+
+#if NET5_0_OR_GREATER
+        // Explicit implementation because this WriteAsync has a default interface implementation.
+        Task IAsyncStreamWriter<TResponse>.WriteAsync(TResponse message, CancellationToken cancellationToken)
+        {
+            return WriteCoreAsync(message, cancellationToken);
+        }
+#endif
+
+        private async Task WriteCoreAsync(TResponse message, CancellationToken cancellationToken)
+        {
             if (message == null)
             {
-                return Task.FromException(new ArgumentNullException(nameof(message)));
+                throw new ArgumentNullException(nameof(message));
             }
 
-            if (_completed || _context.CancellationToken.IsCancellationRequested)
+            CancellationTokenRegistration? registration = null;
+            if (cancellationToken.CanBeCanceled)
             {
-                return Task.FromException(new InvalidOperationException("Can't write the message because the request is complete."));
+                registration = cancellationToken.Register(
+                    static (state) => ((HttpContextServerCallContext)state!).CancelRequest(),
+                    _context);
             }
 
-            lock (_writeLock)
+            try
             {
-                // Pending writes need to be awaited first
-                if (IsWriteInProgressUnsynchronized)
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (_completed || _context.CancellationToken.IsCancellationRequested)
                 {
-                    return Task.FromException(new InvalidOperationException("Can't write the message because the previous write is in progress."));
+                    throw new InvalidOperationException("Can't write the message because the request is complete.");
                 }
 
-                // Save write task to track whether it is complete. Must be set inside lock.
-                _writeTask = _context.HttpContext.Response.BodyWriter.WriteMessageAsync(message, _context, _serializer, canFlush: true);
-            }
+                lock (_writeLock)
+                {
+                    // Pending writes need to be awaited first
+                    if (IsWriteInProgressUnsynchronized)
+                    {
+                        throw new InvalidOperationException("Can't write the message because the previous write is in progress.");
+                    }
 
-            return _writeTask;
+                    // Save write task to track whether it is complete. Must be set inside lock.
+                    _writeTask = _context.HttpContext.Response.BodyWriter.WriteMessageAsync(message, _context, _serializer, canFlush: true);
+                }
+
+                await _writeTask;
+            }
+            finally
+            {
+                registration?.Dispose();
+            }
         }
 
         public void Complete()

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -43,7 +43,37 @@ namespace Grpc.AspNetCore.Server.Internal
             return new Status(StatusCode.Unimplemented, $"Unsupported grpc-encoding value '{unsupportedEncoding}'. Supported encodings: {string.Join(", ", supportedEncodings)}");
         }
 
-        public static async Task WriteMessageAsync<TResponse>(this PipeWriter pipeWriter, TResponse response, HttpContextServerCallContext serverCallContext, Action<TResponse, SerializationContext> serializer, bool canFlush)
+        public static async Task WriteSingleMessageAsync<TResponse>(this PipeWriter pipeWriter, TResponse response, HttpContextServerCallContext serverCallContext, Action<TResponse, SerializationContext> serializer)
+            where TResponse : class
+        {
+            var logger = serverCallContext.Logger;
+            try
+            {
+                // Must call StartAsync before the first pipeWriter.GetSpan() in WriteHeader
+                var httpResponse = serverCallContext.HttpContext.Response;
+                if (!httpResponse.HasStarted)
+                {
+                    await httpResponse.StartAsync();
+                }
+
+                GrpcServerLog.SendingMessage(logger);
+
+                var serializationContext = serverCallContext.SerializationContext;
+                serializationContext.Reset();
+                serializationContext.ResponseBufferWriter = pipeWriter;
+                serializer(response, serializationContext);
+
+                GrpcServerLog.MessageSent(serverCallContext.Logger);
+                GrpcEventSource.Log.MessageSent();
+            }
+            catch (Exception ex)
+            {
+                GrpcServerLog.ErrorSendingMessage(logger, ex);
+                throw;
+            }
+        }
+
+        public static async Task WriteStreamedMessageAsync<TResponse>(this PipeWriter pipeWriter, TResponse response, HttpContextServerCallContext serverCallContext, Action<TResponse, SerializationContext> serializer, CancellationToken cancellationToken = default)
             where TResponse : class
         {
             var logger = serverCallContext.Logger;
@@ -64,7 +94,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 serializer(response, serializationContext);
 
                 // Flush messages unless WriteOptions.Flags has BufferHint set
-                var flush = canFlush && ((serverCallContext.WriteOptions?.Flags ?? default) & WriteFlags.BufferHint) != WriteFlags.BufferHint;
+                var flush = ((serverCallContext.WriteOptions?.Flags ?? default) & WriteFlags.BufferHint) != WriteFlags.BufferHint;
 
                 if (flush)
                 {
@@ -72,7 +102,9 @@ namespace Grpc.AspNetCore.Server.Internal
 
                     // Workaround bug where FlushAsync doesn't return IsCanceled = true on request abort.
                     // https://github.com/dotnet/aspnetcore/issues/40788
-                    if (!flushResult.IsCompleted && serverCallContext.CancellationToken.IsCancellationRequested)
+                    // Also, sometimes the request CT isn't triggered. Also check CT passed into method.
+                    if (!flushResult.IsCompleted &&
+                        (serverCallContext.CancellationToken.IsCancellationRequested || cancellationToken.IsCancellationRequested))
                     {
                         throw new OperationCanceledException("Request aborted while sending the message.");
                     }

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -74,7 +74,7 @@ namespace Grpc.AspNetCore.Server.Internal
                     // https://github.com/dotnet/aspnetcore/issues/40788
                     if (!flushResult.IsCompleted && serverCallContext.CancellationToken.IsCancellationRequested)
                     {
-                        throw new OperationCanceledException();
+                        throw new OperationCanceledException("Request aborted while sending the message.");
                     }
                 }
 

--- a/src/Grpc.Net.Client/Internal/ClientStreamWriterBase.cs
+++ b/src/Grpc.Net.Client/Internal/ClientStreamWriterBase.cs
@@ -40,7 +40,17 @@ namespace Grpc.Net.Client.Internal
 
         public abstract Task CompleteAsync();
 
-        public abstract Task WriteAsync(TRequest message);
+        public Task WriteAsync(TRequest message) => WriteCoreAsync(message, CancellationToken.None);
+
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+        // Explicit implementation because this WriteAsync has a default interface implementation.
+        Task IAsyncStreamWriter<TRequest>.WriteAsync(TRequest message, CancellationToken cancellationToken)
+        {
+            return WriteCoreAsync(message, cancellationToken);
+        }
+#endif
+
+        public abstract Task WriteCoreAsync(TRequest message, CancellationToken cancellationToken);
 
         protected Task CreateErrorTask(string message)
         {

--- a/src/Grpc.Net.Client/Internal/GrpcCall.NonGeneric.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.NonGeneric.cs
@@ -53,6 +53,7 @@ namespace Grpc.Net.Client.Internal
 
         public string? RequestGrpcEncoding { get; internal set; }
 
+        public abstract CancellationToken CancellationToken { get; }
         public abstract Type RequestType { get; }
         public abstract Type ResponseType { get; }
 

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -715,7 +715,8 @@ namespace Grpc.Net.Client.Internal
 
         public Exception CreateFailureStatusException(Status status)
         {
-            if (Channel.ThrowOperationCanceledOnCancellation && status.StatusCode == StatusCode.DeadlineExceeded)
+            if (Channel.ThrowOperationCanceledOnCancellation &&
+                (status.StatusCode == StatusCode.DeadlineExceeded || status.StatusCode == StatusCode.Cancelled))
             {
                 // Convert status response of DeadlineExceeded to OperationCanceledException when
                 // ThrowOperationCanceledOnCancellation is true.

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -109,15 +109,9 @@ namespace Grpc.Net.Client.Internal
 
         private async Task<bool> MoveNextCore(CancellationToken cancellationToken)
         {
-            CancellationTokenRegistration? ctsRegistration = null;
+            _call.TryRegisterCancellation(cancellationToken, out var ctsRegistration);
             try
             {
-                if (cancellationToken.CanBeCanceled)
-                {
-                    // The cancellation token will cancel the call CTS.
-                    ctsRegistration = cancellationToken.Register(_call.CancelCallFromCancellationToken);
-                }
-
                 _call.CancellationToken.ThrowIfCancellationRequested();
 
                 if (_httpResponse == null)

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -171,7 +171,7 @@ namespace Grpc.Net.Client.Internal
 
                 await writeFunc(_call, writeStream, callOptions, state).ConfigureAwait(false);
 
-                // Flush stream to ensure messages are sent immediately
+                // Flush stream to ensure messages are sent immediately.
                 await writeStream.FlushAsync(_call.CancellationToken).ConfigureAwait(false);
 
                 GrpcEventSource.Log.MessageSent();

--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
 
 #if NETSTANDARD2_0
@@ -41,7 +42,13 @@ namespace Grpc.Net.Client.Internal
         void StartServerStreaming(TRequest request);
         void StartDuplexStreaming();
 
-        Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state);
+        Task WriteClientStreamAsync<TState>(
+            Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc,
+            TState state);
+
+        bool TryRegisterCancellation(
+            CancellationToken cancellationToken,
+            [NotNullWhen(true)] out CancellationTokenRegistration? cancellationTokenRegistration);
 
         bool Disposed { get; }
     }

--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -46,6 +46,8 @@ namespace Grpc.Net.Client.Internal
             Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc,
             TState state);
 
+        Exception CreateFailureStatusException(Status status);
+
         bool TryRegisterCancellation(
             CancellationToken cancellationToken,
             [NotNullWhen(true)] out CancellationTokenRegistration? cancellationTokenRegistration);

--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -36,6 +36,9 @@ namespace Grpc.Net.Client.Internal.Retry
         private TaskCompletionSource<object?>? _delayInterruptTcs;
         private TimeSpan? _pushbackDelay;
 
+        private TaskCompletionSource<bool>? _writeClientMessageTcs;
+        private int _writeClientMessageCount;
+
         // Internal for testing
         internal List<IGrpcCall<TRequest, TResponse>> _activeCalls { get; }
         internal Task? CreateHedgingCallsTask { get; set; }
@@ -387,42 +390,92 @@ namespace Grpc.Net.Client.Internal.Retry
         public override async Task ClientStreamWriteAsync(TRequest message, CancellationToken cancellationToken)
         {
             // The retry client stream writer prevents multiple threads from reaching here.
-            await DoClientStreamActionAsync(async calls =>
-            {
-                // Note: There may be less write tasks than calls passed in.
-                // For example, a large message could cause the call to be commited and all active calls are removed.
-                var writeTasks = new List<Task>(calls.Count);
-                List<CancellationTokenRegistration>? registrations = null;
+            
+            // Hedging allows:
+            // 1. Multiple calls to happen simultaniously
+            // 2. Starting a new call once existing calls have failed.
+            // 
+            // We don't want to exit this method until either the message has been sent to the
+            // server at least once successfully, or the call fails.
+            // If there is an error sending the message then wait for another call to successfully
+            // send the buffered data.
+            //
+            // This is done by awaiting a TCS until either:
+            // 1. The message count is sent.
+            // 2. The call is commited with an error, throwing an exception.
+            _writeClientMessageCount++;
+            _writeClientMessageTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                for (var i = 0; i < calls.Count; i++)
+            // Register after TCS is created so immediate failure is propagated to TCS.
+            using var registration = (cancellationToken.CanBeCanceled && cancellationToken != Options.CancellationToken)
+                ? RegisterRetryCancellationToken(cancellationToken)
+                : default;
+
+            try
+            {
+                await DoClientStreamActionAsync(async calls =>
                 {
-                    var c = calls[i];
-                    if (c.TryRegisterCancellation(cancellationToken, out var registration))
+                    // Note: There may be less write tasks than calls passed in.
+                    // For example, a large message could cause the call to be commited and all active calls are removed.
+                    var writeTasks = new List<Task>(calls.Count);
+                    List<CancellationTokenRegistration>? registrations = null;
+
+                    for (var i = 0; i < calls.Count; i++)
                     {
-                        registrations ??= new List<CancellationTokenRegistration>(calls.Count);
-                        registrations.Add(registration.GetValueOrDefault());
+                        var c = calls[i];
+                        if (c.TryRegisterCancellation(cancellationToken, out var registration))
+                        {
+                            registrations ??= new List<CancellationTokenRegistration>(calls.Count);
+                            registrations.Add(registration.GetValueOrDefault());
+                        }
+
+                        var writeTask = c.WriteClientStreamAsync(WriteNewMessage, message);
+
+                        writeTasks.Add(writeTask);
                     }
 
-                    var writeTask = c.WriteClientStreamAsync(WriteNewMessage, message);
-
-                    writeTasks.Add(writeTask);
-                }
-
-                try
-                {
-                    await Task.WhenAll(writeTasks).ConfigureAwait(false);
-                }
-                finally
-                {
-                    if (registrations != null)
+                    try
                     {
-                        foreach (var registration in registrations)
+                        await Task.WhenAll(writeTasks).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        if (registrations != null)
                         {
-                            registration.Dispose();
+                            foreach (var registration in registrations)
+                            {
+                                registration.Dispose();
+                            }
                         }
                     }
+                }).ConfigureAwait(false);
+            }
+            catch
+            {
+                lock (Lock)
+                {
+                    if (CommitedCallTask.IsCompletedSuccessfully())
+                    {
+                        throw;
+                    }
                 }
-            }).ConfigureAwait(false);
+
+                // Flag indicates whether buffered message was successfully written.
+                var success = await _writeClientMessageTcs.Task.ConfigureAwait(false);
+                if (success)
+                {
+                    return;
+                }
+                else
+                {
+                    var commitedCall = CommitedCallTask.Result;
+                    throw commitedCall.CreateFailureStatusException(commitedCall.GetStatus());
+                }
+            }
+            finally
+            {
+                _writeClientMessageTcs = null;
+            }
 
             lock (Lock)
             {
@@ -445,14 +498,9 @@ namespace Grpc.Net.Client.Internal.Retry
 
             lock (Lock)
             {
-                if (_activeCalls.Count > 0)
-                {
-                    return action(_activeCalls);
-                }
-                else
-                {
-                    return WaitForCallUnsynchronizedAsync(action);
-                }
+                return _activeCalls.Count > 0
+                    ? action(_activeCalls)
+                    : WaitForCallUnsynchronizedAsync(action);
             }
 
             async Task WaitForCallUnsynchronizedAsync(Func<IList<IGrpcCall<TRequest, TResponse>>, Task> action)
@@ -462,9 +510,18 @@ namespace Grpc.Net.Client.Internal.Retry
             }
         }
 
+        protected override void OnBufferMessageWritten(int count)
+        {
+            if (count >= _writeClientMessageCount)
+            {
+                _writeClientMessageTcs?.TrySetResult(true);
+            }
+        }
+
         protected override void OnCancellation()
         {
             _hedgingDelayCts?.Cancel();
+            _writeClientMessageTcs?.TrySetResult(false);
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -299,10 +299,14 @@ namespace Grpc.Net.Client.Internal.Retry
             });
         }
 
-        public override Task ClientStreamWriteAsync(TRequest message, CancellationToken cancellationToken)
+        public override async Task ClientStreamWriteAsync(TRequest message, CancellationToken cancellationToken)
         {
+            using var registration = (cancellationToken.CanBeCanceled && cancellationToken != Options.CancellationToken)
+                ? RegisterRetryCancellationToken(cancellationToken)
+                : default;
+
             // The retry client stream writer prevents multiple threads from reaching here.
-            return DoClientStreamActionAsync(async call =>
+            await DoClientStreamActionAsync(async call =>
             {
                 CompatibilityHelpers.Assert(call.ClientStreamWriter != null);
 
@@ -330,7 +334,7 @@ namespace Grpc.Net.Client.Internal.Retry
                 {
                     await call.ClientStreamWriter.CompleteAsync().ConfigureAwait(false);
                 }
-            });
+            }).ConfigureAwait(false);
         }
 
         private async Task DoClientStreamActionAsync(Func<IGrpcCall<TRequest, TResponse>, Task> action)

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamWriter.cs
@@ -58,7 +58,7 @@ namespace Grpc.Net.Client.Internal.Retry
             }
         }
 
-        public override Task WriteAsync(TRequest message)
+        public override Task WriteCoreAsync(TRequest message, CancellationToken cancellationToken)
         {
             lock (WriteLock)
             {
@@ -76,7 +76,7 @@ namespace Grpc.Net.Client.Internal.Retry
                 }
 
                 // Save write task to track whether it is complete. Must be set inside lock.
-                WriteTask = _retryCallBase.ClientStreamWriteAsync(message);
+                WriteTask = _retryCallBase.ClientStreamWriteAsync(message, cancellationToken);
             }
 
             return WriteTask;

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseLog.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseLog.cs
@@ -59,6 +59,9 @@ namespace Grpc.Net.Client.Internal.Retry
         private static readonly Action<ILogger, int, Exception?> _startingAttempt =
             LoggerMessage.Define<int>(LogLevel.Debug, new EventId(12, "StartingAttempt"), "Starting attempt {AttemptCount}.");
 
+        private static readonly Action<ILogger, Exception?> _canceledRetry =
+            LoggerMessage.Define(LogLevel.Debug, new EventId(13, "CanceledRetry"), "gRPC retry call canceled.");
+
         internal static void RetryEvaluated(ILogger logger, StatusCode statusCode, int attemptCount, bool willRetry)
         {
             _retryEvaluated(logger, statusCode, attemptCount, willRetry, null);
@@ -117,6 +120,11 @@ namespace Grpc.Net.Client.Internal.Retry
         internal static void StartingAttempt(ILogger logger, int attempts)
         {
             _startingAttempt(logger, attempts, null);
+        }
+
+        internal static void CanceledRetry(ILogger logger)
+        {
+            _canceledRetry(logger, null);
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
 
 #if NETSTANDARD2_0
@@ -88,6 +89,12 @@ namespace Grpc.Net.Client.Internal.Retry
         public Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state)
         {
             return Task.FromException(new RpcException(_status));
+        }
+
+        public bool TryRegisterCancellation(CancellationToken cancellationToken, [NotNullWhen(true)] out CancellationTokenRegistration? cancellationTokenRegistration)
+        {
+            cancellationTokenRegistration = null;
+            return false;
         }
 
         private sealed class StatusClientStreamWriter : IClientStreamWriter<TRequest>

--- a/test/FunctionalTests/Client/HedgingTests.cs
+++ b/test/FunctionalTests/Client/HedgingTests.cs
@@ -37,6 +37,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
     [TestFixture]
     public class HedgingTests : FunctionalTestBase
     {
+        // Big enough to hit flow control if not immediately read by peer.
         private const int BigMessageSize = 1024 * 1024 * 5;
 
         protected override void ConfigureServices(IServiceCollection services)
@@ -792,7 +793,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
 
             var serviceConfig = ServiceConfigHelpers.CreateHedgingServiceConfig(
                 maxAttempts: maxAttempts);
-            var channel = CreateChannel(serviceConfig: serviceConfig);
+            var channel = CreateChannel(
+                serviceConfig: serviceConfig,
+                maxReceiveMessageSize: BigMessageSize * 2);
 
             var client = TestClientFactory.Create(channel, method);
 

--- a/test/FunctionalTests/Client/HedgingTests.cs
+++ b/test/FunctionalTests/Client/HedgingTests.cs
@@ -779,7 +779,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 }
                 catch (Exception ex)
                 {
-                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    if (IsWriteCanceledException(ex))
                     {
                         serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);
                         return new DataMessage();

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -695,7 +695,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 }
                 catch (Exception ex)
                 {
-                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    if (IsWriteCanceledException(ex))
                     {
                         Logger.LogInformation("Server got expected cancellation when sending big message.");
                         serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -35,6 +35,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
     [TestFixture]
     public class RetryTests : FunctionalTestBase
     {
+        // Big enough to hit flow control if not immediately read by peer.
         private const int BigMessageSize = 1024 * 1024 * 5;
 
         protected override void ConfigureServices(IServiceCollection services)

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -24,6 +24,7 @@ using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Race;
@@ -35,6 +36,17 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
     [TestFixture]
     public class StreamingTests : FunctionalTestBase
     {
+        private const int BigMessageSize = 1024 * 1024 * 5;
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services
+                .AddGrpc(options =>
+                {
+                    options.MaxReceiveMessageSize = BigMessageSize * 2;
+                });
+        }
+
         [Test]
         public async Task DuplexStream_SendLargeFileBatchedAndRecieveLargeFileBatched_Success()
         {
@@ -995,6 +1007,264 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                     contexts[i].Call.Dispose();
                 }
             }
+        }
+
+        [Test]
+        public async Task ServerStreaming_WriteAsyncCancellationBefore_ServerAbort()
+        {
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                return true;
+            });
+
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var serverCanceledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task ServerStreamingWithCancellation(DataMessage request, IServerStreamWriter<DataMessage> responseStream, ServerCallContext context)
+            {
+                await responseStream.WriteAsync(request, CancellationToken.None);
+                await tcs.Task;
+
+                try
+                {
+                    await responseStream.WriteAsync(request, new CancellationToken(true));
+                }
+                catch (OperationCanceledException)
+                {
+                    serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);
+                    throw;
+                }
+            }
+
+            // Arrange
+            var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingWithCancellation);
+
+            var channel = CreateChannel();
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.ServerStreamingCall(new DataMessage { Data = ByteString.CopyFrom(Encoding.UTF8.GetBytes("Hello world")) });
+
+            // Assert
+            Assert.IsTrue(await call.ResponseStream.MoveNext().DefaultTimeout());
+            tcs.SetResult(null);
+
+            var clientEx = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
+            Assert.AreEqual(StatusCode.Cancelled, clientEx.StatusCode);
+
+            Assert.IsTrue(await serverCanceledTcs.Task.DefaultTimeout());
+        }
+
+        [Test]
+        public async Task ServerStreaming_WriteAsyncCancellationDuring_ServerAbort()
+        {
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                return true;
+            });
+
+            var firstMessageTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var serverCanceledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task ServerStreamingWithCancellation(DataMessage request, IServerStreamWriter<DataMessage> responseStream, ServerCallContext context)
+            {
+                Logger.LogInformation("Server sending first message.");
+                await responseStream.WriteAsync(request, CancellationToken.None);
+
+                Logger.LogInformation("Server waiting for client to read first message.");
+                await firstMessageTcs.Task;
+
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                try
+                {
+                    Logger.LogInformation("Server sending big message.");
+                    await responseStream.WriteAsync(
+                        new DataMessage { Data = ByteString.CopyFrom(new byte[BigMessageSize]) },
+                        cts.Token);
+
+                    Logger.LogInformation("Server didn't wait to send big message.");
+                    serverCanceledTcs.SetException(new Exception("Server didn't wait to send big message."));
+                }
+                catch (Exception ex)
+                {
+                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    {
+                        Logger.LogInformation("Server got expected cancellation when sending big message.");
+                        serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);
+                        return;
+                    }
+
+                    Logger.LogInformation("Server got unexpected error when sending big message.");
+                    serverCanceledTcs.TrySetException(ex);
+                    throw;
+                }
+            }
+
+            // Arrange
+            var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingWithCancellation);
+
+            var channel = CreateChannel();
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.ServerStreamingCall(new DataMessage { Data = ByteString.CopyFrom(Encoding.UTF8.GetBytes("Hello world")) });
+
+            // Assert
+            Logger.LogInformation("Client sending first message.");
+            Assert.IsTrue(await call.ResponseStream.MoveNext().DefaultTimeout());
+
+            Logger.LogInformation("Client waiting for server to read first message.");
+            firstMessageTcs.SetResult(null);
+
+            Logger.LogInformation("Client waiting for server cancellation confirmation.");
+            var isCanceled = await serverCanceledTcs.Task.DefaultTimeout();
+            Assert.IsTrue(await serverCanceledTcs.Task.DefaultTimeout());
+
+            Logger.LogInformation("Client reading canceled message from server.");
+            var clientEx = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseStream.MoveNext()).DefaultTimeout();
+            Assert.AreEqual(StatusCode.Cancelled, clientEx.StatusCode);
+        }
+
+        [Test]
+        public async Task ClientStreaming_WriteAsyncCancellationBefore_ClientAbort()
+        {
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                return true;
+            });
+
+            var firstMessageTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var serverCanceledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task<DataMessage> ClientStreamingWithCancellation(IAsyncStreamReader<DataMessage> requestStream, ServerCallContext context)
+            {
+                Logger.LogInformation("Server reading first message.");
+                Assert.IsTrue(await requestStream.MoveNext());
+                firstMessageTcs.SetResult(null);
+
+                try
+                {
+                    Logger.LogInformation("Server reading second message.");
+                    await requestStream.MoveNext();
+                    throw new Exception("Should never reached here.");
+                }
+                catch (Exception ex)
+                {
+                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    {
+                        Logger.LogInformation("Server read canceled as expeceted.");
+                        serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);
+                        return new DataMessage();
+                    }
+
+                    Logger.LogInformation("Server unexpected error from read.");
+                    serverCanceledTcs.SetException(ex);
+                    throw;
+                }
+            }
+
+            // Arrange
+            var method = Fixture.DynamicGrpc.AddClientStreamingMethod<DataMessage, DataMessage>(ClientStreamingWithCancellation);
+
+            var channel = CreateChannel();
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.ClientStreamingCall();
+
+            // Assert
+            Logger.LogInformation("Client sending first message.");
+            await call.RequestStream.WriteAsync(
+                new DataMessage { Data = ByteString.CopyFrom(Encoding.UTF8.GetBytes("Hello world")) },
+                CancellationToken.None).DefaultTimeout();
+
+            await firstMessageTcs.Task.DefaultTimeout();
+
+            Logger.LogInformation("Client sending second message.");
+            var clientEx = await ExceptionAssert.ThrowsAsync<RpcException>(
+                () => call.RequestStream.WriteAsync(
+                new DataMessage { Data = ByteString.CopyFrom(Encoding.UTF8.GetBytes("Hello world")) },
+                new CancellationToken(true))).DefaultTimeout();
+            Assert.AreEqual(StatusCode.Cancelled, clientEx.StatusCode);
+
+            Logger.LogInformation("Client waiting for server canceled confirmation.");
+            Assert.IsTrue(await serverCanceledTcs.Task.DefaultTimeout());
+        }
+
+        [Test]
+        public async Task ClientStreaming_WriteAsyncCancellationDuring_ClientAbort()
+        {
+            SetExpectedErrorsFilter(writeContext =>
+            {
+                return true;
+            });
+
+            var firstMessageTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientCancellationTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var serverCanceledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            async Task<DataMessage> ClientStreamingWithCancellation(IAsyncStreamReader<DataMessage> requestStream, ServerCallContext context)
+            {
+                Logger.LogInformation("Server reading first message.");
+                Assert.IsTrue(await requestStream.MoveNext());
+                firstMessageTcs.SetResult(null);
+
+                await clientCancellationTcs.Task;
+
+                try
+                {
+                    Logger.LogInformation("Server reading second message.");
+                    await requestStream.MoveNext();
+                    throw new Exception("Should never reached here.");
+                }
+                catch (Exception ex)
+                {
+                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    {
+                        Logger.LogInformation("Server read canceled as expeceted.");
+                        serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);
+                        return new DataMessage();
+                    }
+
+                    Logger.LogInformation("Server unexpected error from read.");
+                    serverCanceledTcs.SetException(ex);
+                    throw;
+                }
+            }
+
+            // Arrange
+            var method = Fixture.DynamicGrpc.AddClientStreamingMethod<DataMessage, DataMessage>(ClientStreamingWithCancellation);
+
+            var channel = CreateChannel(maxReceiveMessageSize: BigMessageSize * 2);
+
+            var client = TestClientFactory.Create(channel, method);
+
+            // Act
+            var call = client.ClientStreamingCall();
+
+            // Assert
+            Logger.LogInformation("Client sending first message.");
+            await call.RequestStream.WriteAsync(
+                new DataMessage { Data = ByteString.CopyFrom(Encoding.UTF8.GetBytes("Hello world")) },
+                CancellationToken.None).DefaultTimeout();
+
+            await firstMessageTcs.Task.DefaultTimeout();
+
+            Logger.LogInformation("Client sending second message.");
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            var clientEx = await ExceptionAssert.ThrowsAsync<RpcException>(
+                () => call.RequestStream.WriteAsync(
+                new DataMessage { Data = ByteString.CopyFrom(new byte[BigMessageSize]) },
+                cts.Token)).DefaultTimeout();
+            Assert.AreEqual(StatusCode.Cancelled, clientEx.StatusCode);
+
+            clientCancellationTcs.SetResult(null);
+
+            Logger.LogInformation("Client waiting for server canceled confirmation.");
+            Assert.IsTrue(await serverCanceledTcs.Task.DefaultTimeout());
         }
 #endif
     }

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -1077,6 +1077,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 await firstMessageTcs.Task;
 
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                cts.Token.Register(() => Logger.LogInformation("CTS timer triggered cancellation."));
                 try
                 {
                     Logger.LogInformation("Server sending big message.");
@@ -1089,7 +1090,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 }
                 catch (Exception ex)
                 {
-                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    if (IsWriteCanceledException(ex))
                     {
                         Logger.LogInformation("Server got expected cancellation when sending big message.");
                         serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);
@@ -1153,7 +1154,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 }
                 catch (Exception ex)
                 {
-                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    if (IsWriteCanceledException(ex))
                     {
                         Logger.LogInformation("Server read canceled as expeceted.");
                         serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);
@@ -1223,7 +1224,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
                 }
                 catch (Exception ex)
                 {
-                    if (ex is InvalidOperationException || ex is IOException || ex is OperationCanceledException)
+                    if (IsWriteCanceledException(ex))
                     {
                         Logger.LogInformation("Server read canceled as expeceted.");
                         serverCanceledTcs.SetResult(context.CancellationToken.IsCancellationRequested);

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -36,6 +36,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
     [TestFixture]
     public class StreamingTests : FunctionalTestBase
     {
+        // Big enough to hit flow control if not immediately read by peer.
         private const int BigMessageSize = 1024 * 1024 * 5;
 
         protected override void ConfigureServices(IServiceCollection services)
@@ -1104,7 +1105,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             // Arrange
             var method = Fixture.DynamicGrpc.AddServerStreamingMethod<DataMessage, DataMessage>(ServerStreamingWithCancellation);
 
-            var channel = CreateChannel();
+            var channel = CreateChannel(maxReceiveMessageSize: BigMessageSize * 2);
 
             var client = TestClientFactory.Create(channel, method);
 

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -885,7 +885,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Client
             Assert.AreEqual("Call canceled by the client.", clientEx.Status.Detail);
 
             var serverEx = await ExceptionAssert.ThrowsAsync<Exception>(() => tcs.Task).DefaultTimeout();
-            if (serverEx is IOException)
+            if (serverEx is IOException || serverEx is OperationCanceledException)
             {
                 // Cool
             }

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -39,7 +39,9 @@ namespace Grpc.AspNetCore.FunctionalTests
 
         protected GrpcChannel Channel => _channel ??= CreateChannel();
 
-        protected GrpcChannel CreateChannel(bool useHandler = false, ServiceConfig? serviceConfig = null, int? maxRetryAttempts = null, long? maxRetryBufferSize = null, long? maxRetryBufferPerCallSize = null)
+        protected GrpcChannel CreateChannel(bool useHandler = false, ServiceConfig? serviceConfig = null,
+            int? maxRetryAttempts = null, long? maxRetryBufferSize = null, long? maxRetryBufferPerCallSize = null,
+            int? maxReceiveMessageSize = null)
         {
             var options = new GrpcChannelOptions
             {
@@ -66,6 +68,10 @@ namespace Grpc.AspNetCore.FunctionalTests
             else
             {
                 options.HttpClient = Fixture.Client;
+            }
+            if (maxReceiveMessageSize != null)
+            {
+                options.MaxReceiveMessageSize = maxReceiveMessageSize;
             }
             return GrpcChannel.ForAddress(Fixture.Client.BaseAddress!, options);
         }

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -41,12 +41,13 @@ namespace Grpc.AspNetCore.FunctionalTests
 
         protected GrpcChannel CreateChannel(bool useHandler = false, ServiceConfig? serviceConfig = null,
             int? maxRetryAttempts = null, long? maxRetryBufferSize = null, long? maxRetryBufferPerCallSize = null,
-            int? maxReceiveMessageSize = null)
+            int? maxReceiveMessageSize = null, bool? throwOperationCanceledOnCancellation = null)
         {
             var options = new GrpcChannelOptions
             {
                 LoggerFactory = LoggerFactory,
-                ServiceConfig = serviceConfig
+                ServiceConfig = serviceConfig,
+                ThrowOperationCanceledOnCancellation = throwOperationCanceledOnCancellation ?? false
             };
             // Don't overwrite defaults
             if (maxRetryAttempts != null)

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -161,5 +161,12 @@ namespace Grpc.AspNetCore.FunctionalTests
 
             return null;
         }
+
+        protected static bool IsWriteCanceledException(Exception ex)
+        {
+            return ex is InvalidOperationException ||
+                ex is IOException ||
+                ex is OperationCanceledException;
+        }
     }
 }

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -138,14 +138,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
 
                 for (var i = 0; i < request.MessageCount; i++)
                 {
-                    Logger.LogInformation($"Server writing message {i}");
-                    await responseStream.WriteAsync(new ServerStreamingEchoResponse
-                    {
-                        Message = request.Message
-                    });
-
                     try
                     {
+                        Logger.LogInformation($"Server writing message {i}");
+                        await responseStream.WriteAsync(new ServerStreamingEchoResponse
+                        {
+                            Message = request.Message
+                        });
+
                         await Task.Delay(request.MessageInterval.ToTimeSpan(), context.CancellationToken);
                     }
                     catch (OperationCanceledException)

--- a/test/Grpc.AspNetCore.Server.Tests/Web/PipeExtensionsBase64Tests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/Web/PipeExtensionsBase64Tests.cs
@@ -131,14 +131,14 @@ namespace Grpc.AspNetCore.Server.Tests.Web
         }
 
         [Test]
-        public async Task WriteMessageAsync_NoFlush_WriteNoData()
+        public async Task WriteSingleMessageAsync_NoFlush_WriteNoData()
         {
             // Arrange
             var ms = new MemoryStream();
             var pipeWriter = new Base64PipeWriter(PipeWriter.Create(ms));
 
             // Act
-            await pipeWriter.WriteMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: false);
+            await pipeWriter.WriteSingleMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer);
 
             // Assert
             var messageData = ms.ToArray();
@@ -146,14 +146,14 @@ namespace Grpc.AspNetCore.Server.Tests.Web
         }
 
         [Test]
-        public async Task WriteMessageAsync_EmptyMessage_WriteMessageWithNoData()
+        public async Task WriteStreamedMessageAsync_EmptyMessage_WriteMessageWithNoData()
         {
             // Arrange
             var ms = new MemoryStream();
             var pipeWriter = new Base64PipeWriter(PipeWriter.Create(ms));
 
             // Act
-            await pipeWriter.WriteMessageAsync(new EchoRequest(), HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: true);
+            await pipeWriter.WriteStreamedMessageAsync(new EchoRequest(), HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer);
 
             // Assert
             var base64 = Encoding.UTF8.GetString(ms.ToArray());
@@ -172,16 +172,16 @@ namespace Grpc.AspNetCore.Server.Tests.Web
         }
 
         [Test]
-        public async Task WriteMessageAsync_MultipleMessagesWithFlush_WriteMessagesAsSegments()
+        public async Task WriteStreamedMessageAsync_MultipleMessagesWithFlush_WriteMessagesAsSegments()
         {
             // Arrange
             var ms = new MemoryStream();
             var pipeWriter = new Base64PipeWriter(PipeWriter.Create(ms));
 
             // Act
-            await pipeWriter.WriteMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: true);
-            await pipeWriter.WriteMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: true);
-            await pipeWriter.WriteMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: true);
+            await pipeWriter.WriteStreamedMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer);
+            await pipeWriter.WriteStreamedMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer);
+            await pipeWriter.WriteStreamedMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer);
 
             // Assert
             var base64 = Encoding.UTF8.GetString(ms.ToArray());
@@ -189,16 +189,17 @@ namespace Grpc.AspNetCore.Server.Tests.Web
         }
 
         [Test]
-        public async Task WriteMessageAsync_MultipleMessagesNoFlush_WriteMessages()
+        public async Task WriteStreamedMessageAsync_MultipleMessagesNoFlush_WriteMessages()
         {
             // Arrange
             var ms = new MemoryStream();
             var pipeWriter = new Base64PipeWriter(PipeWriter.Create(ms));
+            var writeOptions = new WriteOptions(WriteFlags.BufferHint);
 
             // Act
-            await pipeWriter.WriteMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: false);
-            await pipeWriter.WriteMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: false);
-            await pipeWriter.WriteMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(), MarshallerEchoRequest.ContextualSerializer, canFlush: false);
+            await pipeWriter.WriteStreamedMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(writeOptions: writeOptions), MarshallerEchoRequest.ContextualSerializer);
+            await pipeWriter.WriteStreamedMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(writeOptions: writeOptions), MarshallerEchoRequest.ContextualSerializer);
+            await pipeWriter.WriteStreamedMessageAsync(new EchoRequest { Message = "test" }, HttpContextServerCallContextHelper.CreateServerCallContext(writeOptions: writeOptions), MarshallerEchoRequest.ContextualSerializer);
 
             pipeWriter.Complete();
 

--- a/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
@@ -311,6 +311,7 @@ namespace Grpc.Net.Client.Tests
 
             public override Type RequestType { get; } = typeof(int);
             public override Type ResponseType { get; } = typeof(string);
+            public override CancellationToken CancellationToken { get; }
         }
 
         private GrpcCallSerializationContext CreateSerializationContext(string? requestGrpcEncoding = null, int? maxSendMessageSize = null)

--- a/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
@@ -64,6 +64,7 @@ namespace Grpc.Net.Client.Tests.Infrastructure
 
             public override Type RequestType => _type;
             public override Type ResponseType => _type;
+            public override CancellationToken CancellationToken { get; }
         }
     }
 }

--- a/test/Shared/HttpContextServerCallContextHelpers.cs
+++ b/test/Shared/HttpContextServerCallContextHelpers.cs
@@ -19,6 +19,7 @@
 using System.IO.Compression;
 using Grpc.AspNetCore.Server;
 using Grpc.AspNetCore.Server.Internal;
+using Grpc.Core;
 using Grpc.Net.Compression;
 using Grpc.Shared.Server;
 using Microsoft.AspNetCore.Http;
@@ -37,6 +38,7 @@ namespace Grpc.Tests.Shared
             int? maxSendMessageSize = null,
             int? maxReceiveMessageSize = null,
             ILogger? logger = null,
+            WriteOptions? writeOptions = null,
             bool initialize = true)
         {
             var options = CreateMethodOptions(
@@ -52,6 +54,10 @@ namespace Grpc.Tests.Shared
                 typeof(object),
                 typeof(object),
                 logger ?? NullLogger.Instance);
+            if (writeOptions != null)
+            {
+                context.WriteOptions = writeOptions;
+            }
             if (initialize)
             {
                 context.Initialize();

--- a/test/Shared/MessageHelpers.cs
+++ b/test/Shared/MessageHelpers.cs
@@ -119,7 +119,7 @@ namespace Grpc.Tests.Shared
                 responseCompressionAlgorithm: compressionEncoding);
             serverCallContext.Initialize();
 
-            pipeWriter.WriteMessageAsync(message, serverCallContext, (r, c) => c.Complete(r.ToByteArray()), canFlush: true).GetAwaiter().GetResult();
+            pipeWriter.WriteStreamedMessageAsync(message, serverCallContext, (r, c) => c.Complete(r.ToByteArray())).GetAwaiter().GetResult();
             stream.Seek(0, SeekOrigin.Begin);
         }
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1422

Turns out it was pretty complicated, especially retries and hedging. PR adds support in all places:

* WriteAsync cancellation on server
* WriteAsync cancellation on client
* WriteAsync cancellation on client for retries and hedging

Also fixed a bug when hedging and writing a large message to a client stream which causes the call to be committed because it exceeded buffer size. I found this while testing.

Also fixed a bug where the server would silently continue if it was aborted while writing a message. Now throws OperationCanceledException.

~Note: Contains some changes from https://github.com/grpc/grpc-dotnet/pull/1644 because Grpc.Core.Api needed to be updated.~