### PR TITLE
Update Grpc.Core dependency to 2.45.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <BenchmarkDotNetPackageVersion>0.13.1</BenchmarkDotNetPackageVersion>
     <GoogleProtobufPackageVersion>3.19.4</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.44.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
-    <GrpcPackageVersion>2.45.0-pre1</GrpcPackageVersion>
+    <GrpcPackageVersion>2.45.0</GrpcPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>6.0.0</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>
     <MicrosoftAspNetCoreApp31PackageVersion>3.1.3</MicrosoftAspNetCoreApp31PackageVersion>


### PR DESCRIPTION
the stable version of Grpc.Core  2.45 has already been release, so we can update to it.
After this is merged, I'll cut the release branch for grpc-dotnet 2.45.x