### PR TITLE
Fix calls throw TaskCanceledException after previous call is canceled

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -483,8 +483,22 @@ namespace Grpc.Net.Client.Balancer.Internal
             }
         }
 
-        // Don't use a record struct here. This type is cast to object and a struct will box.
-        private record StateWatcher(CancellationToken CancellationToken, ConnectivityState? WaitForState, TaskCompletionSource<object?> Tcs);
+        // Use a standard class for the watcher because:
+        // 1. On cancellation, a watcher is removed from collection. Should use default Equals implementation. Record overrides Equals.
+        // 2. This type is cast to object. A struct will box.
+        private sealed class StateWatcher
+        {
+            public StateWatcher(CancellationToken cancellationToken, ConnectivityState? waitForState, TaskCompletionSource<object?> tcs)
+            {
+                CancellationToken = cancellationToken;
+                WaitForState = waitForState;
+                Tcs = tcs;
+            }
+
+            public CancellationToken CancellationToken { get; }
+            public ConnectivityState? WaitForState { get; }
+            public TaskCompletionSource<object?> Tcs { get; }
+        }
     }
 
     internal static class ConnectionManagerLog

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -398,7 +398,6 @@ namespace Grpc.Net.Client.Balancer.Internal
             Debug.Assert(Monitor.IsEntered(_lock));
 
             var nextPickerTcs = _nextPickerTcs;
-            Logger.LogDebug("Got next picker TCS " + nextPickerTcs.GetHashCode());
 
             await _nextPickerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -284,10 +284,13 @@ namespace Grpc.Net.Client.Balancer.Internal
                     {
                         var stateWatcher = _stateWatchers[i];
 
+                        // Trigger watcher if either:
+                        // 1. Watcher is waiting for any state change.
+                        // 2. The state change matches the watcher's.
                         if (stateWatcher.WaitForState == null || stateWatcher.WaitForState == State)
                         {
-                            stateWatcher.Tcs.SetResult(null);
                             _stateWatchers.RemoveAt(i);
+                            stateWatcher.Tcs.SetResult(null);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1654

PR makes 3 changes:
1. Fixes not resetting the picker TCS on cancellation. This caused TaskCanceledException after a previous call is canceled.
2. Fixes deadline exceeded logged multiple times in the client.
3. Makes some minor changes to state watcher. User supplied logs include error `An attempt was made to transition a task to a final state when it had already completed.` which I couldn't reproduce or understand, but I have some wild theories. Changing state watcher from record to class avoids chance of record equality messing things up. Also raise watcher TCS after removing.