### PR TITLE
Fix up nullable annotations for additionalImportDirs

### DIFF
--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -47,7 +47,7 @@ namespace Grpc.Dotnet.Cli.Commands
             command.AddOption(CommonOptions.AdditionalImportDirsOption());
             command.AddOption(CommonOptions.AccessOption());
 
-            command.Handler = CommandHandler.Create<IConsole, FileInfo, Services, Access, string, string[]>(
+            command.Handler = CommandHandler.Create<IConsole, FileInfo, Services, Access, string?, string[]>(
                 async (console, project, services, access, additionalImportDirs, files) =>
                 {
                     try
@@ -68,7 +68,7 @@ namespace Grpc.Dotnet.Cli.Commands
             return command;
         }
 
-        public async Task AddFileAsync(Services services, Access access, string additionalImportDirs, string[] files)
+        public async Task AddFileAsync(Services services, Access access, string? additionalImportDirs, string[] files)
         {
             var resolvedServices = ResolveServices(services);
             await EnsureNugetPackagesAsync(resolvedServices);

--- a/src/dotnet-grpc/Commands/AddUrlCommand.cs
+++ b/src/dotnet-grpc/Commands/AddUrlCommand.cs
@@ -55,7 +55,7 @@ namespace Grpc.Dotnet.Cli.Commands
             command.AddOption(CommonOptions.AdditionalImportDirsOption());
             command.AddOption(CommonOptions.AccessOption());
 
-            command.Handler = CommandHandler.Create<IConsole, FileInfo, Services, Access, string, string, string>(
+            command.Handler = CommandHandler.Create<IConsole, FileInfo, Services, Access, string?, string, string>(
                 async (console, project, services, access, additionalImportDirs, url, output) =>
                 {
                     try
@@ -81,7 +81,7 @@ namespace Grpc.Dotnet.Cli.Commands
             return command;
         }
 
-        public async Task AddUrlAsync(Services services, Access access, string additionalImportDirs, string url, string output)
+        public async Task AddUrlAsync(Services services, Access access, string? additionalImportDirs, string url, string output)
         {
             var resolvedServices = ResolveServices(services);
             await EnsureNugetPackagesAsync(resolvedServices);

--- a/src/dotnet-grpc/Commands/CommandBase.cs
+++ b/src/dotnet-grpc/Commands/CommandBase.cs
@@ -165,7 +165,7 @@ namespace Grpc.Dotnet.Cli.Commands
             }
         }
 
-        public void AddProtobufReference(Services services, string additionalImportDirs, Access access, string file, string url)
+        public void AddProtobufReference(Services services, string? additionalImportDirs, Access access, string file, string url)
         {
             var resolvedPath = Path.IsPathRooted(file) ? file : Path.Join(Project.DirectoryPath, file);
             if (!File.Exists(resolvedPath))

--- a/test/dotnet-grpc.Tests/CommandBaseTests.cs
+++ b/test/dotnet-grpc.Tests/CommandBaseTests.cs
@@ -279,7 +279,7 @@ namespace Grpc.Dotnet.Cli.Tests
             const string proto = "Proto/a.proto";
             
             // Act
-            commandBase.AddProtobufReference(Services.Server, null!, Access.Internal, proto, SourceUrl);
+            commandBase.AddProtobufReference(Services.Server, null, Access.Internal, proto, SourceUrl);
             commandBase.Project.ReevaluateIfNecessary();
 
             // Assert


### PR DESCRIPTION
Some cleanup noticed from https://github.com/grpc/grpc-dotnet/pull/1666.

Flow nullable from app entry point down to method.