### PR TITLE
Fix flaky load balancer test

### DIFF
--- a/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs
@@ -71,7 +71,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer
                 Logger,
                 channel,
                 expectedCount: 2,
-                getPickerSubchannels: picker => ((LeastUsedPicker?)picker)?._subchannels.ToArray() ?? Array.Empty<Subchannel>()).DefaultTimeout();
+                getPickerSubchannels: picker => (picker as LeastUsedPicker)?._subchannels.ToArray() ?? Array.Empty<Subchannel>()).DefaultTimeout();
 
             var client = TestClientFactory.Create(channel, endpoint1.Method);
 


### PR DESCRIPTION
Fixes build failure:
```
  Failed UnaryCall_MultipleCalls_RoundRobin [41 ms]
  Error Message:
   System.InvalidCastException : Unable to cast object of type 'Grpc.Net.Client.Balancer.Internal.EmptyPicker' to type 'Grpc.AspNetCore.FunctionalTests.Balancer.LeastUsedPicker'.
  Stack Trace:
     at Grpc.AspNetCore.FunctionalTests.Balancer.LeastUsedBalancerTests.<>c.<UnaryCall_MultipleCalls_RoundRobin>b__0_2(SubchannelPicker picker) in /home/runner/work/grpc-dotnet/grpc-dotnet/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs:line 74
   at Grpc.AspNetCore.FunctionalTests.Balancer.BalancerHelpers.<>c__DisplayClass8_0.<WaitForSubchannelsToBeReadyAsync>b__1() in /home/runner/work/grpc-dotnet/grpc-dotnet/test/FunctionalTests/Balancer/BalancerHelpers.cs:line 213
   at Grpc.Tests.Shared.TestHelpers.<>c__DisplayClass1_0.<AssertIsTrueRetryAsync>b__0() in /home/runner/work/grpc-dotnet/grpc-dotnet/test/Shared/TestHelpers.cs:line 34
   at Grpc.Tests.Shared.TestHelpers.AssertIsTrueRetryAsync(Func`1 assert, String message, ILogger logger) in /home/runner/work/grpc-dotnet/grpc-dotnet/test/Shared/TestHelpers.cs:line 50
   at Grpc.AspNetCore.FunctionalTests.Balancer.BalancerHelpers.WaitForSubchannelsToBeReadyAsync(ILogger logger, GrpcChannel channel, Int32 expectedCount, Func`2 getPickerSubchannels) in /home/runner/work/grpc-dotnet/grpc-dotnet/test/FunctionalTests/Balancer/BalancerHelpers.cs:line 210
   at Grpc.Tests.Shared.TaskExtensions.TimeoutAfter[T](Task`1 task, TimeSpan timeout, String filePath, Int32 lineNumber) in /home/runner/work/grpc-dotnet/grpc-dotnet/test/Shared/TaskExtensions.cs:line 61
   at Grpc.AspNetCore.FunctionalTests.Balancer.LeastUsedBalancerTests.UnaryCall_MultipleCalls_RoundRobin() in /home/runner/work/grpc-dotnet/grpc-dotnet/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs:line 70
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
  Standard Output Messages:
 0.000s GrpcTestContext - Information: Starting LeastUsedBalancerTests.UnaryCall_MultipleCalls_RoundRobin
 0.002s SERVER Microsoft.AspNetCore.Hosting.Diagnostics - Debug: Hosting started
 0.003s SERVER Microsoft.AspNetCore.Hosting.Diagnostics - Debug: Loaded hosting startup assembly FunctionalTestsWebsite
 0.025s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '1' created with addresses: 127.0.0.1:50051
 0.025s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '2' created with addresses: 127.0.0.1:50052
 0.025s Grpc.Net.Client.Balancer.Subchannel - Trace: Subchannel id '1' connection requested.
 0.025s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '1' state changed to Connecting. Detail: 'Connection requested.'.
 0.026s Grpc.AspNetCore.FunctionalTests.Balancer.LeastUsedBalancer - Trace: Processing subchannel id '1' state changed to Connecting. Detail: 'Connection requested.'.
 0.027s Grpc.Net.Client.Balancer.Internal.ConnectionManager - Debug: Channel state updated to Connecting.
 0.027s Grpc.Net.Client.Balancer.Internal.ConnectionManager - Debug: Channel picker updated.
 0.027s Grpc.Net.Client.Balancer.Subchannel - Trace: Subchannel id '1' connecting to transport.
 0.027s Grpc.Net.Client.Balancer.Subchannel - Trace: Subchannel id '2' connection requested.
 0.027s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '2' state changed to Connecting. Detail: 'Connection requested.'.
 0.027s Grpc.AspNetCore.FunctionalTests.Balancer.LeastUsedBalancer - Trace: Processing subchannel id '2' state changed to Connecting. Detail: 'Connection requested.'.
 0.027s Grpc.Net.Client.Balancer.Subchannel - Trace: Subchannel id '2' connecting to transport.
 0.031s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '1' connection requested in non-idle state of Ready.
 0.032s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '2' connection requested in non-idle state of Ready.
 0.032s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '1' state changed to Ready. Detail: 'Successfully connected to socket.'.
 0.032s Grpc.AspNetCore.FunctionalTests.Balancer.LeastUsedBalancer - Trace: Processing subchannel id '1' state changed to Ready. Detail: 'Successfully connected to socket.'.
 0.033s Grpc.Net.Client.Balancer.Internal.ConnectionManager - Debug: Channel state updated to Ready.
 0.035s GrpcTestContext - Information: Waiting for subchannel ready count: 2
 0.036s Grpc.Net.Client.Balancer.Internal.ConnectionManager - Debug: Channel picker updated.
 0.036s Grpc.Net.Client.Balancer.Subchannel - Debug: Subchannel id '2' state changed to Ready. Detail: 'Successfully connected to socket.'.
 0.036s Grpc.AspNetCore.FunctionalTests.Balancer.LeastUsedBalancer - Trace: Processing subchannel id '2' state changed to Ready. Detail: 'Successfully connected to socket.'.
 0.036s Grpc.Net.Client.Balancer.Internal.ConnectionManager - Debug: Channel picker updated.
 0.042s GrpcTestContext - Information: Finishing LeastUsedBalancerTests.UnaryCall_MultipleCalls_RoundRobin
```