### PR TITLE
Fix call cancellation impacting other calls

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -36,7 +36,6 @@ namespace Grpc.Net.Client.Balancer.Internal
     {
         private static readonly ServiceConfig DefaultServiceConfig = new ServiceConfig();
 
-        private readonly SemaphoreSlim _nextPickerLock;
         private readonly object _lock;
         internal readonly Resolver _resolver;
         private readonly ISubchannelTransportFactory _subchannelTransportFactory;
@@ -47,6 +46,8 @@ namespace Grpc.Net.Client.Balancer.Internal
         // Internal for testing
         internal LoadBalancer? _balancer;
         internal SubchannelPicker? _picker;
+        // Cache picker wrapped in task once and reuse.
+        private Task<SubchannelPicker>? _pickerTask;
         private bool _resolverStarted;
         private TaskCompletionSource<SubchannelPicker> _nextPickerTcs;
         private int _currentSubchannelId;
@@ -61,7 +62,6 @@ namespace Grpc.Net.Client.Balancer.Internal
             LoadBalancerFactory[] loadBalancerFactories)
         {
             _lock = new object();
-            _nextPickerLock = new SemaphoreSlim(1);
             _nextPickerTcs = new TaskCompletionSource<SubchannelPicker>(TaskCreationOptions.RunContinuationsAsynchronously);
             _resolverStartedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -200,7 +200,6 @@ namespace Grpc.Net.Client.Balancer.Internal
         public void Dispose()
         {
             _resolver.Dispose();
-            _nextPickerLock.Dispose();
             lock (_lock)
             {
                 _balancer?.Dispose();
@@ -301,6 +300,7 @@ namespace Grpc.Net.Client.Balancer.Internal
                 {
                     ConnectionManagerLog.ChannelPickerUpdated(Logger);
                     _picker = state.Picker;
+                    _pickerTask = Task.FromResult(state.Picker);
                     _nextPickerTcs.SetResult(state.Picker);
                     _nextPickerTcs = new TaskCompletionSource<SubchannelPicker>(TaskCreationOptions.RunContinuationsAsynchronously);
                 }
@@ -365,69 +365,20 @@ namespace Grpc.Net.Client.Balancer.Internal
             }
         }
 
-        private
-#if !NETSTANDARD2_0
-            ValueTask<SubchannelPicker>
-#else
-            Task<SubchannelPicker>
-#endif
-            GetPickerAsync(SubchannelPicker? currentPicker, CancellationToken cancellationToken)
+        private Task<SubchannelPicker> GetPickerAsync(SubchannelPicker? currentPicker, CancellationToken cancellationToken)
         {
             lock (_lock)
             {
                 if (_picker != null && _picker != currentPicker)
                 {
-#if !NETSTANDARD2_0
-                    return new ValueTask<SubchannelPicker>(_picker);
-#else
-                    return Task.FromResult<SubchannelPicker>(_picker);
-#endif
+                    return _pickerTask!;
                 }
                 else
                 {
-                    return GetNextPickerAsync(cancellationToken);
+                    ConnectionManagerLog.PickWaiting(Logger);
+
+                    return _nextPickerTcs.Task.WaitAsync(cancellationToken);
                 }
-            }
-        }
-
-        private async
-#if !NETSTANDARD2_0
-            ValueTask<SubchannelPicker>
-#else
-            Task<SubchannelPicker>
-#endif
-            GetNextPickerAsync(CancellationToken cancellationToken)
-        {
-            ConnectionManagerLog.PickWaiting(Logger);
-
-            Debug.Assert(Monitor.IsEntered(_lock));
-
-            var nextPickerTcs = _nextPickerTcs;
-
-            await _nextPickerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                using (cancellationToken.Register(
-                    static s => ((TaskCompletionSource<SubchannelPicker?>)s!).TrySetCanceled(),
-                    nextPickerTcs))
-                {
-                    try
-                    {
-                        return await nextPickerTcs.Task.ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        // Picker can throw when canceled so reset picker in finally block.
-                        lock (_lock)
-                        {
-                            _nextPickerTcs = new TaskCompletionSource<SubchannelPicker>(TaskCreationOptions.RunContinuationsAsynchronously);
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                _nextPickerLock.Release();
             }
         }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -371,7 +371,8 @@ namespace Grpc.Net.Client.Balancer.Internal
             {
                 if (_picker != null && _picker != currentPicker)
                 {
-                    return _pickerTask!;
+                    Debug.Assert(_pickerTask != null);
+                    return _pickerTask;
                 }
                 else
                 {

--- a/src/Shared/CompatibilityHelpers.cs
+++ b/src/Shared/CompatibilityHelpers.cs
@@ -44,5 +44,16 @@ namespace Grpc.Shared
             return s.IndexOf(value, comparisonType);
 #endif
         }
+
+#if !NET6_0_OR_GREATER
+        public async static Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            using (cancellationToken.Register(static s => ((TaskCompletionSource<T>)s!).TrySetCanceled(), tcs))
+            {
+                return await (await Task.WhenAny(task, tcs.Task).ConfigureAwait(false)).ConfigureAwait(false);
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
There is a bug in the new address picker to do with cancellation.

Canceling a call also cancels other queued-up calls. The fix is to not use a share `TaskCompletionSource` between callers for cancellation. Instead, WaitAsync has its own TCS. WaitAsync is new in .NET 6 so a compatible version is added to older platforms.

This change makes picking much simpler. It hopeful addresses `An attempt was made to transition a task to a final state when it had already completed.` from https://github.com/grpc/grpc-dotnet/issues/1654