### PR TITLE
Update Directory.Build.targets

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,8 +19,8 @@
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)Grpc.DotNet.ruleset</CodeAnalysisRuleset>
 
     <IsTrimmable>true</IsTrimmable>
-    <!-- TODO(JamesNK) Trim anaylzers broken in .NET 7. Impacts benchmark environments that build with .NET 7 SDK. -->
-    <!-- Reenable when https://github.com/dotnet/linker/issues/2718 is fixed. -->
+    <!-- TODO(JamesNK) Trim anaylzers broken in .NET 7. Impacts benchmark environments that build with .NET 7 SDK. Issue: https://github.com/grpc/grpc-dotnet/issues/1667
+         Reenable when https://github.com/dotnet/linker/issues/2718 is fixed. -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,7 +19,7 @@
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)Grpc.DotNet.ruleset</CodeAnalysisRuleset>
 
     <IsTrimmable>true</IsTrimmable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <!-- IsGrpcPublishedPackage is set in csproj so related config must be in targets file -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,6 +19,8 @@
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)Grpc.DotNet.ruleset</CodeAnalysisRuleset>
 
     <IsTrimmable>true</IsTrimmable>
+    <!-- TODO(JamesNK) Trim anaylzers broken in .NET 7. Impacts benchmark environments that build with .NET 7 SDK. -->
+    <!-- Reenable when https://github.com/dotnet/linker/issues/2718 is fixed. -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
 


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/1667

Trim analyzers are currently broken in .NET 7. Doesn't impact this repo, but benchmarks break when attempting to compile source code here with .NET 7 SDK.