### PR TITLE
Update README.md: small edit to indicate .NET 3.0 or later.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 gRPC is a modern, open source, high-performance remote procedure call (RPC) framework that can run anywhere. gRPC enables client and server applications to communicate transparently, and simplifies the building of connected systems.
 
-gRPC functionality for .NET Core 3.0 includes:
+gRPC functionality for .NET Core 3.0 or later includes:
 
 * [Grpc.AspNetCore](https://www.nuget.org/packages/Grpc.AspNetCore) &ndash; An ASP.NET Core framework for hosting gRPC services. gRPC on ASP.NET Core integrates with standard ASP.NET Core features like logging, dependency injection (DI), authentication and authorization.
 * [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client) &ndash; A gRPC client for .NET Core that builds upon the familiar `HttpClient`. The client uses new HTTP/2 functionality in .NET Core.
@@ -17,7 +17,7 @@ See [blogpost](https://grpc.io/blog/grpc-csharp-future/) for more details.
 
 ## To start using gRPC for .NET
 
-The best place to start using gRPC for .NET is the gRPC template that comes with .NET Core 3.0. Use the template to [create a gRPC service website and client](https://docs.microsoft.com/aspnet/core/tutorials/grpc/grpc-start).
+The best place to start using gRPC for .NET is the gRPC template that comes with .NET Core 3.0 or later. Use the template to [create a gRPC service website and client](https://docs.microsoft.com/aspnet/core/tutorials/grpc/grpc-start).
 
 For additional examples of using gRPC in .NET refer to https://github.com/grpc/grpc-dotnet/tree/master/examples.
 


### PR DESCRIPTION
The text referring to .NET Core 3.0 made it sound like that was the only version this was available for and that gRPC for .NET has not been updated.  I simply added "or later" to make it a little clearer.   :)