### PR TITLE
Upgrade System.Commandline and add command line tests

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -23,8 +23,8 @@
     <Nunit3TestAdapterPackageVersion>3.16.1</Nunit3TestAdapterPackageVersion>
     <OpenTelemetryPackageVersion>0.6.0-beta.1</OpenTelemetryPackageVersion>
     <ProtobufNetGrpcPackageVersion>1.0.140</ProtobufNetGrpcPackageVersion>
-    <SystemCommandLinePackageVersion>2.0.0-beta1.20214.1</SystemCommandLinePackageVersion>
-    <SystemCommandLineRenderingPackageVersion>0.3.0-alpha.20214.1</SystemCommandLineRenderingPackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-beta3.22114.1</SystemCommandLinePackageVersion>
+    <SystemCommandLineRenderingPackageVersion>0.4.0-alpha.22114.1</SystemCommandLineRenderingPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemIOPipelinesPackageVersion>5.0.1</SystemIOPipelinesPackageVersion>
     <SystemMemoryPackageVersion>4.5.3</SystemMemoryPackageVersion>

--- a/perf/benchmarkapps/GrpcClient/ClientOptions.cs
+++ b/perf/benchmarkapps/GrpcClient/ClientOptions.cs
@@ -22,7 +22,7 @@ namespace GrpcClient
 {
     public class ClientOptions
     {
-        public string? Url { get; set; }
+        public Uri? Url { get; set; }
 #if NET5_0_OR_GREATER
         public string? UdsFileName { get; set; }
 #endif

--- a/perf/benchmarkapps/GrpcClient/Program.cs
+++ b/perf/benchmarkapps/GrpcClient/Program.cs
@@ -87,8 +87,6 @@ namespace GrpcClient
             {
                 _options = options;
 
-                Log("gRPC Client");
-
                 var runtimeVersion = typeof(object).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
                 var isServerGC = GCSettings.IsServerGC;
                 var processorCount = Environment.ProcessorCount;
@@ -112,6 +110,8 @@ namespace GrpcClient
                 await StopJobAsync();
             }, new ReflectionBinder<ClientOptions>(options));
 
+            Log("gRPC Client");
+
             return await rootCommand.InvokeAsync(args);
         }
 
@@ -128,6 +128,8 @@ namespace GrpcClient
             {
                 var boundValue = new T();
 
+                Log($"Binding {typeof(T)}");
+
                 foreach (var option in _options)
                 {
                     var value = bindingContext.ParseResult.GetValueForOption(option);
@@ -136,6 +138,8 @@ namespace GrpcClient
                     if (propertyInfo != null)
                     {
                         propertyInfo.SetValue(boundValue, value);
+                        
+                        Log($"-{propertyInfo.Name} = {value}");
                     }
                 }
 

--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -27,7 +27,7 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class AddFileCommand : CommandBase
     {
-        public AddFileCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+        public AddFileCommand(IConsole console, string? projectPath, HttpClient httpClient)
             : base(console, projectPath, httpClient) { }
 
         public static Command Create(HttpClient httpClient)
@@ -53,7 +53,7 @@ namespace Grpc.Dotnet.Cli.Commands
             command.AddOption(additionalImportDirsOption);
             command.AddArgument(filesArgument);
 
-            command.SetHandler<FileInfo, Services, Access, string?, string[], InvocationContext, IConsole>(
+            command.SetHandler<string, Services, Access, string?, string[], InvocationContext, IConsole>(
                 async (project, services, access, additionalImportDirs, files, context, console) =>
                 {
                     try

--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -27,43 +27,49 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class AddFileCommand : CommandBase
     {
-        public AddFileCommand(IConsole console, FileInfo? projectPath)
-            : base(console, projectPath) { }
+        public AddFileCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+            : base(console, projectPath, httpClient) { }
 
-        public static Command Create()
+        public static Command Create(HttpClient httpClient)
         {
             var command = new Command(
                 name: "add-file",
                 description: CoreStrings.AddFileCommandDescription);
-            command.AddArgument(new Argument<string[]>
+
+            var projectOption = CommonOptions.ProjectOption();
+            var serviceOption = CommonOptions.ServiceOption();
+            var additionalImportDirsOption = CommonOptions.AdditionalImportDirsOption();
+            var accessOption = CommonOptions.AccessOption();
+            var filesArgument = new Argument<string[]>
             {
                 Name = "files",
                 Description = CoreStrings.AddFileCommandArgumentDescription,
                 Arity = ArgumentArity.OneOrMore
-            });
+            };
 
-            command.AddOption(CommonOptions.ProjectOption());
-            command.AddOption(CommonOptions.ServiceOption());
-            command.AddOption(CommonOptions.AdditionalImportDirsOption());
-            command.AddOption(CommonOptions.AccessOption());
+            command.AddOption(projectOption);
+            command.AddOption(serviceOption);
+            command.AddOption(accessOption);
+            command.AddOption(additionalImportDirsOption);
+            command.AddArgument(filesArgument);
 
-            command.Handler = CommandHandler.Create<IConsole, FileInfo, Services, Access, string?, string[]>(
-                async (console, project, services, access, additionalImportDirs, files) =>
+            command.SetHandler<FileInfo, Services, Access, string?, string[], InvocationContext, IConsole>(
+                async (project, services, access, additionalImportDirs, files, context, console) =>
                 {
                     try
                     {
-                        var command = new AddFileCommand(console, project);
+                        var command = new AddFileCommand(console, project, httpClient);
                         await command.AddFileAsync(services, access, additionalImportDirs, files);
 
-                        return 0;
+                        context.ExitCode = 0;
                     }
                     catch (CLIToolException e)
                     {
                         console.LogError(e);
 
-                        return -1;
+                        context.ExitCode = -1;
                     }
-                });
+                }, projectOption, serviceOption, accessOption, additionalImportDirsOption, filesArgument);
 
             return command;
         }

--- a/src/dotnet-grpc/Commands/AddUrlCommand.cs
+++ b/src/dotnet-grpc/Commands/AddUrlCommand.cs
@@ -26,7 +26,7 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class AddUrlCommand : CommandBase
     {
-        public AddUrlCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+        public AddUrlCommand(IConsole console, string? projectPath, HttpClient httpClient)
             : base(console, projectPath, httpClient) { }
 
         // Internal for testing
@@ -60,7 +60,7 @@ namespace Grpc.Dotnet.Cli.Commands
             command.AddOption(accessOption);
             command.AddArgument(urlArgument);
 
-            command.SetHandler<FileInfo, Services, Access, string?, string, string, InvocationContext, IConsole>(
+            command.SetHandler<string, Services, Access, string?, string, string, InvocationContext, IConsole>(
                 async (project, services, access, additionalImportDirs, url, output, context, console) =>
                 {
                     try

--- a/src/dotnet-grpc/Commands/AddUrlCommand.cs
+++ b/src/dotnet-grpc/Commands/AddUrlCommand.cs
@@ -26,37 +26,42 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class AddUrlCommand : CommandBase
     {
-        public AddUrlCommand(IConsole console, FileInfo? projectPath)
-            : base(console, projectPath) { }
+        public AddUrlCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+            : base(console, projectPath, httpClient) { }
 
         // Internal for testing
         internal AddUrlCommand(IConsole console, HttpClient client)
             : base(console, client) { }
 
-        public static Command Create()
+        public static Command Create(HttpClient httpClient)
         {
             var command = new Command(
                 name: "add-url",
                 description: CoreStrings.AddUrlCommandDescription);
-            command.AddArgument(new Argument<string>
+
+            var projectOption = CommonOptions.ProjectOption();
+            var serviceOption = CommonOptions.ServiceOption();
+            var additionalImportDirsOption = CommonOptions.AdditionalImportDirsOption();
+            var accessOption = CommonOptions.AccessOption();
+            var outputOption = new Option<string>(
+                aliases: new[] { "-o", "--output" },
+                description: CoreStrings.OutputOptionDescription);
+            var urlArgument = new Argument<string>
             {
                 Name = "url",
                 Description = CoreStrings.AddUrlCommandArgumentDescription,
                 Arity = ArgumentArity.ExactlyOne
-            });
+            };
 
-            var outputOption = new Option(
-                aliases: new[] { "-o", "--output" },
-                description: CoreStrings.OutputOptionDescription);
-            outputOption.Argument = new Argument<string> { Name = "path", Arity = ArgumentArity.ExactlyOne };
             command.AddOption(outputOption);
-            command.AddOption(CommonOptions.ProjectOption());
-            command.AddOption(CommonOptions.ServiceOption());
-            command.AddOption(CommonOptions.AdditionalImportDirsOption());
-            command.AddOption(CommonOptions.AccessOption());
+            command.AddOption(projectOption);
+            command.AddOption(serviceOption);
+            command.AddOption(additionalImportDirsOption);
+            command.AddOption(accessOption);
+            command.AddArgument(urlArgument);
 
-            command.Handler = CommandHandler.Create<IConsole, FileInfo, Services, Access, string?, string, string>(
-                async (console, project, services, access, additionalImportDirs, url, output) =>
+            command.SetHandler<FileInfo, Services, Access, string?, string, string, InvocationContext, IConsole>(
+                async (project, services, access, additionalImportDirs, url, output, context, console) =>
                 {
                     try
                     {
@@ -65,18 +70,18 @@ namespace Grpc.Dotnet.Cli.Commands
                             throw new CLIToolException(CoreStrings.ErrorNoOutputProvided);
                         }
 
-                        var command = new AddUrlCommand(console, project);
+                        var command = new AddUrlCommand(console, project, httpClient);
                         await command.AddUrlAsync(services, access, additionalImportDirs, url, output);
 
-                        return 0;
+                        context.ExitCode = 0;
                     }
                     catch (CLIToolException e)
                     {
                         console.LogError(e);
 
-                        return -1;
+                        context.ExitCode = -1;
                     }
-                });
+                }, projectOption, serviceOption, accessOption, additionalImportDirsOption, urlArgument, outputOption);
 
             return command;
         }

--- a/src/dotnet-grpc/Commands/CommandBase.cs
+++ b/src/dotnet-grpc/Commands/CommandBase.cs
@@ -47,8 +47,8 @@ namespace Grpc.Dotnet.Cli.Commands
 
         private readonly HttpClient _httpClient;
 
-        public CommandBase(IConsole console, FileInfo? projectPath)
-            : this(console, ResolveProject(projectPath), new HttpClient()) { }
+        public CommandBase(IConsole console, FileInfo? projectPath, HttpClient client)
+            : this(console, ResolveProject(projectPath), client) { }
 
         // Internal for testing
         internal CommandBase(IConsole console, Project project)

--- a/src/dotnet-grpc/Commands/ListCommand.cs
+++ b/src/dotnet-grpc/Commands/ListCommand.cs
@@ -29,7 +29,7 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class ListCommand : CommandBase
     {
-        public ListCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+        public ListCommand(IConsole console, string? projectPath, HttpClient httpClient)
             : base(console, projectPath, httpClient) { }
 
         public static Command Create(HttpClient httpClient)
@@ -41,7 +41,7 @@ namespace Grpc.Dotnet.Cli.Commands
 
             command.AddOption(projectOption);
 
-            command.SetHandler<FileInfo, InvocationContext, IConsole>(
+            command.SetHandler<string, InvocationContext, IConsole>(
                 (project, context, console) =>
                 {
                     try

--- a/src/dotnet-grpc/Commands/ListCommand.cs
+++ b/src/dotnet-grpc/Commands/ListCommand.cs
@@ -29,33 +29,35 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class ListCommand : CommandBase
     {
-        public ListCommand(IConsole console, FileInfo? projectPath)
-            : base(console, projectPath) { }
+        public ListCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+            : base(console, projectPath, httpClient) { }
 
-        public static Command Create()
+        public static Command Create(HttpClient httpClient)
         {
             var command = new Command(
                 name: "list",
                 description: CoreStrings.ListCommandDescription);
-            command.AddOption(CommonOptions.ProjectOption());
+            var projectOption = CommonOptions.ProjectOption();
 
-            command.Handler = CommandHandler.Create<IConsole, FileInfo>(
-                (console, project) =>
+            command.AddOption(projectOption);
+
+            command.SetHandler<FileInfo, InvocationContext, IConsole>(
+                (project, context, console) =>
                 {
                     try
                     {
-                        var command = new ListCommand(console, project);
+                        var command = new ListCommand(console, project, httpClient);
                         command.List();
 
-                        return 0;
+                        context.ExitCode = 0;
                     }
                     catch (CLIToolException e)
                     {
                         console.LogError(e);
 
-                        return -1;
+                        context.ExitCode = -1;
                     }
-                });
+                }, projectOption);
 
             return command;
         }

--- a/src/dotnet-grpc/Commands/RefreshCommand.cs
+++ b/src/dotnet-grpc/Commands/RefreshCommand.cs
@@ -27,48 +27,52 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class RefreshCommand : CommandBase
     {
-        public RefreshCommand(IConsole console, FileInfo? projectPath)
-            : base(console, projectPath) { }
+        public RefreshCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+            : base(console, projectPath, httpClient) { }
 
         // Internal for testing
         public RefreshCommand(IConsole console, HttpClient client)
             : base(console, client) { }
 
-        public static Command Create()
+        public static Command Create(HttpClient httpClient)
         {
             var command = new Command(
                 name: "refresh",
                 description: CoreStrings.RefreshCommandDescription);
 
-            command.AddArgument(new Argument<string[]>
+            var projectOption = CommonOptions.ProjectOption();
+            var dryRunOption = new Option<bool>(
+                aliases: new[] { "--dry-run" },
+                description: CoreStrings.DryRunOptionDescription
+                );
+            var referencesArgument = new Argument<string[]>
             {
                 Name = "references",
                 Description = CoreStrings.RefreshCommandArgumentDescription,
                 Arity = ArgumentArity.ZeroOrMore
-            });
-            command.AddOption(CommonOptions.ProjectOption());
-            command.AddOption(new Option(
-                aliases: new[] { "--dry-run" },
-                description: CoreStrings.DryRunOptionDescription
-                ));
+            };
 
-            command.Handler = CommandHandler.Create<IConsole, FileInfo, bool, string[]>(
-                async (console, project, dryRun, references) =>
+            command.AddOption(projectOption);
+            command.AddOption(dryRunOption);
+            command.AddArgument(referencesArgument);
+
+            command.SetHandler<FileInfo, bool, string[], InvocationContext, IConsole>(
+                async (project, dryRun, references, context, console) =>
                 {
                     try
                     {
-                        var command = new RefreshCommand(console, project);
+                        var command = new RefreshCommand(console, project, httpClient);
                         await command.RefreshAsync(dryRun, references);
 
-                        return 0;
+                        context.ExitCode = 0;
                     }
                     catch (CLIToolException e)
                     {
                         console.LogError(e);
 
-                        return -1;
+                        context.ExitCode = -1;
                     }
-                });
+                }, projectOption, dryRunOption, referencesArgument);
 
             return command;
         }

--- a/src/dotnet-grpc/Commands/RefreshCommand.cs
+++ b/src/dotnet-grpc/Commands/RefreshCommand.cs
@@ -27,7 +27,7 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class RefreshCommand : CommandBase
     {
-        public RefreshCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+        public RefreshCommand(IConsole console, string? projectPath, HttpClient httpClient)
             : base(console, projectPath, httpClient) { }
 
         // Internal for testing
@@ -56,7 +56,7 @@ namespace Grpc.Dotnet.Cli.Commands
             command.AddOption(dryRunOption);
             command.AddArgument(referencesArgument);
 
-            command.SetHandler<FileInfo, bool, string[], InvocationContext, IConsole>(
+            command.SetHandler<string, bool, string[], InvocationContext, IConsole>(
                 async (project, dryRun, references, context, console) =>
                 {
                     try

--- a/src/dotnet-grpc/Commands/RemoveCommand.cs
+++ b/src/dotnet-grpc/Commands/RemoveCommand.cs
@@ -27,40 +27,43 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class RemoveCommand : CommandBase
     {
-        public RemoveCommand(IConsole console, FileInfo? projectPath)
-            : base(console, projectPath) { }
+        public RemoveCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+            : base(console, projectPath, httpClient) { }
 
-        public static Command Create()
+        public static Command Create(HttpClient httpClient)
         {
             var command = new Command(
                 name: "remove",
                 description: CoreStrings.RemoveCommandDescription);
-            command.AddArgument(new Argument<string[]>
+
+            var projectOption = CommonOptions.ProjectOption();
+            var referencesArgument = new Argument<string[]>
             {
                 Name = "references",
                 Description = CoreStrings.RemoveCommandArgumentDescription,
                 Arity = ArgumentArity.OneOrMore
-            });
+            };
+            
+            command.AddOption(projectOption);
+            command.AddArgument(referencesArgument);
 
-            command.AddOption(CommonOptions.ProjectOption());
-
-            command.Handler = CommandHandler.Create<IConsole, FileInfo, string[]>(
-                (console, project, references) =>
+            command.SetHandler<FileInfo, string[], InvocationContext, IConsole>(
+                (project, references, context, console) =>
                 {
                     try
                     {
-                        var command = new RemoveCommand(console, project);
+                        var command = new RemoveCommand(console, project, httpClient);
                         command.Remove(references);
 
-                        return 0;
+                        context.ExitCode = 0;
                     }
                     catch (CLIToolException e)
                     {
                         console.LogError(e);
 
-                        return -1;
+                        context.ExitCode = -1;
                     }
-                });
+                }, projectOption, referencesArgument);
 
             return command;
         }

--- a/src/dotnet-grpc/Commands/RemoveCommand.cs
+++ b/src/dotnet-grpc/Commands/RemoveCommand.cs
@@ -27,7 +27,7 @@ namespace Grpc.Dotnet.Cli.Commands
 {
     internal class RemoveCommand : CommandBase
     {
-        public RemoveCommand(IConsole console, FileInfo? projectPath, HttpClient httpClient)
+        public RemoveCommand(IConsole console, string? projectPath, HttpClient httpClient)
             : base(console, projectPath, httpClient) { }
 
         public static Command Create(HttpClient httpClient)
@@ -47,7 +47,7 @@ namespace Grpc.Dotnet.Cli.Commands
             command.AddOption(projectOption);
             command.AddArgument(referencesArgument);
 
-            command.SetHandler<FileInfo, string[], InvocationContext, IConsole>(
+            command.SetHandler<string, string[], InvocationContext, IConsole>(
                 (project, references, context, console) =>
                 {
                     try

--- a/src/dotnet-grpc/Options/CommonOptions.cs
+++ b/src/dotnet-grpc/Options/CommonOptions.cs
@@ -25,37 +25,33 @@ namespace Grpc.Dotnet.Cli.Options
     {
         public static Option ProjectOption()
         {
-            var o = new Option(
+            var o = new Option<FileInfo>(
                 aliases: new[] { "-p", "--project" },
                 description: CoreStrings.ProjectOptionDescription);
-            o.Argument = new Argument<FileInfo> { Name = "project" };
             return o;
         }
 
         public static Option ServiceOption()
         {
-            var o = new Option(
+            var o = new Option<Services>(
                 aliases: new[] { "-s", "--services" },
                 description: CoreStrings.ServiceOptionDescription);
-            o.Argument = new Argument<Services> { Name = "services" };
             return o;
         }
 
         public static Option AccessOption()
         {
-            var o = new Option(
+            var o = new Option<Access>(
                 aliases: new[] { "--access" },
                 description: CoreStrings.AccessOptionDescription);
-            o.Argument = new Argument<Access> { Name = "access" };
             return o;
         }
 
         public static Option AdditionalImportDirsOption()
         {
-            var o = new Option(
+            var o = new Option<string>(
                 aliases: new[] { "-i", "--additional-import-dirs" },
                 description: CoreStrings.AdditionalImportDirsOption);
-            o.Argument = new Argument<string> { Name = "dirs" };
             return o;
         }
     }

--- a/src/dotnet-grpc/Options/CommonOptions.cs
+++ b/src/dotnet-grpc/Options/CommonOptions.cs
@@ -25,7 +25,7 @@ namespace Grpc.Dotnet.Cli.Options
     {
         public static Option ProjectOption()
         {
-            var o = new Option<FileInfo>(
+            var o = new Option<string>(
                 aliases: new[] { "-p", "--project" },
                 description: CoreStrings.ProjectOptionDescription);
             return o;

--- a/src/dotnet-grpc/Program.cs
+++ b/src/dotnet-grpc/Program.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
@@ -30,18 +31,25 @@ namespace Grpc.Dotnet.Cli
         {
             MSBuildLocator.RegisterDefaults();
 
-            var parser = new CommandLineBuilder()
-                .AddCommand(AddFileCommand.Create())
-                .AddCommand(AddUrlCommand.Create())
-                .AddCommand(RefreshCommand.Create())
-                .AddCommand(RemoveCommand.Create())
-                .AddCommand(ListCommand.Create())
-                .UseDefaults()
-                .Build();
-
+            var parser = BuildParser(new HttpClient());
             var result = parser.Parse(args);
 
             return result.InvokeAsync(new SystemConsole());
+        }
+
+        internal static Parser BuildParser(HttpClient client)
+        {
+            var root = new RootCommand();
+            root.AddCommand(AddFileCommand.Create(client));
+            root.AddCommand(AddUrlCommand.Create(client));
+            root.AddCommand(RefreshCommand.Create(client));
+            root.AddCommand(RemoveCommand.Create(client));
+            root.AddCommand(ListCommand.Create(client));
+
+            var parser = new CommandLineBuilder(root)
+                .UseDefaults()
+                .Build();
+            return parser;
         }
     }
 }

--- a/test/dotnet-grpc.Tests/AddFileCommandTests.cs
+++ b/test/dotnet-grpc.Tests/AddFileCommandTests.cs
@@ -41,8 +41,7 @@ namespace Grpc.Dotnet.Cli.Tests
             var parser = Program.BuildParser(CreateClient());
 
             // Act
-            Directory.SetCurrentDirectory(tempDir);
-            var result = await parser.InvokeAsync($"add-file -s Server --access Internal -i ImportDir {Path.Combine("Proto", "*.proto")}", testConsole);
+            var result = await parser.InvokeAsync($"add-file -p {tempDir} -s Server --access Internal -i ImportDir {Path.Combine("Proto", "*.proto")}", testConsole);
 
             // Assert
             Assert.AreEqual(0, result, testConsole.Error.ToString());
@@ -67,7 +66,6 @@ namespace Grpc.Dotnet.Cli.Tests
             }
 
             // Cleanup
-            Directory.SetCurrentDirectory(currentDir);
             Directory.Delete(tempDir, true);
         }
 

--- a/test/dotnet-grpc.Tests/AddFileCommandTests.cs
+++ b/test/dotnet-grpc.Tests/AddFileCommandTests.cs
@@ -17,8 +17,10 @@
 #endregion
 
 using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using Grpc.Dotnet.Cli.Commands;
 using Grpc.Dotnet.Cli.Options;
+using Microsoft.Build.Evaluation;
 using NUnit.Framework;
 
 namespace Grpc.Dotnet.Cli.Tests
@@ -26,6 +28,49 @@ namespace Grpc.Dotnet.Cli.Tests
     [TestFixture]
     public class AddFileCommandTests : TestBase
     {
+        [Test]
+        [NonParallelizable]
+        public async Task Commandline_AddFileCommand_AddsPackagesAndReferences()
+        {
+            // Arrange
+            var currentDir = Directory.GetCurrentDirectory();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var testConsole = new TestConsole();
+            new DirectoryInfo(Path.Combine(currentDir, "TestAssets", "EmptyProject")).CopyTo(tempDir);
+
+            var parser = Program.BuildParser(CreateClient());
+
+            // Act
+            Directory.SetCurrentDirectory(tempDir);
+            var result = await parser.InvokeAsync($"add-file -s Server --access Internal -i ImportDir {Path.Combine("Proto", "*.proto")}", testConsole);
+
+            // Assert
+            Assert.AreEqual(0, result, testConsole.Error.ToString());
+
+            var project = ProjectCollection.GlobalProjectCollection.LoadedProjects.Single(p => p.DirectoryPath == tempDir);
+            project.ReevaluateIfNecessary();
+
+            var packageRefs = project.GetItems(CommandBase.PackageReferenceElement);
+            Assert.AreEqual(1, packageRefs.Count);
+            Assert.NotNull(packageRefs.SingleOrDefault(r => r.UnevaluatedInclude == "Grpc.AspNetCore" && !r.HasMetadata(CommandBase.PrivateAssetsElement)));
+
+
+            var protoRefs = project.GetItems(CommandBase.ProtobufElement);
+            Assert.AreEqual(2, protoRefs.Count);
+            Assert.NotNull(protoRefs.SingleOrDefault(r => r.UnevaluatedInclude == "Proto\\a.proto"));
+            Assert.NotNull(protoRefs.SingleOrDefault(r => r.UnevaluatedInclude == "Proto\\b.proto"));
+            foreach (var protoRef in protoRefs)
+            {
+                Assert.AreEqual("Server", protoRef.GetMetadataValue(CommandBase.GrpcServicesElement));
+                Assert.AreEqual("ImportDir", protoRef.GetMetadataValue(CommandBase.AdditionalImportDirsElement));
+                Assert.AreEqual("Internal", protoRef.GetMetadataValue(CommandBase.AccessElement));
+            }
+
+            // Cleanup
+            Directory.SetCurrentDirectory(currentDir);
+            Directory.Delete(tempDir, true);
+        }
+
         [Test]
         [NonParallelizable]
         public async Task AddFileCommand_AddsPackagesAndReferences()
@@ -37,7 +82,7 @@ namespace Grpc.Dotnet.Cli.Tests
 
             // Act
             Directory.SetCurrentDirectory(tempDir);
-            var command = new AddFileCommand(new TestConsole(), null);
+            var command = new AddFileCommand(new TestConsole(), projectPath: null, CreateClient());
             await command.AddFileAsync(Services.Server, Access.Internal, "ImportDir", new[] { Path.Combine("Proto", "*.proto") });
             command.Project.ReevaluateIfNecessary();
 

--- a/test/dotnet-grpc.Tests/AddUrlCommandTests.cs
+++ b/test/dotnet-grpc.Tests/AddUrlCommandTests.cs
@@ -17,10 +17,12 @@
 #endregion
 
 using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using Grpc.Dotnet.Cli.Commands;
 using Grpc.Dotnet.Cli.Internal;
 using Grpc.Dotnet.Cli.Options;
 using Grpc.Tests.Shared;
+using Microsoft.Build.Evaluation;
 using NUnit.Framework;
 
 namespace Grpc.Dotnet.Cli.Tests
@@ -28,6 +30,48 @@ namespace Grpc.Dotnet.Cli.Tests
     [TestFixture]
     public class AddUrlCommandTests : TestBase
     {
+        [Test]
+        [NonParallelizable]
+        public async Task Commandline_AddUrlCommand_AddsPackagesAndReferences()
+        {
+            // Arrange
+            var currentDir = Directory.GetCurrentDirectory();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var testConsole = new TestConsole();
+            new DirectoryInfo(Path.Combine(currentDir, "TestAssets", "EmptyProject")).CopyTo(tempDir);
+
+            var parser = Program.BuildParser(CreateClient());
+
+            // Act
+            Directory.SetCurrentDirectory(tempDir);
+            var result = await parser.InvokeAsync($"add-url -s Server --access Internal -i ImportDir -o {Path.Combine("Proto", "c.proto")} {SourceUrl}", testConsole);
+
+            // Assert
+            Assert.AreEqual(0, result, testConsole.Error.ToString());
+
+            var project = ProjectCollection.GlobalProjectCollection.LoadedProjects.Single(p => p.DirectoryPath == tempDir);
+            project.ReevaluateIfNecessary();
+
+            var packageRefs = project.GetItems(CommandBase.PackageReferenceElement);
+            Assert.AreEqual(1, packageRefs.Count);
+            Assert.NotNull(packageRefs.SingleOrDefault(r => r.UnevaluatedInclude == "Grpc.AspNetCore" && !r.HasMetadata(CommandBase.PrivateAssetsElement)));
+
+            var protoRefs = project.GetItems(CommandBase.ProtobufElement);
+            Assert.AreEqual(1, protoRefs.Count);
+            var protoRef = protoRefs.Single();
+            Assert.AreEqual("Proto\\c.proto", protoRef.UnevaluatedInclude);
+            Assert.AreEqual("Server", protoRef.GetMetadataValue(CommandBase.GrpcServicesElement));
+            Assert.AreEqual("ImportDir", protoRef.GetMetadataValue(CommandBase.AdditionalImportDirsElement));
+            Assert.AreEqual("Internal", protoRef.GetMetadataValue(CommandBase.AccessElement));
+            Assert.AreEqual(SourceUrl, protoRef.GetMetadataValue(CommandBase.SourceUrlElement));
+
+            Assert.IsNotEmpty(File.ReadAllText(Path.Combine(project.DirectoryPath, "Proto", "c.proto")));
+
+            // Cleanup
+            Directory.SetCurrentDirectory(currentDir);
+            Directory.Delete(tempDir, true);
+        }
+
         [Test]
         [NonParallelizable]
         public async Task AddUrlCommand_AddsPackagesAndReferences()

--- a/test/dotnet-grpc.Tests/AddUrlCommandTests.cs
+++ b/test/dotnet-grpc.Tests/AddUrlCommandTests.cs
@@ -43,8 +43,7 @@ namespace Grpc.Dotnet.Cli.Tests
             var parser = Program.BuildParser(CreateClient());
 
             // Act
-            Directory.SetCurrentDirectory(tempDir);
-            var result = await parser.InvokeAsync($"add-url -s Server --access Internal -i ImportDir -o {Path.Combine("Proto", "c.proto")} {SourceUrl}", testConsole);
+            var result = await parser.InvokeAsync($"add-url -p {tempDir} -s Server --access Internal -i ImportDir -o {Path.Combine("Proto", "c.proto")} {SourceUrl}", testConsole);
 
             // Assert
             Assert.AreEqual(0, result, testConsole.Error.ToString());
@@ -68,7 +67,6 @@ namespace Grpc.Dotnet.Cli.Tests
             Assert.IsNotEmpty(File.ReadAllText(Path.Combine(project.DirectoryPath, "Proto", "c.proto")));
 
             // Cleanup
-            Directory.SetCurrentDirectory(currentDir);
             Directory.Delete(tempDir, true);
         }
 

--- a/test/dotnet-grpc.Tests/CommandBaseTests.cs
+++ b/test/dotnet-grpc.Tests/CommandBaseTests.cs
@@ -396,7 +396,7 @@ namespace Grpc.Dotnet.Cli.Tests
         public void ResolveProject_ThrowsIfProjectFileDoesNotExist()
         {
             // Act, Assert
-            Assert.Throws<CLIToolException>(() => CommandBase.ResolveProject(new FileInfo("NonExistent")));
+            Assert.Throws<CLIToolException>(() => CommandBase.ResolveProject("NonExistent"));
         }
 
         [Test]

--- a/test/dotnet-grpc.Tests/ListCommandTests.cs
+++ b/test/dotnet-grpc.Tests/ListCommandTests.cs
@@ -17,7 +17,9 @@
 #endregion
 
 using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using Grpc.Dotnet.Cli.Commands;
+using Microsoft.Build.Evaluation;
 using NUnit.Framework;
 
 namespace Grpc.Dotnet.Cli.Tests
@@ -25,6 +27,56 @@ namespace Grpc.Dotnet.Cli.Tests
     [TestFixture]
     public class ListCommandTests : TestBase
     {
+        [Test]
+        public async Task Commandline_List_ListsReferences()
+        {
+            var currentDir = Directory.GetCurrentDirectory();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            try
+            {
+                // Arrange
+                var testConsole = new TestConsole();
+                new DirectoryInfo(Path.Combine(currentDir, "TestAssets", "MultipleReferences")).CopyTo(tempDir);
+                var parser = Program.BuildParser(CreateClient());
+
+                // Act
+                Directory.SetCurrentDirectory(tempDir);
+                var result = await parser.InvokeAsync("list", testConsole);
+
+                // Assert
+                Assert.AreEqual(0, result, testConsole.Error.ToString());
+
+                var project = ProjectCollection.GlobalProjectCollection.LoadedProjects.Single(p => p.DirectoryPath == tempDir);
+                project.ReevaluateIfNecessary();
+
+                var output = testConsole.Out.ToString()!;
+                var lines = output.Split(Environment.NewLine);
+
+                // First line is the heading and should conatin Protobuf Reference, Service Type, Source URL, Access
+                AssertContains(lines[0], "Protobuf Reference");
+                AssertContains(lines[0], "Service Type");
+                AssertContains(lines[0], "Source URL");
+                AssertContains(lines[0], "Access");
+
+                // Second line is the reference to
+                //<Protobuf Include="Proto/a.proto">
+                //  <SourceUrl>https://contoso.com/greet.proto</SourceUrl>
+                //</Protobuf>
+                Assert.AreEqual(new string[] { "Proto/a.proto", "Both", "https://contoso.com/greet.proto" }, lines[1].Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+                // Third line is the reference to
+                //<Protobuf Include="Proto/b.proto" Access="Internal"/>
+                Assert.AreEqual(new string[] { "Proto/b.proto", "Both", "Internal" }, lines[2].Split(' ', StringSplitOptions.RemoveEmptyEntries));
+            }
+            finally
+            {
+                // Cleanup
+                Directory.SetCurrentDirectory(currentDir);
+                Directory.Delete(tempDir, true);
+            }
+        }
+
         [Test]
         public void List_ListsReferences()
         {
@@ -39,7 +91,7 @@ namespace Grpc.Dotnet.Cli.Tests
 
                 // Act
                 Directory.SetCurrentDirectory(tempDir);
-                var command = new ListCommand(testConsole, null);
+                var command = new ListCommand(testConsole, null, CreateClient());
 
                 Assert.IsNotNull(command.Project);
                 Assert.AreEqual("test.csproj", Path.GetFileName(command.Project.FullPath));

--- a/test/dotnet-grpc.Tests/ListCommandTests.cs
+++ b/test/dotnet-grpc.Tests/ListCommandTests.cs
@@ -41,8 +41,7 @@ namespace Grpc.Dotnet.Cli.Tests
                 var parser = Program.BuildParser(CreateClient());
 
                 // Act
-                Directory.SetCurrentDirectory(tempDir);
-                var result = await parser.InvokeAsync("list", testConsole);
+                var result = await parser.InvokeAsync($"list -p {tempDir}", testConsole);
 
                 // Assert
                 Assert.AreEqual(0, result, testConsole.Error.ToString());
@@ -72,7 +71,6 @@ namespace Grpc.Dotnet.Cli.Tests
             finally
             {
                 // Cleanup
-                Directory.SetCurrentDirectory(currentDir);
                 Directory.Delete(tempDir, true);
             }
         }

--- a/test/dotnet-grpc.Tests/RefreshCommandTests.cs
+++ b/test/dotnet-grpc.Tests/RefreshCommandTests.cs
@@ -43,8 +43,7 @@ namespace Grpc.Dotnet.Cli.Tests
             var parser = Program.BuildParser(CreateClient());
 
             // Act
-            Directory.SetCurrentDirectory(tempDir);
-            var result = await parser.InvokeAsync($"refresh --dry-run {dryRun}", testConsole);
+            var result = await parser.InvokeAsync($"refresh -p {tempDir} --dry-run {dryRun}", testConsole);
 
             // Assert
             Assert.AreEqual(0, result, testConsole.Error.ToString());
@@ -56,7 +55,6 @@ namespace Grpc.Dotnet.Cli.Tests
             Assert.AreEqual(dryRun, string.IsNullOrEmpty(File.ReadAllText(Path.Combine(project.DirectoryPath, "Proto", "a.proto"))));
 
             // Cleanup
-            Directory.SetCurrentDirectory(currentDir);
             Directory.Delete(tempDir, true);
         }
 

--- a/test/dotnet-grpc.Tests/RefreshCommandTests.cs
+++ b/test/dotnet-grpc.Tests/RefreshCommandTests.cs
@@ -17,9 +17,11 @@
 #endregion
 
 using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using System.Globalization;
 using Grpc.Dotnet.Cli.Commands;
 using Grpc.Dotnet.Cli.Properties;
+using Microsoft.Build.Evaluation;
 using NUnit.Framework;
 
 namespace Grpc.Dotnet.Cli.Tests
@@ -27,6 +29,37 @@ namespace Grpc.Dotnet.Cli.Tests
     [TestFixture]
     public class RefreshCommandTests : TestBase
     {
+        [TestCase(true)]
+        [TestCase(false)]
+        [NonParallelizable]
+        public async Task Commandline_Refresh_RefreshesReferences(bool dryRun)
+        {
+            // Arrange
+            var currentDir = Directory.GetCurrentDirectory();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var testConsole = new TestConsole();
+            new DirectoryInfo(Path.Combine(currentDir, "TestAssets", "ProjectWithReference")).CopyTo(tempDir);
+
+            var parser = Program.BuildParser(CreateClient());
+
+            // Act
+            Directory.SetCurrentDirectory(tempDir);
+            var result = await parser.InvokeAsync($"refresh --dry-run {dryRun}", testConsole);
+
+            // Assert
+            Assert.AreEqual(0, result, testConsole.Error.ToString());
+
+            var project = ProjectCollection.GlobalProjectCollection.LoadedProjects.Single(p => p.DirectoryPath == tempDir);
+            project.ReevaluateIfNecessary();
+
+            Assert.AreEqual(string.Format(CultureInfo.InvariantCulture, CoreStrings.LogDownload, "Proto/a.proto", SourceUrl), testConsole.Out.ToString()!.TrimEnd());
+            Assert.AreEqual(dryRun, string.IsNullOrEmpty(File.ReadAllText(Path.Combine(project.DirectoryPath, "Proto", "a.proto"))));
+
+            // Cleanup
+            Directory.SetCurrentDirectory(currentDir);
+            Directory.Delete(tempDir, true);
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         [NonParallelizable]

--- a/test/dotnet-grpc.Tests/RemoveCommandTests.cs
+++ b/test/dotnet-grpc.Tests/RemoveCommandTests.cs
@@ -17,7 +17,9 @@
 #endregion
 
 using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using Grpc.Dotnet.Cli.Commands;
+using Microsoft.Build.Evaluation;
 using NUnit.Framework;
 
 namespace Grpc.Dotnet.Cli.Tests
@@ -25,6 +27,37 @@ namespace Grpc.Dotnet.Cli.Tests
     [TestFixture]
     public class RemoveCommandTests : TestBase
     {
+        [Test]
+        [NonParallelizable]
+        public async Task Commandline_Remove_RemovesReferences()
+        {
+            // Arrange
+            var currentDir = Directory.GetCurrentDirectory();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var testConsole = new TestConsole();
+            new DirectoryInfo(Path.Combine(currentDir, "TestAssets", "ProjectWithReference")).CopyTo(tempDir);
+
+            var parser = Program.BuildParser(CreateClient());
+
+            // Act
+            Directory.SetCurrentDirectory(tempDir);
+            var result = await parser.InvokeAsync($"remove {Path.Combine("Proto", "a.proto")}", testConsole);
+
+            // Assert
+            Assert.AreEqual(0, result, testConsole.Error.ToString());
+
+            var project = ProjectCollection.GlobalProjectCollection.LoadedProjects.Single(p => p.DirectoryPath == tempDir);
+            project.ReevaluateIfNecessary();
+
+            var protoRefs = project.GetItems(CommandBase.ProtobufElement);
+            Assert.AreEqual(0, protoRefs.Count);
+            Assert.True(File.Exists(Path.Combine(project.DirectoryPath, "Proto", "a.proto")));
+
+            // Cleanup
+            Directory.SetCurrentDirectory(currentDir);
+            Directory.Delete(tempDir, true);
+        }
+
         [Test]
         [NonParallelizable]
         public void Remove_RemovesReferences()
@@ -36,7 +69,7 @@ namespace Grpc.Dotnet.Cli.Tests
 
             // Act
             Directory.SetCurrentDirectory(tempDir);
-            var command = new RemoveCommand(new TestConsole(), null);
+            var command = new RemoveCommand(new TestConsole(), null, CreateClient());
             command.Remove(new[] { Path.Combine("Proto", "a.proto") });
 
             // Assert

--- a/test/dotnet-grpc.Tests/RemoveCommandTests.cs
+++ b/test/dotnet-grpc.Tests/RemoveCommandTests.cs
@@ -40,8 +40,7 @@ namespace Grpc.Dotnet.Cli.Tests
             var parser = Program.BuildParser(CreateClient());
 
             // Act
-            Directory.SetCurrentDirectory(tempDir);
-            var result = await parser.InvokeAsync($"remove {Path.Combine("Proto", "a.proto")}", testConsole);
+            var result = await parser.InvokeAsync($"remove -p {tempDir} {Path.Combine("Proto", "a.proto")}", testConsole);
 
             // Assert
             Assert.AreEqual(0, result, testConsole.Error.ToString());
@@ -54,7 +53,6 @@ namespace Grpc.Dotnet.Cli.Tests
             Assert.True(File.Exists(Path.Combine(project.DirectoryPath, "Proto", "a.proto")));
 
             // Cleanup
-            Directory.SetCurrentDirectory(currentDir);
             Directory.Delete(tempDir, true);
         }
 

--- a/testassets/InteropTestsClient/Program.cs
+++ b/testassets/InteropTestsClient/Program.cs
@@ -32,10 +32,10 @@ namespace InteropTestsClient
         {
             var rootCommand = new RootCommand();
             rootCommand.AddOption(new Option<string>(new string[] { "--client_type", nameof(ClientOptions.ClientType) }, () => "httpclient"));
-            rootCommand.AddOption(new Option<string>(new string[] { "--server_host", nameof(ClientOptions.ServerHost) }) { Required = true });
+            rootCommand.AddOption(new Option<string>(new string[] { "--server_host", nameof(ClientOptions.ServerHost) }) { IsRequired = true });
             rootCommand.AddOption(new Option<string>(new string[] { "--server_host_override", nameof(ClientOptions.ServerHostOverride) }));
-            rootCommand.AddOption(new Option<int>(new string[] { "--server_port", nameof(ClientOptions.ServerPort) }) { Required = true });
-            rootCommand.AddOption(new Option<string>(new string[] { "--test_case", nameof(ClientOptions.TestCase) }) { Required = true });
+            rootCommand.AddOption(new Option<int>(new string[] { "--server_port", nameof(ClientOptions.ServerPort) }) { IsRequired = true });
+            rootCommand.AddOption(new Option<string>(new string[] { "--test_case", nameof(ClientOptions.TestCase) }) { IsRequired = true });
             rootCommand.AddOption(new Option<bool>(new string[] { "--use_tls", nameof(ClientOptions.UseTls) }));
             rootCommand.AddOption(new Option<bool>(new string[] { "--use_test_ca", nameof(ClientOptions.UseTestCa) }));
             rootCommand.AddOption(new Option<string>(new string[] { "--default_service_account", nameof(ClientOptions.DefaultServiceAccount) }));
@@ -45,7 +45,7 @@ namespace InteropTestsClient
             rootCommand.AddOption(new Option<bool>(new string[] { "--use_winhttp", nameof(ClientOptions.UseWinHttp) }));
             rootCommand.AddOption(new Option<bool>(new string[] { "--use_http3", nameof(ClientOptions.UseHttp3) }));
 
-            rootCommand.Handler = CommandHandler.Create<ClientOptions>(async (options) =>
+            rootCommand.SetHandler<ClientOptions>(async (options) =>
             {
                 var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
 

--- a/testassets/InteropTestsClient/Program.cs
+++ b/testassets/InteropTestsClient/Program.cs
@@ -17,7 +17,9 @@
 #endregion
 
 using System.CommandLine;
+using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
+using System.Globalization;
 using System.Reflection;
 using Grpc.Shared.TestAssets;
 using Grpc.Tests.Shared;
@@ -30,34 +32,32 @@ namespace InteropTestsClient
     {
         public static async Task<int> Main(string[] args)
         {
+            var options = new List<Option>();
+            options.Add(new Option<string>(new string[] { "--client_type", nameof(ClientOptions.ClientType) }, () => "httpclient"));
+            options.Add(new Option<string>(new string[] { "--server_host", nameof(ClientOptions.ServerHost) }) { IsRequired = true });
+            options.Add(new Option<string>(new string[] { "--server_host_override", nameof(ClientOptions.ServerHostOverride) }));
+            options.Add(new Option<int>(new string[] { "--server_port", nameof(ClientOptions.ServerPort) }) { IsRequired = true });
+            options.Add(new Option<string>(new string[] { "--test_case", nameof(ClientOptions.TestCase) }) { IsRequired = true });
+            options.Add(new Option<bool>(new string[] { "--use_tls", nameof(ClientOptions.UseTls) }));
+            options.Add(new Option<bool>(new string[] { "--use_test_ca", nameof(ClientOptions.UseTestCa) }));
+            options.Add(new Option<string>(new string[] { "--default_service_account", nameof(ClientOptions.DefaultServiceAccount) }));
+            options.Add(new Option<string>(new string[] { "--oauth_scope", nameof(ClientOptions.OAuthScope) }));
+            options.Add(new Option<string>(new string[] { "--service_account_key_file", nameof(ClientOptions.ServiceAccountKeyFile) }));
+            options.Add(new Option<string>(new string[] { "--grpc_web_mode", nameof(ClientOptions.GrpcWebMode) }));
+            options.Add(new Option<bool>(new string[] { "--use_winhttp", nameof(ClientOptions.UseWinHttp) }));
+            options.Add(new Option<bool>(new string[] { "--use_http3", nameof(ClientOptions.UseHttp3) }));
+
             var rootCommand = new RootCommand();
-            rootCommand.AddOption(new Option<string>(new string[] { "--client_type", nameof(ClientOptions.ClientType) }, () => "httpclient"));
-            rootCommand.AddOption(new Option<string>(new string[] { "--server_host", nameof(ClientOptions.ServerHost) }) { IsRequired = true });
-            rootCommand.AddOption(new Option<string>(new string[] { "--server_host_override", nameof(ClientOptions.ServerHostOverride) }));
-            rootCommand.AddOption(new Option<int>(new string[] { "--server_port", nameof(ClientOptions.ServerPort) }) { IsRequired = true });
-            rootCommand.AddOption(new Option<string>(new string[] { "--test_case", nameof(ClientOptions.TestCase) }) { IsRequired = true });
-            rootCommand.AddOption(new Option<bool>(new string[] { "--use_tls", nameof(ClientOptions.UseTls) }));
-            rootCommand.AddOption(new Option<bool>(new string[] { "--use_test_ca", nameof(ClientOptions.UseTestCa) }));
-            rootCommand.AddOption(new Option<string>(new string[] { "--default_service_account", nameof(ClientOptions.DefaultServiceAccount) }));
-            rootCommand.AddOption(new Option<string>(new string[] { "--oauth_scope", nameof(ClientOptions.OAuthScope) }));
-            rootCommand.AddOption(new Option<string>(new string[] { "--service_account_key_file", nameof(ClientOptions.ServiceAccountKeyFile) }));
-            rootCommand.AddOption(new Option<string>(new string[] { "--grpc_web_mode", nameof(ClientOptions.GrpcWebMode) }));
-            rootCommand.AddOption(new Option<bool>(new string[] { "--use_winhttp", nameof(ClientOptions.UseWinHttp) }));
-            rootCommand.AddOption(new Option<bool>(new string[] { "--use_http3", nameof(ClientOptions.UseHttp3) }));
+            foreach (var option in options)
+            {
+                rootCommand.AddOption(option);
+            }
 
             rootCommand.SetHandler<ClientOptions>(async (options) =>
             {
                 var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
 
-                Console.WriteLine("Runtime: " + runtimeVersion);
-                Console.WriteLine("Use TLS: " + options.UseTls);
-                Console.WriteLine("Use WinHttp: " + options.UseWinHttp);
-                Console.WriteLine("Use HTTP/3: " + options.UseHttp3);
-                Console.WriteLine("Use GrpcWebMode: " + options.GrpcWebMode);
-                Console.WriteLine("Use Test CA: " + options.UseTestCa);
-                Console.WriteLine("Client type: " + options.ClientType);
-                Console.WriteLine("Server host: " + options.ServerHost);
-                Console.WriteLine("Server port: " + options.ServerPort);
+                Log("Runtime: " + runtimeVersion);
 
                 var services = new ServiceCollection();
                 services.AddLogging(configure =>
@@ -73,9 +73,49 @@ namespace InteropTestsClient
 
                 var interopClient = new InteropClient(options, loggerFactory);
                 await interopClient.Run();
-            });
+            }, new ReflectionBinder<ClientOptions>(options));
+
+            Log("Interop Test Client");
 
             return await rootCommand.InvokeAsync(args);
+        }
+
+        private static void Log(string message)
+        {
+            var time = DateTime.Now.ToString("hh:mm:ss.fff", CultureInfo.InvariantCulture);
+            Console.WriteLine($"[{time}] {message}");
+        }
+
+        private class ReflectionBinder<T> : BinderBase<T> where T : new()
+        {
+            private readonly List<Option> _options;
+
+            public ReflectionBinder(List<Option> options)
+            {
+                _options = options;
+            }
+
+            protected override T GetBoundValue(BindingContext bindingContext)
+            {
+                var boundValue = new T();
+
+                Log($"Binding {typeof(T)}");
+
+                foreach (var option in _options)
+                {
+                    var value = bindingContext.ParseResult.GetValueForOption(option);
+
+                    var propertyInfo = typeof(T).GetProperty(option.Name, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                    if (propertyInfo != null)
+                    {
+                        propertyInfo.SetValue(boundValue, value);
+
+                        Log($"-{propertyInfo.Name} = {value}");
+                    }
+                }
+
+                return boundValue;
+            }
         }
     }
 }

--- a/testassets/InteropTestsClient/Program.cs
+++ b/testassets/InteropTestsClient/Program.cs
@@ -19,6 +19,7 @@
 using System.CommandLine;
 using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using Grpc.Shared.TestAssets;
@@ -33,19 +34,19 @@ namespace InteropTestsClient
         public static async Task<int> Main(string[] args)
         {
             var options = new List<Option>();
-            options.Add(new Option<string>(new string[] { "--client_type", nameof(ClientOptions.ClientType) }, () => "httpclient"));
-            options.Add(new Option<string>(new string[] { "--server_host", nameof(ClientOptions.ServerHost) }) { IsRequired = true });
-            options.Add(new Option<string>(new string[] { "--server_host_override", nameof(ClientOptions.ServerHostOverride) }));
-            options.Add(new Option<int>(new string[] { "--server_port", nameof(ClientOptions.ServerPort) }) { IsRequired = true });
-            options.Add(new Option<string>(new string[] { "--test_case", nameof(ClientOptions.TestCase) }) { IsRequired = true });
-            options.Add(new Option<bool>(new string[] { "--use_tls", nameof(ClientOptions.UseTls) }));
-            options.Add(new Option<bool>(new string[] { "--use_test_ca", nameof(ClientOptions.UseTestCa) }));
-            options.Add(new Option<string>(new string[] { "--default_service_account", nameof(ClientOptions.DefaultServiceAccount) }));
-            options.Add(new Option<string>(new string[] { "--oauth_scope", nameof(ClientOptions.OAuthScope) }));
-            options.Add(new Option<string>(new string[] { "--service_account_key_file", nameof(ClientOptions.ServiceAccountKeyFile) }));
-            options.Add(new Option<string>(new string[] { "--grpc_web_mode", nameof(ClientOptions.GrpcWebMode) }));
-            options.Add(new Option<bool>(new string[] { "--use_winhttp", nameof(ClientOptions.UseWinHttp) }));
-            options.Add(new Option<bool>(new string[] { "--use_http3", nameof(ClientOptions.UseHttp3) }));
+            options.Add(new Option<string>(new string[] { "--client_type" }, () => "httpclient") { Name = nameof(ClientOptions.ClientType) });
+            options.Add(new Option<string>(new string[] { "--server_host" }) { IsRequired = true, Name = nameof(ClientOptions.ServerHost) });
+            options.Add(new Option<string>(new string[] { "--server_host_override" }) { Name = nameof(ClientOptions.ServerHostOverride) });
+            options.Add(new Option<int>(new string[] { "--server_port" }) { IsRequired = true, Name = nameof(ClientOptions.ServerPort) });
+            options.Add(new Option<string>(new string[] { "--test_case" }) { IsRequired = true, Name = nameof(ClientOptions.TestCase) });
+            options.Add(new Option<bool>(new string[] { "--use_tls" }) { Name = nameof(ClientOptions.UseTls) });
+            options.Add(new Option<bool>(new string[] { "--use_test_ca" }) { Name = nameof(ClientOptions.UseTestCa) });
+            options.Add(new Option<string>(new string[] { "--default_service_account" }) { Name = nameof(ClientOptions.DefaultServiceAccount) });
+            options.Add(new Option<string>(new string[] { "--oauth_scope" }) { Name = nameof(ClientOptions.OAuthScope) });
+            options.Add(new Option<string>(new string[] { "--service_account_key_file" }) { Name = nameof(ClientOptions.ServiceAccountKeyFile) });
+            options.Add(new Option<string>(new string[] { "--grpc_web_mode" }) { Name = nameof(ClientOptions.GrpcWebMode) });
+            options.Add(new Option<bool>(new string[] { "--use_winhttp" }) { Name = nameof(ClientOptions.UseWinHttp) });
+            options.Add(new Option<bool>(new string[] { "--use_http3" }) { Name = nameof(ClientOptions.UseHttp3) });
 
             var rootCommand = new RootCommand();
             foreach (var option in options)


### PR DESCRIPTION
Updates System.Commandline to the latest version. It's a fairly big change in API and usage. I'm guessing it's done in the name of trimming. Annoying though.

I added unit tests for invoking via command line to ensure nothing has broken.

I also made it so that the project option can just be a path, and implicitly uses a single csproj in the path. This matches `dotnet` 