### PR TITLE
Run interop tests against Java instead of Grpc C# (Grpc.Core)

### DIFF
--- a/kokoro/interop.sh
+++ b/kokoro/interop.sh
@@ -27,4 +27,4 @@ cd ../grpc
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/run_tests/run_interop_tests.py -l aspnetcore csharpcoreclr -s aspnetcore csharpcoreclr --use_docker --internal_ci -t -j 8
+tools/run_tests/run_interop_tests.py -l aspnetcore java -s aspnetcore java --use_docker --internal_ci -t -j 8


### PR DESCRIPTION
Grpc C# has been removed from master branch of grpc/grpc, so we need to choose some other language to run the interop tests against.
Chose java because it builds more quickly than grpc C++. golang would also work.