### PR TITLE
Ensuring required services are registered when using the server reflection

### DIFF
--- a/src/Grpc.AspNetCore.Server.Reflection/GrpcReflectionEndpointRouteBuilderExtensions.cs
+++ b/src/Grpc.AspNetCore.Server.Reflection/GrpcReflectionEndpointRouteBuilderExtensions.cs
@@ -18,6 +18,7 @@
 
 using Grpc.Reflection;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -39,7 +40,19 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(builder));
             }
 
+            ValidateServicesRegistered(builder.ServiceProvider);
+
             return builder.MapGrpcService<ReflectionServiceImpl>();
+        }
+
+        private static void ValidateServicesRegistered(IServiceProvider serviceProvider)
+        {
+            var marker = serviceProvider.GetService(typeof(GrpcReflectionMarkerService));
+            if (marker == null)
+            {
+                throw new InvalidOperationException("Unable to find the required services. Please add all the required services by calling " +
+                    "'IServiceCollection.AddGrpcReflection()' inside the call to 'ConfigureServices(...)' in the application startup code.");
+            }
         }
     }
 }

--- a/src/Grpc.AspNetCore.Server.Reflection/GrpcReflectionMarkerService.cs
+++ b/src/Grpc.AspNetCore.Server.Reflection/GrpcReflectionMarkerService.cs
@@ -1,0 +1,29 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// A marker class used to determine if all the required gRPC reflection services were added
+    /// to the <see cref="IServiceCollection"/>.
+    /// </summary>
+    internal class GrpcReflectionMarkerService
+    {
+
+    }
+}

--- a/src/Grpc.AspNetCore.Server.Reflection/GrpcReflectionServiceExtensions.cs
+++ b/src/Grpc.AspNetCore.Server.Reflection/GrpcReflectionServiceExtensions.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
+            services.TryAddSingleton<GrpcReflectionMarkerService>();
+
             // ReflectionServiceImpl is designed to be a singleton
             // Explicitly register creating it in DI using descriptors calculated from gRPC endpoints in the app
             services.TryAddSingleton<ReflectionServiceImpl>(serviceProvider =>

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -35,6 +35,20 @@ namespace Grpc.AspNetCore.Server.Tests
     public class GrpcEndpointRouteBuilderExtensionsTests
     {
         [Test]
+        public void MapGrpcReflectionService_WithoutServices_RaiseError()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider(validateScopes: true));
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => routeBuilder.MapGrpcReflectionService())!;
+            Assert.AreEqual("Unable to find the required services. Please add all the required services by calling " +
+                    "'IServiceCollection.AddGrpcReflection()' inside the call to 'ConfigureServices(...)' in the application startup code.", ex.Message);
+        }
+
+        [Test]
         public void MapGrpcService_WithoutServices_RaiseError()
         {
             // Arrange


### PR DESCRIPTION
This PR solves the problem related in this [issue](https://github.com/grpc/grpc-dotnet/issues/1729).

It is being checked whether the services needed to use gRPC reflection have been added. If not, an `InvalidOperationException` is thrown, asking to call the `IServiceCollection.AddGrpcReflection()` method.