### PR TITLE
Fix warnings when running benchmarks in .NET 7

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -13,6 +13,8 @@
 
     <!-- Turn on preview features so we can use Http3. Can be removed in .NET 7 -->
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <!-- TODO(JamesNK): Workaround https://github.com/grpc/grpc/issues/29672 -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
+++ b/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
@@ -6,6 +6,8 @@
     <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
     <!-- Enable server GC to more closely simulate a microservice app making calls -->
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <!-- TODO(JamesNK): Workaround https://github.com/grpc/grpc/issues/29672 -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <!-- TODO(JamesNK): Workaround https://github.com/grpc/grpc/issues/29672 -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -161,13 +161,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
                         }
                     }
                 }
-                catch (OperationCanceledException)
+                catch (Exception ex)
                 {
+                    Logger.LogInformation(ex, "Server error.");
                     return;
                 }
                 finally
                 {
-                    Logger.LogInformation($"Server waiting for RequestAborted.");
+                    Logger.LogInformation("Server waiting for RequestAborted.");
                     await serverAbortedTcs.Task;
                 }
             }

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -125,8 +125,9 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
             AssertHasLogRpcConnectionError(StatusCode.Aborted, "Aborted from server side.");
         }
 
-        [Test]
-        public async Task SendValidRequest_ClientAbort_ClientThrowsCancelledException()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task SendValidRequest_ClientAbort_ClientThrowsCancelledException(bool delayWithCancellationToken)
         {
             var serverAbortedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
             async Task ServerStreamingEcho(ServerStreamingEchoRequest request, IServerStreamWriter<ServerStreamingEchoResponse> responseStream, ServerCallContext context)
@@ -150,7 +151,14 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client
                             Message = request.Message
                         });
 
-                        await Task.Delay(request.MessageInterval.ToTimeSpan(), context.CancellationToken);
+                        if (delayWithCancellationToken)
+                        {
+                            await Task.Delay(request.MessageInterval.ToTimeSpan(), context.CancellationToken);
+                        }
+                        else
+                        {
+                            await Task.Delay(request.MessageInterval.ToTimeSpan());
+                        }
                     }
                 }
                 catch (OperationCanceledException)


### PR DESCRIPTION
https://dev.azure.com/dnceng/internal/_build/results?buildId=1774030&view=logs&j=c8217af0-de7d-5e68-361c-a1e6c44be6a1&t=f2db64d4-e317-5098-839d-eae36295160d
```
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\BenchmarkService.cs(8,7): error CS8981: The type name 'pb' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\BenchmarkService.cs(9,7): error CS8981: The type name 'pbc' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\BenchmarkService.cs(10,7): error CS8981: The type name 'pbr' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\BenchmarkService.cs(11,7): error CS8981: The type name 'scg' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\BenchmarkServiceGrpc.cs(25,7): error CS8981: The type name 'grpc' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\Messages.cs(8,7): error CS8981: The type name 'pb' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\Messages.cs(9,7): error CS8981: The type name 'pbc' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\Messages.cs(10,7): error CS8981: The type name 'pbr' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\obj\Release\net7.0\win-x64\Messages.cs(11,7): error CS8981: The type name 'scg' only contains lower-cased ascii characters. Such names may become reserved for the language. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8292\prpgrdxs.xi1\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj]
```