### PR TITLE
Validate AddCallCredentials are used by client

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -205,8 +205,8 @@ namespace Grpc.Net.Client
                 {
                     throw new InvalidOperationException($"Unable to determine the TLS configuration of the channel from address '{Address}'. " +
                         $"{nameof(GrpcChannelOptions)}.{nameof(GrpcChannelOptions.Credentials)} must be specified when the address doesn't have a 'http' or 'https' scheme. " +
-                        "To call TLS endpoints, set credentials to 'new SslCredentials()'. " +
-                        "To call non-TLS endpoints, set credentials to 'ChannelCredentials.Insecure'.");
+                        $"To call TLS endpoints, set credentials to '{nameof(ChannelCredentials)}.{nameof(ChannelCredentials.SecureSsl)}'. " +
+                        $"To call non-TLS endpoints, set credentials to '{nameof(ChannelCredentials)}.{nameof(ChannelCredentials.Insecure)}'.");
                 }
                 callCredentials = null;
             }

--- a/src/Grpc.Net.Client/Internal/DefaultChannelCredentialsConfigurator.cs
+++ b/src/Grpc.Net.Client/Internal/DefaultChannelCredentialsConfigurator.cs
@@ -20,7 +20,7 @@ using Grpc.Core;
 
 namespace Grpc.Net.Client.Internal
 {
-    internal class DefaultChannelCredentialsConfigurator : ChannelCredentialsConfiguratorBase
+    internal sealed class DefaultChannelCredentialsConfigurator : ChannelCredentialsConfiguratorBase
     {
         public bool? IsSecure { get; private set; }
         public List<CallCredentials>? CallCredentials { get; private set; }

--- a/src/Grpc.Net.ClientFactory/GrpcClientFactoryOptions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientFactoryOptions.cs
@@ -58,6 +58,8 @@ namespace Grpc.Net.ClientFactory
         /// </summary>
         public Func<CallInvoker, object>? Creator { get; set; }
 
+        internal bool HasCallCredentials { get; set; }
+
         internal static CallInvoker BuildInterceptors(
             CallInvoker callInvoker,
             IServiceProvider serviceProvider,

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-using Grpc.Net.Client;
 using Grpc.Net.ClientFactory;
 using Grpc.Net.ClientFactory.Internal;
 using Grpc.Shared;
@@ -341,24 +340,6 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 });
             });
-            //services.PostConfigure<GrpcClientFactoryOptions>(name, options =>
-            //{
-            //    if (options.HasCallCredentials && options.Address?.Scheme == Uri.UriSchemeHttp)
-            //    {
-            //        var channelOptions = new GrpcChannelOptions();
-            //        if (options.ChannelOptionsActions.Count > 0)
-            //        {
-            //            foreach (var action in options.ChannelOptionsActions)
-            //            {
-            //                action(channelOptions);
-            //            }
-            //        }
-            //        if (channelOptions.UnsafeUseInsecureChannelCallCredentials)
-            //        {
-
-            //        }
-            //    }
-            //});
 
             var builder = new DefaultHttpClientBuilder(services, name);
 

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using Grpc.Net.Client;
 using Grpc.Net.ClientFactory;
 using Grpc.Net.ClientFactory.Internal;
 using Grpc.Shared;
@@ -340,7 +341,24 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 });
             });
+            //services.PostConfigure<GrpcClientFactoryOptions>(name, options =>
+            //{
+            //    if (options.HasCallCredentials && options.Address?.Scheme == Uri.UriSchemeHttp)
+            //    {
+            //        var channelOptions = new GrpcChannelOptions();
+            //        if (options.ChannelOptionsActions.Count > 0)
+            //        {
+            //            foreach (var action in options.ChannelOptionsActions)
+            //            {
+            //                action(channelOptions);
+            //            }
+            //        }
+            //        if (channelOptions.UnsafeUseInsecureChannelCallCredentials)
+            //        {
 
+            //        }
+            //    }
+            //});
 
             var builder = new DefaultHttpClientBuilder(services, name);
 

--- a/src/Grpc.Net.ClientFactory/GrpcHttpClientBuilderExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcHttpClientBuilderExtensions.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<GrpcClientFactoryOptions>(builder.Name, options =>
             {
+                options.HasCallCredentials = true;
                 options.CallOptionsActions.Add((callOptionsContext) =>
                 {
                     var credentials = CallCredentials.FromInterceptor((context, metadata) => authInterceptor(context, metadata));
@@ -184,6 +185,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<GrpcClientFactoryOptions>(builder.Name, options =>
             {
+                options.HasCallCredentials = true;
                 options.CallOptionsActions.Add((callOptionsContext) =>
                 {
                     var credentials = CallCredentials.FromInterceptor((context, metadata) => authInterceptor(context, metadata, callOptionsContext.ServiceProvider));
@@ -217,6 +219,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<GrpcClientFactoryOptions>(builder.Name, options =>
             {
+                options.HasCallCredentials = true;
                 options.CallOptionsActions.Add((callOptionsContext) =>
                 {
                     callOptionsContext.CallOptions = ResolveCallOptionsCredentials(callOptionsContext.CallOptions, credentials);

--- a/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
@@ -36,8 +36,6 @@ namespace Grpc.Net.ClientFactory.Internal
             _serviceProvider = serviceProvider;
             _callInvokerFactory = callInvokerFactory;
             _grpcClientFactoryOptionsMonitor = grpcClientFactoryOptionsMonitor;
-
-            
         }
 
         public override TClient CreateClient<TClient>(string name) where TClient : class

--- a/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
@@ -36,6 +36,8 @@ namespace Grpc.Net.ClientFactory.Internal
             _serviceProvider = serviceProvider;
             _callInvokerFactory = callInvokerFactory;
             _grpcClientFactoryOptionsMonitor = grpcClientFactoryOptionsMonitor;
+
+            
         }
 
         public override TClient CreateClient<TClient>(string name) where TClient : class

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -475,7 +475,7 @@ namespace Grpc.Net.Client.Tests
             // Assert
             Assert.AreEqual("Unable to determine the TLS configuration of the channel from address 'test:///localhost'. " +
                 "GrpcChannelOptions.Credentials must be specified when the address doesn't have a 'http' or 'https' scheme. " +
-                "To call TLS endpoints, set credentials to 'new SslCredentials()'. " +
+                "To call TLS endpoints, set credentials to 'ChannelCredentials.SecureSsl'. " +
                 "To call non-TLS endpoints, set credentials to 'ChannelCredentials.Insecure'.", ex.Message);
         }
 

--- a/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/GrpcHttpClientBuilderExtensionsTests.cs
@@ -19,6 +19,9 @@
 using System.Net;
 using Greet;
 using Grpc.Core;
+#if NET5_0_OR_GREATER
+using Grpc.Net.Client.Balancer;
+#endif
 using Grpc.Net.ClientFactory;
 using Grpc.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
@@ -623,6 +626,49 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
                 "client.AddCallCredentials((context, metadata) => {}).ConfigureChannel(o => o.UnsafeUseInsecureChannelCallCredentials = true)", ex.Message);
         }
 
+#if NET5_0_OR_GREATER
+        [Test]
+        public void AddCallCredentials_StaticLoadBalancingSecureChannel_Success()
+        {
+            // Arrange
+            HttpRequestMessage? sentRequest = null;
+
+            var services = new ServiceCollection();
+            services.AddSingleton<ResolverFactory>(new StaticResolverFactory(_ => new[]
+            {
+                new BalancerAddress("localhost", 80)
+            }));
+
+            // Can't use ConfigurePrimaryHttpMessageHandler with load balancing because underlying
+            services
+                .AddGrpcClient<Greeter.GreeterClient>(o =>
+                {
+                    o.Address = new Uri("static:///localhost");
+                })
+                .ConfigureChannel(o =>
+                {
+                    o.Credentials = ChannelCredentials.SecureSsl;
+                })
+                .AddCallCredentials(CallCredentials.FromInterceptor((context, metadata) =>
+                {
+                    metadata.Add("factory-authorize", "auth!");
+                    return Task.CompletedTask;
+                }))
+                .AddHttpMessageHandler(() => new TestHttpMessageHandler(request =>
+                {
+                    sentRequest = request;
+                }));
+
+            var serviceProvider = services.BuildServiceProvider(validateScopes: true);
+
+            // Act & Assert
+            var clientFactory = serviceProvider.GetRequiredService<GrpcClientFactory>();
+            _ = clientFactory.CreateClient<Greeter.GreeterClient>(nameof(Greeter.GreeterClient));
+
+            // No call because there isn't an endpoint at localhost:80
+        }
+#endif
+
         [Test]
         public async Task AddCallCredentials_InsecureChannel_UnsafeUseInsecureChannelCallCredentials_Success()
         {
@@ -733,7 +779,7 @@ namespace Grpc.AspNetCore.Server.ClientFactory.Tests
             }
         }
 
-        private class TestHttpMessageHandler : HttpMessageHandler
+        private class TestHttpMessageHandler : DelegatingHandler
         {
             public bool Invoked { get; private set; }
 


### PR DESCRIPTION
Call credentials configured on a non-TLS channel aren't used. Instead, a warning is logged. This is confusing until a dev reads documentation or looks at logs. This behavior was chosen because it's what Grpc.Core does, and compatibility is important.

gRPC client factory has a new `AddCallCredentials` method. This PR updates the client factory to validate that call credentials are used, otherwise, it throws an error. Compatibility with Grpc.Core isn't a problem because gRPC client factory is new for grpc-dotnet.