### PR TITLE
Revert "Change InteropTestClient to net5.0"

### DIFF
--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net6.0;net5.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts grpc/grpc-dotnet#1514

Switch interop tests back to net6.0, since the google backends have been updated to avoid the "too many pings" issue caused by the .NET 6 "dynamic window sizing" feature (see https://github.com/grpc/grpc-dotnet/issues/1511 and https://github.com/dotnet/runtime/issues/62216)

