### PR TITLE
Add HTTP event source logging to gRPC benchmark client

### DIFF
--- a/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
+++ b/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
@@ -21,6 +21,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 
+    <Compile Include="..\..\..\test\Shared\HttpEventSourceListener.cs" Link="HttpEventSourceListener.cs" />
+
     <PackageReference Include="Microsoft.Crank.EventSources" Version="$(MicrosoftCrankEventSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsPackageVersion)" />


### PR DESCRIPTION
Benchmarks are broken with HTTP/3. Improving logging to find out why.