### PR TITLE
Additional dependency version cleanup (after moving some nuget packages to from grpc to grpc-dotnet)

### DIFF
--- a/examples/Reflector/Client/Client.csproj
+++ b/examples/Reflector/Client/Client.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />
-    <PackageReference Include="Grpc.Reflection" Version="$(GrpcPackageVersion)" />
+    <PackageReference Include="Grpc.Reflection" Version="$(GrpcDotNetPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
   

--- a/examples/Tester/Common/Common.csproj
+++ b/examples/Tester/Common/Common.csproj
@@ -9,7 +9,7 @@
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcPackageVersion)"/>
+    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcDotNetPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/examples/Tester/Common/Common.csproj
+++ b/examples/Tester/Common/Common.csproj
@@ -9,7 +9,7 @@
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/examples/Vigor/Client/Client.csproj
+++ b/examples/Vigor/Client/Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.HealthCheck" Version="$(GrpcPackageVersion)" />
+    <PackageReference Include="Grpc.HealthCheck" Version="$(GrpcDotNetPackageVersion)" />
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -30,7 +30,7 @@
     </None>
 
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
-    <PackageReference Include="Grpc.Core" Version="$(GrpcPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Core" Version="$(GrpcPackageVersion)"/>
     <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsPackageVersion)" />


### PR DESCRIPTION
Some occurrences of `PrivateAssets="All"` seems unnecessary?
Grpc.Reflection and Grpc.HealthCheck now live in grpc-dotnet repository, so their version should be GrpcDotNetPackageVersion in examples?