### PR TITLE
Make ChannelCredentials.Create work with allowing insecure credentials

### DIFF
--- a/src/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/Grpc.Core.Api/ChannelCredentials.cs
@@ -89,6 +89,11 @@ public abstract class ChannelCredentials
     /// <summary>
     /// Returns <c>true</c> if this credential type allows being composed by <c>CompositeCredentials</c>.
     /// </summary>
+    /// <remark>
+    /// Note: No longer used. Decision on whether composition is allowed now happens in
+    /// <see cref="ChannelCredentialsConfiguratorBase.SetCompositeCredentials(object, ChannelCredentials, CallCredentials)"/>.
+    /// Internal property left for safety because Grpc.Core has internal access to Grpc.Core.Api.
+    /// </remark>
     internal virtual bool IsComposable => false;
 
     private sealed class InsecureCredentials : ChannelCredentials
@@ -118,11 +123,6 @@ public abstract class ChannelCredentials
         {
             this.channelCredentials = GrpcPreconditions.CheckNotNull(channelCredentials);
             this.callCredentials = GrpcPreconditions.CheckNotNull(callCredentials);
-
-            if (!channelCredentials.IsComposable)
-            {
-                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "CallCredentials can't be composed with {0}. CallCredentials must be used with secure channel credentials like SslCredentials.", channelCredentials.GetType().Name));
-            }
         }
 
         public override void InternalPopulateConfiguration(ChannelCredentialsConfiguratorBase configurator, object state)

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -185,7 +185,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
     {
         if (channelOptions.Credentials != null)
         {
-            var configurator = new DefaultChannelCredentialsConfigurator();
+            var configurator = new DefaultChannelCredentialsConfigurator(channelOptions.UnsafeUseInsecureChannelCallCredentials);
             channelOptions.Credentials.InternalPopulateConfiguration(configurator, channelOptions.Credentials);
 
             isSecure = configurator.IsSecure ?? false;

--- a/test/Grpc.Core.Api.Tests/ChannelCredentialsTest.cs
+++ b/test/Grpc.Core.Api.Tests/ChannelCredentialsTest.cs
@@ -25,18 +25,6 @@ namespace Grpc.Core.Tests;
 public class ChannelCredentialsTest
 {
     [Test]
-    public void InsecureCredentials_IsNonComposable()
-    {
-        Assert.IsFalse(ChannelCredentials.Insecure.IsComposable);
-    }
-
-    [Test]
-    public void SecureCredentials_IsComposable()
-    {
-        Assert.IsTrue(ChannelCredentials.SecureSsl.IsComposable);
-    }
-
-    [Test]
     public void ChannelCredentials_CreateComposite()
     {
         var composite = ChannelCredentials.Create(new FakeChannelCredentials(true), new FakeCallCredentials());
@@ -44,9 +32,5 @@ public class ChannelCredentialsTest
 
         Assert.Throws(typeof(ArgumentNullException), () => ChannelCredentials.Create(null, new FakeCallCredentials()));
         Assert.Throws(typeof(ArgumentNullException), () => ChannelCredentials.Create(new FakeChannelCredentials(true), null));
-
-        // forbid composing non-composable
-        var ex = Assert.Throws(typeof(ArgumentException), () => ChannelCredentials.Create(new FakeChannelCredentials(false), new FakeCallCredentials()));
-        Assert.AreEqual("CallCredentials can't be composed with FakeChannelCredentials. CallCredentials must be used with secure channel credentials like SslCredentials.", ex.Message);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1800

Note that this change means Grpc.Core using a newer version of Grpc.Core.Api no longer throws an error when calling `ChannelCredentials.Create(ChannelCredentials.Insecure, callCredentials)`. That could be remedied by updating Grpc.Core to throw an error inside the configurator like Grpc.Net.Client does, but Grpc.Core is in maintenance. IMO not worth it.

I think this is safe to change because new behavior goes from error to non-error, and I don't see a situation where anyone would ever depend on the error.

@jtattermusch Thoughts?