### PR TITLE
Fix client factory trim warning

### DIFF
--- a/src/Grpc.Net.ClientFactory/GrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientFactory.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Grpc.Net.ClientFactory
 {
     /// <summary>
@@ -30,6 +32,10 @@ namespace Grpc.Net.ClientFactory
         /// <typeparam name="TClient">The gRPC client type.</typeparam>
         /// <param name="name">The configuration name.</param>
         /// <returns>A gRPC client instance.</returns>
-        public abstract TClient CreateClient<TClient>(string name) where TClient : class;
+        public abstract TClient CreateClient<
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TClient>(string name) where TClient : class;
     }
 }

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using Grpc.Net.ClientFactory;
 using Grpc.Net.ClientFactory.Internal;
 using Grpc.Shared;
@@ -280,7 +281,11 @@ namespace Microsoft.Extensions.DependencyInjection
             return services.AddGrpcClientCore<TClient>(name);
         }
 
-        private static IHttpClientBuilder AddGrpcClientCore<TClient>(this IServiceCollection services, string name) where TClient : class
+        private static IHttpClientBuilder AddGrpcClientCore<
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TClient>(this IServiceCollection services, string name) where TClient : class
         {
             if (name == null)
             {
@@ -305,7 +310,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// This is a custom method to register the HttpClient and typed factory. Needed because we need to access the config name when creating the typed client
         /// </summary>
-        private static IHttpClientBuilder AddGrpcHttpClient<TClient>(this IServiceCollection services, string name)
+        private static IHttpClientBuilder AddGrpcHttpClient<
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TClient>(this IServiceCollection services, string name)
             where TClient : class
         {
             if (services == null)

--- a/src/Grpc.Net.ClientFactory/Internal/DefaultClientActivator.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultClientActivator.cs
@@ -16,13 +16,18 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Grpc.Net.ClientFactory.Internal
 {
     // Should be registered as a singleton, so it that it can act as a cache for the Activator.
-    internal class DefaultClientActivator<TClient> where TClient : class
+    internal class DefaultClientActivator<
+#if NET5_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        TClient> where TClient : class
     {
         private static readonly Func<ObjectFactory> _createActivator = static () => ActivatorUtilities.CreateFactory(typeof(TClient), new Type[] { typeof(CallInvoker), });
 

--- a/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,7 +39,11 @@ namespace Grpc.Net.ClientFactory.Internal
             _grpcClientFactoryOptionsMonitor = grpcClientFactoryOptionsMonitor;
         }
 
-        public override TClient CreateClient<TClient>(string name) where TClient : class
+        public override TClient CreateClient<
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TClient>(string name) where TClient : class
         {
             var defaultClientActivator = _serviceProvider.GetService<DefaultClientActivator<TClient>>();
             if (defaultClientActivator == null)


### PR DESCRIPTION
Fix warning:

```
/_/src/Grpc.Net.ClientFactory/Internal/DefaultClientActivator.cs(27,85): Trim analysis warning IL2087: Grpc.Net.ClientFactory.Internal.DefaultClientActivator<TClien
t>.<>c.<.cctor>b__9_0(): 'instanceType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInj
ection.ActivatorUtilities.CreateFactory(Type, Type[])'. The generic parameter 'TClient' of 'Grpc.Net.ClientFactory.Internal.DefaultClientActivator<TClient>.<>c' doe
s not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [C:\Develo
pment\Source\grpc-dotnet\examples\Aggregator\Server\Server.csproj]
```