### PR TITLE
Fix async propagation in GrpcCall.cs

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -282,7 +282,7 @@ namespace Grpc.Net.Client.Internal
             _callTcs.TrySetResult(status);
         }
 
-        public Task<Metadata> GetResponseHeadersAsync()
+        public async Task<Metadata> GetResponseHeadersAsync()
         {
             if (_responseHeadersTask == null)
             {
@@ -290,7 +290,7 @@ namespace Grpc.Net.Client.Internal
                 _responseHeadersTask = GetResponseHeadersCoreAsync();
             }
 
-            return _responseHeadersTask;
+            return await _responseHeadersTask;
         }
 
         private async Task<Metadata> GetResponseHeadersCoreAsync()


### PR DESCRIPTION
We're having a problem where we're getting UnobservedTaskException events that look like this:

```
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Status(StatusCode="Cancelled", Detail="Call canceled by the client."))
---> Grpc.Core.RpcException: Status(StatusCode="Cancelled", Detail="Call canceled by the client.")
at Grpc.Net.Client.Internal.GrpcCall`2.GetResponseHeadersCoreAsync()
--- End of inner exception stack trace ---
```

I don't think that this PR solves our issue, but it might give better callstacks.