### PR TITLE
add logging of exceptions to sample code test logger

### DIFF
--- a/examples/Tester/Tests/Server/IntegrationTests/Helpers/GrpcTestContext.cs
+++ b/examples/Tester/Tests/Server/IntegrationTests/Helpers/GrpcTestContext.cs
@@ -44,7 +44,7 @@ namespace Tests.Server.IntegrationTests.Helpers
             // if it is written in the test's execution context.
             ExecutionContext.Run(_executionContext, s =>
             {
-                Console.WriteLine($"{_stopwatch.Elapsed.TotalSeconds:N3}s {category} - {logLevel}: {message}");
+                Console.WriteLine($"{_stopwatch.Elapsed.TotalSeconds:N3}s {category} - {logLevel}: {message}: {exception}");
             }, null);
         }
 


### PR DESCRIPTION
I used the example gRPC test code to start but didn't realize the exceptions were getting lost, this just includes logging any exceptions from the server too.  Ref: #1839