### PR TITLE
Update Grpc.Tools dependency to 2.48.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <GoogleProtobufPackageVersion>3.19.4</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.44.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.46.3</GrpcPackageVersion>
-    <GrpcToolsPackageVersion>2.47.0</GrpcToolsPackageVersion>
+    <GrpcToolsPackageVersion>2.48.0</GrpcToolsPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>6.0.0</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>
     <MicrosoftAspNetCoreApp31PackageVersion>3.1.3</MicrosoftAspNetCoreApp31PackageVersion>


### PR DESCRIPTION
I'll cut the release branch for 2.48.x after merging this.