### PR TITLE
Load balancing fix to clear disposed subchannels on resolver error

### DIFF
--- a/src/Grpc.Net.Client/Balancer/BalancerAddress.cs
+++ b/src/Grpc.Net.Client/Balancer/BalancerAddress.cs
@@ -17,6 +17,7 @@
 #endregion
 
 #if SUPPORT_LOAD_BALANCING
+using System.Diagnostics;
 using System.Net;
 
 namespace Grpc.Net.Client.Balancer
@@ -35,6 +36,7 @@ namespace Grpc.Net.Client.Balancer
         /// Initializes a new instance of the <see cref="BalancerAddress"/> class with the specified <see cref="DnsEndPoint"/>.
         /// </summary>
         /// <param name="endPoint">The end point.</param>
+        [DebuggerStepThrough]
         public BalancerAddress(DnsEndPoint endPoint)
         {
             EndPoint = endPoint;
@@ -45,6 +47,7 @@ namespace Grpc.Net.Client.Balancer
         /// </summary>
         /// <param name="host">The host.</param>
         /// <param name="port">The port.</param>
+        [DebuggerStepThrough]
         public BalancerAddress(string host, int port) : this(new DnsEndPoint(host, port))
         {
         }

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -76,6 +76,7 @@ namespace Grpc.Net.Client.Balancer
                     {
                         RemoveSubchannel(addressSubchannel.Subchannel);
                     }
+                    _addressSubchannels.Clear();
                     Controller.UpdateState(new BalancerState(ConnectivityState.TransientFailure, new ErrorPicker(status)));
                     break;
             }

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -344,11 +344,7 @@ namespace Grpc.Net.Client.Tests.Balancer
                 LoadBalancingConfigs = { new RoundRobinConfig() }
             };
 
-            var transportFactory = new TestSubchannelTransportFactory(async (_, ct) =>
-            {
-                await Task.Delay(1, ct);
-                return ConnectivityState.Ready;
-            });
+            var transportFactory = new TestSubchannelTransportFactory();
             var clientChannel = CreateConnectionManager(loggerFactory, resolver, transportFactory, new[] { new RoundRobinBalancerFactory() });
             // Configure balancer similar to how GrpcChannel constructor does it
             clientChannel.ConfigureBalancer(c => new ChildHandlerLoadBalancer(
@@ -404,11 +400,7 @@ namespace Grpc.Net.Client.Tests.Balancer
                 LoadBalancingConfigs = { new RoundRobinConfig() }
             };
 
-            var transportFactory = new TestSubchannelTransportFactory(async (_, ct) =>
-            {
-                await Task.Delay(1, ct);
-                return ConnectivityState.Ready;
-            });
+            var transportFactory = new TestSubchannelTransportFactory();
             var clientChannel = CreateConnectionManager(loggerFactory, resolver, transportFactory, new[] { new RoundRobinBalancerFactory() });
             // Configure balancer similar to how GrpcChannel constructor does it
             clientChannel.ConfigureBalancer(c => new ChildHandlerLoadBalancer(


### PR DESCRIPTION
Builds on https://github.com/grpc/grpc-dotnet/pull/1844

@mot256 I investigated your issue, and I think the problem and solution are simpler than your original changes. I think the underlying issue is disposed subchannels are incorrectly left in `_addressSubchannels` when there is a resolver error. Fixing that issue fixes the tests.

Could you test this and see whether the fix works for you?