### PR TITLE
Change nullable GetValueOrDefault to Value

### DIFF
--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\Shared\Server\ServerMethodInvokerBase.cs" Link="Model\Internal\ServerMethodInvokerBase.cs" />
     <Compile Include="..\Shared\Server\ServerStreamingServerMethodInvoker.cs" Link="Model\Internal\ServerStreamingServerMethodInvoker.cs" />
     <Compile Include="..\Shared\Server\UnaryServerMethodInvoker.cs" Link="Model\Internal\UnaryServerMethodInvoker.cs" />
+    <Compile Include="..\Shared\NullableAttributes.cs" Link="Internal\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextSerializationContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextSerializationContext.cs
@@ -19,6 +19,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 using Grpc.Core;
@@ -39,6 +40,7 @@ namespace Grpc.AspNetCore.Server.Internal
 
         public PipeWriter ResponseBufferWriter { get; set; } = default!;
 
+        [MemberNotNullWhen(true, nameof(_payloadLength))]
         private bool DirectSerializationSupported => _compressionProvider == null && _payloadLength != null;
 
         public HttpContextSerializationContext(HttpContextServerCallContext serverCallContext)
@@ -186,7 +188,7 @@ namespace Grpc.AspNetCore.Server.Internal
                     }
                     else
                     {
-                        GrpcServerLog.SerializedMessage(_serverCallContext.Logger, _serverCallContext.ResponseType, _payloadLength.GetValueOrDefault());
+                        GrpcServerLog.SerializedMessage(_serverCallContext.Logger, _serverCallContext.ResponseType, _payloadLength.Value);
                     }
                     break;
                 default:

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextSerializationContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextSerializationContext.cs
@@ -19,7 +19,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 using Grpc.Core;
@@ -40,8 +39,20 @@ namespace Grpc.AspNetCore.Server.Internal
 
         public PipeWriter ResponseBufferWriter { get; set; } = default!;
 
-        [MemberNotNullWhen(true, nameof(_payloadLength))]
-        private bool DirectSerializationSupported => _compressionProvider == null && _payloadLength != null;
+        private bool IsDirectSerializationSupported(out int payloadLength)
+        {
+            // Message can be written directly to the buffer if:
+            // - Its length is known.
+            // - There is no compression.
+            if (_payloadLength != null)
+            {
+                payloadLength = _payloadLength.Value;
+                return _compressionProvider == null;
+            }
+
+            payloadLength = 0;
+            return false;
+        }
 
         public HttpContextSerializationContext(HttpContextServerCallContext serverCallContext)
         {
@@ -132,13 +143,11 @@ namespace Grpc.AspNetCore.Server.Internal
             {
                 case InternalState.Initialized:
                     // When writing directly to the buffer the header with message size needs to be written first
-                    if (DirectSerializationSupported)
+                    if (IsDirectSerializationSupported(out var payloadLength))
                     {
-                        Debug.Assert(_payloadLength != null, "A payload length is required for direct serialization.");
+                        EnsureMessageSizeAllowed(payloadLength);
 
-                        EnsureMessageSizeAllowed(_payloadLength.Value);
-
-                        WriteHeader(ResponseBufferWriter, _payloadLength.Value, compress: false);
+                        WriteHeader(ResponseBufferWriter, payloadLength, compress: false);
                     }
 
                     _state = InternalState.IncompleteBufferWriter;
@@ -153,9 +162,20 @@ namespace Grpc.AspNetCore.Server.Internal
 
         private IBufferWriter<byte> ResolveBufferWriter()
         {
-            return DirectSerializationSupported
-                ? (IBufferWriter<byte>)ResponseBufferWriter
-                : _bufferWriter ??= new ArrayBufferWriter<byte>();
+            if (IsDirectSerializationSupported(out var payloadLength))
+            {
+                return ResponseBufferWriter;
+            }
+            else if (_bufferWriter == null)
+            {
+                // Initialize buffer writer with exact length if available.
+                // ArrayBufferWriter doesn't allow zero initial length.
+                _bufferWriter = payloadLength > 0
+                    ? new ArrayBufferWriter<byte>(payloadLength)
+                    : new ArrayBufferWriter<byte>();
+            }
+
+            return _bufferWriter;
         }
 
         private void EnsureMessageSizeAllowed(int payloadLength)
@@ -177,7 +197,11 @@ namespace Grpc.AspNetCore.Server.Internal
                 case InternalState.IncompleteBufferWriter:
                     _state = InternalState.CompleteBufferWriter;
 
-                    if (!DirectSerializationSupported)
+                    if (IsDirectSerializationSupported(out var payloadLength))
+                    {
+                        GrpcServerLog.SerializedMessage(_serverCallContext.Logger, _serverCallContext.ResponseType, payloadLength);
+                    }
+                    else
                     {
                         Debug.Assert(_bufferWriter != null, "Buffer writer has been set to get to this state.");
 
@@ -185,10 +209,6 @@ namespace Grpc.AspNetCore.Server.Internal
 
                         GrpcServerLog.SerializedMessage(_serverCallContext.Logger, _serverCallContext.ResponseType, data.Length);
                         WriteMessage(data);
-                    }
-                    else
-                    {
-                        GrpcServerLog.SerializedMessage(_serverCallContext.Logger, _serverCallContext.ResponseType, _payloadLength.Value);
                     }
                     break;
                 default:

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -361,7 +361,7 @@ namespace Grpc.AspNetCore.Server.Internal
             }
         }
 
-        private static bool TryReadMessage(ref ReadOnlySequence<byte> buffer, HttpContextServerCallContext context, [NotNullWhen(true)] out ReadOnlySequence<byte> message)
+        private static bool TryReadMessage(ref ReadOnlySequence<byte> buffer, HttpContextServerCallContext context, out ReadOnlySequence<byte> message)
         {
             if (!TryReadHeader(buffer, out var compressed, out var messageLength))
             {

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -219,7 +219,7 @@ namespace Grpc.AspNetCore.Server.Internal
                             if (TryReadMessage(ref buffer, serverCallContext, out var data))
                             {
                                 // Finished and the complete message has arrived
-                                GrpcServerLog.DeserializingMessage(logger, (int)data.GetValueOrDefault().Length, typeof(T));
+                                GrpcServerLog.DeserializingMessage(logger, (int)data.Length, typeof(T));
 
                                 serverCallContext.DeserializationContext.SetPayload(data);
                                 request = deserializer(serverCallContext.DeserializationContext);
@@ -311,7 +311,7 @@ namespace Grpc.AspNetCore.Server.Internal
                             {
                                 completeMessage = true;
 
-                                GrpcServerLog.DeserializingMessage(logger, (int)data.Value.Length, typeof(T));
+                                GrpcServerLog.DeserializingMessage(logger, (int)data.Length, typeof(T));
 
                                 serverCallContext.DeserializationContext.SetPayload(data);
                                 var request = deserializer(serverCallContext.DeserializationContext);
@@ -361,11 +361,11 @@ namespace Grpc.AspNetCore.Server.Internal
             }
         }
 
-        private static bool TryReadMessage(ref ReadOnlySequence<byte> buffer, HttpContextServerCallContext context, [NotNullWhen(true)] out ReadOnlySequence<byte>? message)
+        private static bool TryReadMessage(ref ReadOnlySequence<byte> buffer, HttpContextServerCallContext context, [NotNullWhen(true)] out ReadOnlySequence<byte> message)
         {
             if (!TryReadHeader(buffer, out var compressed, out var messageLength))
             {
-                message = null;
+                message = default;
                 return false;
             }
 
@@ -376,7 +376,7 @@ namespace Grpc.AspNetCore.Server.Internal
 
             if (buffer.Length < HeaderSize + messageLength)
             {
-                message = null;
+                message = default;
                 return false;
             }
 
@@ -429,7 +429,7 @@ namespace Grpc.AspNetCore.Server.Internal
             return true;
         }
 
-        private static bool TryDecompressMessage(ILogger logger, string compressionEncoding, IReadOnlyDictionary<string, ICompressionProvider> compressionProviders, in ReadOnlySequence<byte> messageData, [NotNullWhen(true)] out ReadOnlySequence<byte>? result)
+        private static bool TryDecompressMessage(ILogger logger, string compressionEncoding, IReadOnlyDictionary<string, ICompressionProvider> compressionProviders, in ReadOnlySequence<byte> messageData, out ReadOnlySequence<byte> result)
         {
             if (compressionProviders.TryGetValue(compressionEncoding, out var compressionProvider))
             {
@@ -445,7 +445,7 @@ namespace Grpc.AspNetCore.Server.Internal
                 return true;
             }
 
-            result = null;
+            result = default;
             return false;
         }
     }

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
@@ -66,8 +66,8 @@ namespace Grpc.Net.Client.Web.Internal
                 // to take into account base64 encoding size difference:
                 // Increase length by 4/3, then round up to the next multiple of 4.
                 length = _mode == GrpcWebMode.GrpcWebText
-                    ? ((4 * contentLength.GetValueOrDefault() / 3) + 3) & ~3
-                    : contentLength.GetValueOrDefault();
+                    ? ((4 * contentLength.Value / 3) + 3) & ~3
+                    : contentLength.Value;
                 return true;
             }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -148,13 +148,13 @@ namespace Grpc.Net.Client.Balancer.Internal
                         if (_previousServiceConfig == null)
                         {
                             // Step 4.ii: If no config was provided or set previously, then treat resolution as a failure.
-                            channelStatus = result.ServiceConfigStatus.GetValueOrDefault();
+                            channelStatus = result.ServiceConfigStatus.Value;
                         }
                         else
                         {
                             // Step 4.i: Continue using previous service config if it was set and a new one is not provided.
                             workingServiceConfig = _previousServiceConfig;
-                            ConnectionManagerLog.ResolverServiceConfigFallback(Logger, result.ServiceConfigStatus.GetValueOrDefault());
+                            ConnectionManagerLog.ResolverServiceConfigFallback(Logger, result.ServiceConfigStatus.Value);
                         }
                     }
                 }
@@ -164,7 +164,6 @@ namespace Grpc.Net.Client.Balancer.Internal
                     workingServiceConfig = result.ServiceConfig;
                     _previousServiceConfig = result.ServiceConfig;
                 }
-
 
                 if (workingServiceConfig?.LoadBalancingConfigs.Count > 0)
                 {

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -138,11 +138,11 @@ namespace Grpc.Net.Client.Balancer
                 if (i != null)
                 {
                     // There is a match so take current subchannel.
-                    newOrCurrentSubchannel = currentSubchannels[i.GetValueOrDefault()];
+                    newOrCurrentSubchannel = currentSubchannels[i.Value];
 
                     // Remove from current collection because any subchannels
                     // remaining in this collection at the end will be disposed.
-                    currentSubchannels.RemoveAt(i.GetValueOrDefault());
+                    currentSubchannels.RemoveAt(i.Value);
 
                     SubchannelLog.SubchannelPreserved(_logger, newOrCurrentSubchannel.Subchannel.Id, address);
                 }

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -345,7 +345,7 @@ namespace Grpc.Net.Client
                 throw CreateException(RetryThrottlingPolicy.TokenRatioPropertyName);
             }
 
-            return new ChannelRetryThrottling(retryThrottling.MaxTokens.GetValueOrDefault(), retryThrottling.TokenRatio.GetValueOrDefault(), LoggerFactory);
+            return new ChannelRetryThrottling(retryThrottling.MaxTokens.Value, retryThrottling.TokenRatio.Value, LoggerFactory);
 
             static InvalidOperationException CreateException(string propertyName)
             {

--- a/src/Grpc.Net.Client/Internal/Configuration/ConvertHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/Configuration/ConvertHelpers.cs
@@ -121,7 +121,7 @@ namespace Grpc.Net.Client.Internal.Configuration
 
             // This format is based on the Protobuf duration's JSON mapping.
             // https://github.com/protocolbuffers/protobuf/blob/35bdcabdd6a05ce9ee738ad7df8c1299d9c7fc4b/src/google/protobuf/duration.proto#L92
-            return value.GetValueOrDefault().TotalSeconds.ToString(CultureInfo.InvariantCulture) + "s";
+            return value.Value.TotalSeconds.ToString(CultureInfo.InvariantCulture) + "s";
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
@@ -18,6 +18,7 @@
 
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using Grpc.Core;
@@ -35,6 +36,7 @@ namespace Grpc.Net.Client.Internal
         private int? _payloadLength;
         private ICompressionProvider? _compressionProvider;
 
+        [MemberNotNullWhen(true, nameof(_payloadLength))]
         private bool DirectSerializationSupported => _compressionProvider == null && _payloadLength != null;
 
         private ArrayBufferWriter<byte>? _bufferWriter;
@@ -198,7 +200,7 @@ namespace Grpc.Net.Client.Internal
             {
                 if (_buffer == null)
                 {
-                    _buffer = ArrayPool<byte>.Shared.Rent(GrpcProtocolConstants.HeaderSize + _payloadLength.GetValueOrDefault());
+                    _buffer = ArrayPool<byte>.Shared.Rent(GrpcProtocolConstants.HeaderSize + _payloadLength.Value);
                 }
 
                 return this;
@@ -208,7 +210,7 @@ namespace Grpc.Net.Client.Internal
                 // Initialize buffer writer with exact length if available.
                 // ArrayBufferWriter doesn't allow zero initial length.
                 _bufferWriter = _payloadLength > 0
-                    ? new ArrayBufferWriter<byte>(_payloadLength.GetValueOrDefault())
+                    ? new ArrayBufferWriter<byte>(_payloadLength.Value)
                     : new ArrayBufferWriter<byte>();
             }
 
@@ -245,7 +247,7 @@ namespace Grpc.Net.Client.Internal
                     }
                     else
                     {
-                        GrpcCallLog.SerializedMessage(_call.Logger, _call.RequestType, _payloadLength.GetValueOrDefault());
+                        GrpcCallLog.SerializedMessage(_call.Logger, _call.RequestType, _payloadLength.Value);
                     }
                     break;
                 default:

--- a/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallSerializationContext.cs
@@ -18,7 +18,6 @@
 
 using System.Buffers;
 using System.Buffers.Binary;
-using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using Grpc.Core;
@@ -36,8 +35,20 @@ namespace Grpc.Net.Client.Internal
         private int? _payloadLength;
         private ICompressionProvider? _compressionProvider;
 
-        [MemberNotNullWhen(true, nameof(_payloadLength))]
-        private bool DirectSerializationSupported => _compressionProvider == null && _payloadLength != null;
+        private bool IsDirectSerializationSupported(out int payloadLength)
+        {
+            // Message can be written directly to the buffer if:
+            // - Its length is known.
+            // - There is no compression.
+            if (_payloadLength != null)
+            {
+                payloadLength = _payloadLength.Value;
+                return _compressionProvider == null;
+            }
+
+            payloadLength = 0;
+            return false;
+        }
 
         private ArrayBufferWriter<byte>? _bufferWriter;
         private byte[]? _buffer;
@@ -174,13 +185,11 @@ namespace Grpc.Net.Client.Internal
                     var bufferWriter = ResolveBufferWriter();
 
                     // When writing directly to the buffer the header with message size needs to be written first
-                    if (DirectSerializationSupported)
+                    if (IsDirectSerializationSupported(out var payloadLength))
                     {
-                        CompatibilityHelpers.Assert(_payloadLength != null, "A payload length is required for direct serialization.");
+                        EnsureMessageSizeAllowed(payloadLength);
 
-                        EnsureMessageSizeAllowed(_payloadLength.Value);
-
-                        WriteHeader(_buffer, _payloadLength.Value, compress: false);
+                        WriteHeader(_buffer, payloadLength, compress: false);
                         _bufferPosition += GrpcProtocolConstants.HeaderSize;
                     }
 
@@ -196,11 +205,11 @@ namespace Grpc.Net.Client.Internal
 
         private IBufferWriter<byte> ResolveBufferWriter()
         {
-            if (DirectSerializationSupported)
+            if (IsDirectSerializationSupported(out var payloadLength))
             {
                 if (_buffer == null)
                 {
-                    _buffer = ArrayPool<byte>.Shared.Rent(GrpcProtocolConstants.HeaderSize + _payloadLength.Value);
+                    _buffer = ArrayPool<byte>.Shared.Rent(GrpcProtocolConstants.HeaderSize + payloadLength);
                 }
 
                 return this;
@@ -209,8 +218,8 @@ namespace Grpc.Net.Client.Internal
             {
                 // Initialize buffer writer with exact length if available.
                 // ArrayBufferWriter doesn't allow zero initial length.
-                _bufferWriter = _payloadLength > 0
-                    ? new ArrayBufferWriter<byte>(_payloadLength.Value)
+                _bufferWriter = payloadLength > 0
+                    ? new ArrayBufferWriter<byte>(payloadLength)
                     : new ArrayBufferWriter<byte>();
             }
 
@@ -236,7 +245,11 @@ namespace Grpc.Net.Client.Internal
                 case InternalState.IncompleteBufferWriter:
                     _state = InternalState.CompleteBufferWriter;
 
-                    if (!DirectSerializationSupported)
+                    if (IsDirectSerializationSupported(out var payloadLength))
+                    {
+                        GrpcCallLog.SerializedMessage(_call.Logger, _call.RequestType, payloadLength);
+                    }
+                    else
                     {
                         CompatibilityHelpers.Assert(_bufferWriter != null, "Buffer writer has been set to get to this state.");
 
@@ -244,10 +257,6 @@ namespace Grpc.Net.Client.Internal
 
                         GrpcCallLog.SerializedMessage(_call.Logger, _call.RequestType, data.Length);
                         WriteMessage(data);
-                    }
-                    else
-                    {
-                        GrpcCallLog.SerializedMessage(_call.Logger, _call.RequestType, _payloadLength.Value);
                     }
                     break;
                 default:

--- a/src/Grpc.Net.Client/Internal/GrpcMethodInfo.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcMethodInfo.cs
@@ -84,10 +84,10 @@ namespace Grpc.Net.Client.Internal
 
             return new RetryPolicyInfo
             {
-                MaxAttempts = r.MaxAttempts.GetValueOrDefault(),
-                InitialBackoff = r.InitialBackoff.GetValueOrDefault(),
-                MaxBackoff = r.MaxBackoff.GetValueOrDefault(),
-                BackoffMultiplier = r.BackoffMultiplier.GetValueOrDefault(),
+                MaxAttempts = r.MaxAttempts.Value,
+                InitialBackoff = r.InitialBackoff.Value,
+                MaxBackoff = r.MaxBackoff.Value,
+                BackoffMultiplier = r.BackoffMultiplier.Value,
                 RetryableStatusCodes = r.RetryableStatusCodes.ToList()
             };
         }
@@ -105,8 +105,8 @@ namespace Grpc.Net.Client.Internal
 
             return new HedgingPolicyInfo
             {
-                MaxAttempts = h.MaxAttempts.GetValueOrDefault(),
-                HedgingDelay = h.HedgingDelay.GetValueOrDefault(),
+                MaxAttempts = h.MaxAttempts.Value,
+                HedgingDelay = h.HedgingDelay ?? TimeSpan.Zero,
                 NonFatalStatusCodes = h.NonFatalStatusCodes.ToList()
             };
         }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -559,7 +559,7 @@ namespace Grpc.Net.Client.Internal
             var exceptionMessage = CommonGrpcProtocolHelpers.ConvertToRpcExceptionMessage(ex);
             statusCode ??= ResolveRpcExceptionStatusCode(ex);
 
-            return new Status(statusCode.GetValueOrDefault(), summary + " " + exceptionMessage, ex);
+            return new Status(statusCode.Value, summary + " " + exceptionMessage, ex);
         }
     }
 }

--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -175,7 +175,7 @@ namespace Grpc.Net.Client.Internal.Retry
                             {
                                 if (retryPushbackMS >= 0)
                                 {
-                                    _pushbackDelay = TimeSpan.FromMilliseconds(retryPushbackMS.GetValueOrDefault());
+                                    _pushbackDelay = TimeSpan.FromMilliseconds(retryPushbackMS.Value);
                                 }
                                 _delayInterruptTcs.TrySetResult(null);
                             }
@@ -348,7 +348,7 @@ namespace Grpc.Net.Client.Internal.Retry
                     if (_pushbackDelay != null)
                     {
                         // Use pushback value and delay again
-                        hedgingDelay = _pushbackDelay.GetValueOrDefault();
+                        hedgingDelay = _pushbackDelay.Value;
 
                         _pushbackDelay = null;
                     }
@@ -426,7 +426,7 @@ namespace Grpc.Net.Client.Internal.Retry
                         if (c.TryRegisterCancellation(cancellationToken, out var registration))
                         {
                             registrations ??= new List<CancellationTokenRegistration>(calls.Count);
-                            registrations.Add(registration.GetValueOrDefault());
+                            registrations.Add(registration.Value);
                         }
 
                         var writeTask = c.WriteClientStreamAsync(WriteNewMessage, message);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -161,7 +161,7 @@ namespace Grpc.Net.Client.Internal.Retry
                         CommitCall(currentCall, CommitReason.ResponseHeadersReceived);
 
                         responseStatus = await currentCall.CallTask.ConfigureAwait(false);
-                        if (responseStatus.GetValueOrDefault().StatusCode == StatusCode.OK)
+                        if (responseStatus.Value.StatusCode == StatusCode.OK)
                         {
                             RetryAttemptCallSuccess();
                         }
@@ -169,7 +169,7 @@ namespace Grpc.Net.Client.Internal.Retry
                         // Commited so exit retry loop.
                         return;
                     }
-                    else if (IsSuccessfulStreamingCall(responseStatus.GetValueOrDefault(), currentCall))
+                    else if (IsSuccessfulStreamingCall(responseStatus.Value, currentCall))
                     {
                         // Headers were returned. We're commited.
                         CommitCall(currentCall, CommitReason.ResponseHeadersReceived);
@@ -186,7 +186,7 @@ namespace Grpc.Net.Client.Internal.Retry
                         return;
                     }
 
-                    var status = responseStatus.GetValueOrDefault();
+                    var status = responseStatus.Value;
                     var retryPushbackMS = GetRetryPushback(httpResponse);
 
                     // Failures only count towards retry throttling if they have a known, retriable status.
@@ -205,8 +205,8 @@ namespace Grpc.Net.Client.Internal.Retry
                         TimeSpan delayDuration;
                         if (retryPushbackMS != null)
                         {
-                            delayDuration = TimeSpan.FromMilliseconds(retryPushbackMS.GetValueOrDefault());
-                            _nextRetryDelayMilliseconds = retryPushbackMS.GetValueOrDefault();
+                            delayDuration = TimeSpan.FromMilliseconds(retryPushbackMS.Value);
+                            _nextRetryDelayMilliseconds = retryPushbackMS.Value;
                         }
                         else
                         {
@@ -234,7 +234,7 @@ namespace Grpc.Net.Client.Internal.Retry
 
                         // Can't retry.
                         // Signal public API exceptions that they should finish throwing and then exit the retry loop.
-                        CommitCall(resolvedCall, result.GetValueOrDefault());
+                        CommitCall(resolvedCall, result.Value);
                         return;
                     }
                 }

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -82,7 +82,7 @@ namespace Grpc.Net.Client.Internal.Retry
                 _ctsRegistration = RegisterRetryCancellationToken(options.CancellationToken);
             }
 
-            var deadline = Options.Deadline.GetValueOrDefault(DateTime.MaxValue);
+            var deadline = Options.Deadline ?? DateTime.MaxValue;
             if (deadline != DateTime.MaxValue)
             {
                 var timeout = CommonGrpcProtocolHelpers.GetTimerDueTime(deadline - Channel.Clock.UtcNow, Channel.MaxTimerDueTime);
@@ -97,8 +97,8 @@ namespace Grpc.Net.Client.Internal.Retry
 
             if (retryAttempts > Channel.MaxRetryAttempts)
             {
-                Log.MaxAttemptsLimited(Logger, retryAttempts, Channel.MaxRetryAttempts.GetValueOrDefault());
-                MaxRetryAttempts = Channel.MaxRetryAttempts.GetValueOrDefault();
+                Log.MaxAttemptsLimited(Logger, retryAttempts, Channel.MaxRetryAttempts.Value);
+                MaxRetryAttempts = Channel.MaxRetryAttempts.Value;
             }
             else
             {

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -82,7 +82,7 @@ namespace Grpc.Net.Client.Internal.Retry
                 _ctsRegistration = RegisterRetryCancellationToken(options.CancellationToken);
             }
 
-            var deadline = Options.Deadline ?? DateTime.MaxValue;
+            var deadline = Options.Deadline.GetValueOrDefault(DateTime.MaxValue);
             if (deadline != DateTime.MaxValue)
             {
                 var timeout = CommonGrpcProtocolHelpers.GetTimerDueTime(deadline - Channel.Clock.UtcNow, Channel.MaxTimerDueTime);

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -136,7 +136,7 @@ namespace Grpc.Net.Client
                         throw call.CreateRpcException(CreateUnknownMessageEncodingMessageStatus(grpcEncoding, supportedEncodings));
                     }
 
-                    payload = decompressedMessage.GetValueOrDefault();
+                    payload = decompressedMessage;
                 }
                 else
                 {
@@ -248,7 +248,7 @@ namespace Grpc.Net.Client
             }
         }
 
-        private static bool TryDecompressMessage(ILogger logger, string compressionEncoding, Dictionary<string, ICompressionProvider> compressionProviders, byte[] messageData, int length, [NotNullWhen(true)] out ReadOnlySequence<byte>? result)
+        private static bool TryDecompressMessage(ILogger logger, string compressionEncoding, Dictionary<string, ICompressionProvider> compressionProviders, byte[] messageData, int length, out ReadOnlySequence<byte> result)
         {
             if (compressionProviders.TryGetValue(compressionEncoding, out var compressionProvider))
             {
@@ -264,7 +264,7 @@ namespace Grpc.Net.Client
                 return true;
             }
 
-            result = null;
+            result = default;
             return false;
         }
 

--- a/src/Shared/NullableAttributes.cs
+++ b/src/Shared/NullableAttributes.cs
@@ -83,7 +83,7 @@ namespace System.Diagnostics.CodeAnalysis
 
 #endif
 
-#if NETSTANDARD2_0 || NETSTANDARD2_1
+#if NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_0
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     internal sealed class MemberNotNullWhenAttribute : Attribute

--- a/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Buffers;
 using System.Buffers.Binary;
 using Grpc.Core;
 using Grpc.Net.Client.Internal;
@@ -163,6 +164,11 @@ namespace Grpc.Net.Client.Tests
             // Act
             serializationContext.SetPayloadLength(1);
             var bufferWriter = serializationContext.GetBufferWriter();
+
+            Assert.AreEqual(1, ((ArrayBufferWriter<byte>)bufferWriter).Capacity);
+            Assert.AreEqual(1, ((ArrayBufferWriter<byte>)bufferWriter).FreeCapacity);
+            Assert.AreEqual(0, ((ArrayBufferWriter<byte>)bufferWriter).WrittenSpan.Length);
+
             var span = bufferWriter.GetSpan(3);
             span[0] = byte.MaxValue;
             bufferWriter.Advance(3);


### PR DESCRIPTION
`GetValueOrDefault` was used to avoid null check in [`Nullable<T>.Value`](https://github.com/dotnet/runtime/blob/5958eeb8a0ace432005c4e9fa47e14114e032688/src/libraries/System.Private.CoreLib/src/System/Nullable.cs#L36-L46). JIT in .NET 5/6/7 optimizes this away.

There probably is a very small perf hit on older platforms (.NET Framework/.NET Core 3), but IMO the easier-to-read and safer code is better.