### PR TITLE
Fix using disposed token in connect and resulting status

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ErrorPicker.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ErrorPicker.cs
@@ -18,6 +18,7 @@
 
 #if SUPPORT_LOAD_BALANCING
 using System;
+using System.Diagnostics;
 using Grpc.Core;
 
 namespace Grpc.Net.Client.Balancer.Internal
@@ -28,6 +29,7 @@ namespace Grpc.Net.Client.Balancer.Internal
 
         public ErrorPicker(Status status)
         {
+            Debug.Assert(status.StatusCode != StatusCode.OK, "Error status code must not be OK.");
             _status = status;
         }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
@@ -46,6 +46,7 @@ namespace Grpc.Net.Client.Balancer.Internal
     internal sealed class ConnectContext
     {
         private readonly CancellationTokenSource _cts;
+        private readonly CancellationToken _token;
         private bool _disposed;
 
         // This flag allows the transport to determine why the cancellation token was canceled.
@@ -53,11 +54,14 @@ namespace Grpc.Net.Client.Balancer.Internal
         // - Connection timeout, e.g. SocketsHttpHandler.ConnectTimeout was exceeded.
         public bool IsConnectCanceled { get; private set; }
 
-        public CancellationToken CancellationToken => _cts.Token;
+        public CancellationToken CancellationToken => _token;
 
         public ConnectContext(TimeSpan connectTimeout)
         {
             _cts = new CancellationTokenSource(connectTimeout);
+
+            // Take a copy of the token to avoid ObjectDisposedException when accessing _cts.Token after CTS is disposed.
+            _token = _cts.Token;
         }
 
         public void CancelConnect()

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -313,7 +313,7 @@ namespace Grpc.Net.Client.Balancer
             {
                 SubchannelLog.ConnectError(_logger, Id, ex);
 
-                UpdateConnectivityState(ConnectivityState.TransientFailure, "Error connecting to subchannel.");
+                UpdateConnectivityState(ConnectivityState.TransientFailure, new Status(StatusCode.Unavailable, "Error connecting to subchannel.", ex));
             }
             finally
             {

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -626,6 +626,7 @@ namespace Grpc.Net.Client.Tests
             var currentConnectivityState = ConnectivityState.TransientFailure;
 
             var services = new ServiceCollection();
+            services.AddNUnitLogger();
             services.AddSingleton<ResolverFactory, ChannelTestResolverFactory>();
             services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory(async (s, c) =>
             {

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
@@ -81,7 +81,8 @@ namespace Grpc.Net.Client.Tests.Infrastructure.Balancer
             var newState = await (_onTryConnect?.Invoke(context.CancellationToken) ?? Task.FromResult(ConnectivityState.Ready));
 
             CurrentAddress = Subchannel._addresses[0];
-            Subchannel.UpdateConnectivityState(newState, Status.DefaultSuccess);
+            var newStatus = newState == ConnectivityState.TransientFailure ? new Status(StatusCode.Internal, "") : Status.DefaultSuccess;
+            Subchannel.UpdateConnectivityState(newState, newStatus);
 
             _connectTcs.TrySetResult(null);
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1870

Two bugs:
* If a connect is in progress when the context is disposed then the next time the cancellation token is accessed an error will get thrown. Take a copy of the cancellation token to avoid this error.
* The subchannel connectivity state updates to TransientFailure when this error happens. The problem is the status is incorrectly reported as OK. Fixed by using the right overload.