### PR TITLE
Fix race condition in flaky test

### DIFF
--- a/test/Grpc.Net.Client.Tests/Retry/HedgingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/HedgingCallTests.cs
@@ -333,7 +333,9 @@ namespace Grpc.Net.Client.Tests.Retry
             var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => hedgingCall.GetResponseAsync()).DefaultTimeout();
             Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
             Assert.AreEqual("Call canceled by the client.", ex.Status.Detail);
-            Assert.IsNull(hedgingCall._ctsRegistration);
+
+            // There is a race between unregistering and GetResponseAsync returning.
+            await TestHelpers.AssertIsTrueRetryAsync(() => hedgingCall._ctsRegistration == null, "Hedge call CTS unregistered.");
         }
 
         [Test]


### PR DESCRIPTION
Fixes:

```
  Failed AsyncUnaryCall_CancellationDuringBackoff_CanceledStatus [27 ms]
  Error Message:
     Expected: null
  But was:  System.Threading.CancellationTokenRegistration

  Stack Trace:
     at Grpc.Net.Client.Tests.Retry.HedgingCallTests.AsyncUnaryCall_CancellationDuringBackoff_CanceledStatus() in /home/runner/work/grpc-dotnet/grpc-dotnet/test/Grpc.Net.Client.Tests/Retry/HedgingCallTests.cs:line 336
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Execution.SimpleWorkItem.<>c__DisplayClass4_0.<PerformWork>b__0()
   at NUnit.Framework.Internal.ContextUtils.<>c__DisplayClass1_0`1.<DoIsolated>b__0(Object _)
```