### PR TITLE
Fix ObjectDisposedException throw in PollingResolver.Refresh() method

### DIFF
--- a/src/Grpc.Net.Client/Balancer/PollingResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/PollingResolver.cs
@@ -129,7 +129,7 @@ namespace Grpc.Net.Client.Balancer
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(DnsResolver));
+                throw new ObjectDisposedException(GetType().Name);
             }
             if (_listener == null)
             {


### PR DESCRIPTION
Us the name of the class extending PollingResolver when throwing the ObjectDisposedException in the PollingResolver.Refresh() method instead of DnsResolver.