### PR TITLE
Use the extending class name when throwing ObjectDisposedException

### DIFF
--- a/src/Grpc.Net.Client/Balancer/PollingResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/PollingResolver.cs
@@ -129,7 +129,7 @@ namespace Grpc.Net.Client.Balancer
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(DnsResolver));
+                throw new ObjectDisposedException(GetType().Name);
             }
             if (_listener == null)
             {


### PR DESCRIPTION
Don't use the DnsResolver class name but the extending class name when throwing the ObjectDisposedException in the PollingResolver.Resolve() method