### PR TITLE
Fix grpc benchmark cancellation

### DIFF
--- a/perf/benchmarkapps/GrpcClient/Program.cs
+++ b/perf/benchmarkapps/GrpcClient/Program.cs
@@ -639,7 +639,7 @@ class Program
 
         var client = new BenchmarkService.BenchmarkServiceClient(_channels[connectionId]);
         var callOptions = CreateCallOptions();
-        callOptions.WithCancellationToken(cts.Token);
+        callOptions = callOptions.WithCancellationToken(cts.Token);
         using var call = client.StreamingFromServer(CreateSimpleRequest(), callOptions);
 
         while (!cts.IsCancellationRequested)


### PR DESCRIPTION
Methods on `CallOptions` return a new instance of the options struct.