### PR TITLE
Fix build failure on benchmark server

### DIFF
--- a/src/Grpc.Core.Api/AuthContext.cs
+++ b/src/Grpc.Core.Api/AuthContext.cs
@@ -101,7 +101,7 @@ public class AuthContext
     /// </summary>
     public IEnumerable<AuthProperty> FindPropertiesByName(string propertyName)
     {
-        List<AuthProperty> result;
+        List<AuthProperty>? result;
         if (!properties.TryGetValue(propertyName, out result))
         {
             return Enumerable.Empty<AuthProperty>();

--- a/src/Grpc.Core.Api/Internal/CodeAnalysisAttributes.cs
+++ b/src/Grpc.Core.Api/Internal/CodeAnalysisAttributes.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+#if !NET5_0_OR_GREATER
+
 // Content of this file is copied with permission from:
 // https://github.com/dotnet/runtime/tree/e2e43f44f1032780fa7c2bb965153c9da615c3d0/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis
 // These types are intented to be added as internalized source to libraries and apps that want to
@@ -148,3 +150,5 @@ internal enum DynamicallyAccessedMemberTypes
     /// </summary>
     All = ~None
 }
+
+#endif

--- a/src/Grpc.Core.Api/Metadata.cs
+++ b/src/Grpc.Core.Api/Metadata.cs
@@ -338,7 +338,7 @@ public sealed class Metadata : IList<Metadata.Entry>
             {
                 if (valueBytes == null)
                 {
-                    return EncodingASCII.GetBytes(value);
+                    return EncodingASCII.GetBytes(value!);
                 }
 
                 // defensive copy to guarantee immutability
@@ -391,7 +391,7 @@ public sealed class Metadata : IList<Metadata.Entry>
         /// </summary>
         internal byte[] GetSerializedValueUnsafe()
         {
-            return valueBytes ?? EncodingASCII.GetBytes(value);
+            return valueBytes ?? EncodingASCII.GetBytes(value!);
         }
 
         internal bool KeyEqualsIgnoreCase(string key)


### PR DESCRIPTION
For some reason, the Grpc.Core.Api project is being built targeting .NET 7. This only happens on Linux.

These are useful changes to make because Grpc.Core.Api will target a new version of .NET at some point. Still, I'm confused why build has started behaving this way. Bug in 8.0 alpha SDK? 🤷 

https://dev.azure.com/dnceng/internal/_build/results?buildId=2020161&view=logs&j=c8217af0-de7d-5e68-361c-a1e6c44be6a1&t=08f9ece3-b1e6-51ce-7219-b24eb80cfd7d


```
============================================================================== 
Task         : h2c ASP.NET Core - Client: h2load Streams: 1
Description  : Sends a message to Azure Service Bus using a service connection (no agent is required)
Version      : 1.198.0
Author       : Microsoft Corporation
Help URL     : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/publish-to-azure-service-bus
============================================================================== 
[12:41:02.291] Running session '20221013.2' with description ''
[12:41:02.365] Starting job 'application' ...
[12:41:02.368] Submitted job: http://asp-citrine-win:5001/jobs/352
[12:41:03.403] 'application' has been selected by the server ...
[12:41:03.404] 'application' is now building ... http://asp-citrine-win:5001/jobs/352/buildlog
[12:41:14.442] 'application' failed on agent, stopping...

Command:
dotnet publish GrpcAspNetCoreServer.csproj -c Release -o C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\published /p:MicrosoftNETCoreAppPackageVersion=7.0.0-rtm.22511.4 /p:MicrosoftAspNetCoreAppPackageVersion=7.0.0-rtm.22513.3 /p:MicrosoftWindowsDesktopAppPackageVersion=7.0.0-rc.1.22427.1 /p:MicrosoftNETCoreApp50PackageVersion=7.0.0-rtm.22511.4 /p:GenerateErrorForMissingTargetingPacks=false /p:MicrosoftNETPlatformLibrary=Microsoft.NETCore.App /p:RestoreNoCache=true --framework net7.0 --self-contained -r win-x64 
MSBuild version 17.5.0-preview-22511-01+a440ea9cf for .NET
  Determining projects to restore...
  Restored C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Net.Common\Grpc.Net.Common.csproj (in 1.76 sec).
  Restored C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj (in 1.76 sec).
  Restored C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\perf\benchmarkapps\GrpcAspNetCoreServer\GrpcAspNetCoreServer.csproj (in 1.76 sec).
  Restored C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj (in 2.49 sec).
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\BindServiceMethodAttribute.cs(36,19): error CS0436: The type 'DynamicallyAccessedMemberTypes' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMemberTypes' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs(64,12): error CS0436: The type 'DynamicallyAccessedMemberTypes' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMemberTypes' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs(55,48): error CS0436: The type 'DynamicallyAccessedMemberTypes' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMemberTypes' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\BindServiceMethodAttribute.cs(36,79): error CS0436: The type 'DynamicallyAccessedMemberTypes' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMemberTypes' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\BindServiceMethodAttribute.cs(36,126): error CS0436: The type 'DynamicallyAccessedMemberTypes' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMemberTypes' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\BindServiceMethodAttribute.cs(36,176): error CS0436: The type 'DynamicallyAccessedMemberTypes' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMemberTypes' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\BindServiceMethodAttribute.cs(43,40): error CS0436: The type 'DynamicallyAccessedMembersAttribute' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMembersAttribute' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\BindServiceMethodAttribute.cs(52,6): error CS0436: The type 'DynamicallyAccessedMembersAttribute' in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs' conflicts with the imported type 'DynamicallyAccessedMembersAttribute' in 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in 'C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Internal\CodeAnalysisAttributes.cs'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\AuthContext.cs(105,55): error CS8600: Converting null literal or possible null value to non-nullable type. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Metadata.cs(341,51): error CS8604: Possible null reference argument for parameter 's' in 'byte[] Encoding.GetBytes(string s)'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Metadata.cs(394,57): error CS8604: Possible null reference argument for parameter 's' in 'byte[] Encoding.GetBytes(string s)'. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-8932\topzn1ke.bay\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=net7.0]
Exit code: 1

[12:41:14.453] Job has failed, interrupting benchmarks ...
[12:41:14.457] Stopping job 'application' ...
[12:41:15.483] Deleting job 'application' ...

| application           |                           |   |
| --------------------- | ------------------------- | - |
| .NET Core SDK Version | 8.0.100-alpha.1.22513.16  |   |
| ASP.NET Core Version  | 7.0.0-rtm.22513.3+c627886 |   |
| .NET Runtime Version  | 7.0.0-rtm.22511.4+d25158d |   |
```