### PR TITLE
Upgrade dotnet-grpc dependencies

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,19 +6,18 @@
     <GrpcDotNetPackageVersion>2.47.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.46.5</GrpcPackageVersion>
     <GrpcToolsPackageVersion>2.49.0</GrpcToolsPackageVersion>
-    <MicrosoftAspNetCoreAppPackageVersion>7.0.0-preview.6.22327.7</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>7.0.0-rc.2.22476.2</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp6PackageVersion>6.0.0</MicrosoftAspNetCoreApp6PackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>
     <MicrosoftAspNetCoreApp31PackageVersion>3.1.3</MicrosoftAspNetCoreApp31PackageVersion>
-    <MicrosoftBuildLocatorPackageVersion>1.2.2</MicrosoftBuildLocatorPackageVersion>
-    <MicrosoftBuildPackageVersion>16.0.461</MicrosoftBuildPackageVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersPackageVersion>7.0.0-preview1.22310.1</MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
+    <MicrosoftBuildLocatorPackageVersion>1.5.5</MicrosoftBuildLocatorPackageVersion>
+    <MicrosoftBuildPackageVersion>16.9.0</MicrosoftBuildPackageVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersPackageVersion>7.0.0-preview1.22464.1</MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
     <MicrosoftCrankEventSourcesPackageVersion>0.2.0-alpha.21255.1</MicrosoftCrankEventSourcesPackageVersion>
     <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.1</MicrosoftExtensionsLoggingTestingPackageVersion>
     <MicrosoftExtensionsPackageVersion>3.0.3</MicrosoftExtensionsPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>16.9.1</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>1.0.0</MicrosoftSourceLinkGitHubPackageVersion>
-    <MicrosoftTyePackageVersion>0.5.0-alpha.20555.1</MicrosoftTyePackageVersion>
     <MicrosoftWin32RegistryLinePackageVersion>4.6.0</MicrosoftWin32RegistryLinePackageVersion>
     <MoqPackageVersion>4.16.1</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.3</NewtonsoftJsonPackageVersion>
@@ -27,13 +26,13 @@
     <OpenTelemetryPackageVersion>1.3.0</OpenTelemetryPackageVersion>
     <OpenTelemetryIntergationPackageVersion>1.0.0-rc9.4</OpenTelemetryIntergationPackageVersion>
     <ProtobufNetGrpcPackageVersion>1.0.140</ProtobufNetGrpcPackageVersion>
-    <SystemCommandLinePackageVersion>2.0.0-beta3.22114.1</SystemCommandLinePackageVersion>
-    <SystemCommandLineRenderingPackageVersion>0.4.0-alpha.22114.1</SystemCommandLineRenderingPackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-beta4.22272.1</SystemCommandLinePackageVersion>
+    <SystemCommandLineRenderingPackageVersion>0.4.0-alpha.22272.1</SystemCommandLineRenderingPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemIOPipelinesPackageVersion>5.0.1</SystemIOPipelinesPackageVersion>
     <SystemMemoryPackageVersion>4.5.3</SystemMemoryPackageVersion>
     <SystemNetHttpWinHttpHandlerPackageVersion>6.0.1</SystemNetHttpWinHttpHandlerPackageVersion>
-    <SystemSecurityPrincipalWindowsPackageVersion>4.6.0</SystemSecurityPrincipalWindowsPackageVersion>
+    <SystemSecurityPrincipalWindowsPackageVersion>4.7.0</SystemSecurityPrincipalWindowsPackageVersion>
     <SystemThreadingChannelsPackageVersion>4.6.0</SystemThreadingChannelsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using Grpc.Dotnet.Cli.Internal;
@@ -53,23 +54,29 @@ internal class AddFileCommand : CommandBase
         command.AddOption(additionalImportDirsOption);
         command.AddArgument(filesArgument);
 
-        command.SetHandler<string, Services, Access, string?, string[], InvocationContext, IConsole>(
-            async (project, services, access, additionalImportDirs, files, context, console) =>
+        command.SetHandler(
+            async (context) =>
             {
+                var project = context.ParseResult.GetValueForOption(projectOption);
+                var services = context.ParseResult.GetValueForOption(serviceOption);
+                var access = context.ParseResult.GetValueForOption(accessOption);
+                var additionalImportDirs = context.ParseResult.GetValueForOption(additionalImportDirsOption);
+                var files = context.ParseResult.GetValueForArgument(filesArgument);
+
                 try
                 {
-                    var command = new AddFileCommand(console, project, httpClient);
+                    var command = new AddFileCommand(context.Console, project, httpClient);
                     await command.AddFileAsync(services, access, additionalImportDirs, files);
 
                     context.ExitCode = 0;
                 }
                 catch (CLIToolException e)
                 {
-                    console.LogError(e);
+                    context.Console.LogError(e);
 
                     context.ExitCode = -1;
                 }
-            }, projectOption, serviceOption, accessOption, additionalImportDirsOption, filesArgument);
+            });
 
         return command;
     }

--- a/src/dotnet-grpc/Commands/AddUrlCommand.cs
+++ b/src/dotnet-grpc/Commands/AddUrlCommand.cs
@@ -60,9 +60,16 @@ internal class AddUrlCommand : CommandBase
         command.AddOption(accessOption);
         command.AddArgument(urlArgument);
 
-        command.SetHandler<string, Services, Access, string?, string, string, InvocationContext, IConsole>(
-            async (project, services, access, additionalImportDirs, url, output, context, console) =>
+        command.SetHandler(
+            async (context) =>
             {
+                var project = context.ParseResult.GetValueForOption(projectOption);
+                var services = context.ParseResult.GetValueForOption(serviceOption);
+                var access = context.ParseResult.GetValueForOption(accessOption);
+                var additionalImportDirs = context.ParseResult.GetValueForOption(additionalImportDirsOption);
+                var output = context.ParseResult.GetValueForOption(outputOption);
+                var url = context.ParseResult.GetValueForArgument(urlArgument);
+
                 try
                 {
                     if (string.IsNullOrEmpty(output))
@@ -70,18 +77,18 @@ internal class AddUrlCommand : CommandBase
                         throw new CLIToolException(CoreStrings.ErrorNoOutputProvided);
                     }
 
-                    var command = new AddUrlCommand(console, project, httpClient);
+                    var command = new AddUrlCommand(context.Console, project, httpClient);
                     await command.AddUrlAsync(services, access, additionalImportDirs, url, output);
 
                     context.ExitCode = 0;
                 }
                 catch (CLIToolException e)
                 {
-                    console.LogError(e);
+                    context.Console.LogError(e);
 
                     context.ExitCode = -1;
                 }
-            }, projectOption, serviceOption, accessOption, additionalImportDirsOption, urlArgument, outputOption);
+            });
 
         return command;
     }

--- a/src/dotnet-grpc/Commands/ListCommand.cs
+++ b/src/dotnet-grpc/Commands/ListCommand.cs
@@ -41,23 +41,24 @@ internal class ListCommand : CommandBase
 
         command.AddOption(projectOption);
 
-        command.SetHandler<string, InvocationContext, IConsole>(
-            (project, context, console) =>
+        command.SetHandler(
+            (context) =>
             {
+                var project = context.ParseResult.GetValueForOption(projectOption);
                 try
                 {
-                    var command = new ListCommand(console, project, httpClient);
+                    var command = new ListCommand(context.Console, project, httpClient);
                     command.List();
 
                     context.ExitCode = 0;
                 }
                 catch (CLIToolException e)
                 {
-                    console.LogError(e);
+                    context.Console.LogError(e);
 
                     context.ExitCode = -1;
                 }
-            }, projectOption);
+            });
 
         return command;
     }

--- a/src/dotnet-grpc/Commands/RefreshCommand.cs
+++ b/src/dotnet-grpc/Commands/RefreshCommand.cs
@@ -56,23 +56,27 @@ internal class RefreshCommand : CommandBase
         command.AddOption(dryRunOption);
         command.AddArgument(referencesArgument);
 
-        command.SetHandler<string, bool, string[], InvocationContext, IConsole>(
-            async (project, dryRun, references, context, console) =>
+        command.SetHandler(
+            async (context) =>
             {
+                var project = context.ParseResult.GetValueForOption(projectOption);
+                var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+                var references = context.ParseResult.GetValueForArgument(referencesArgument);
+                
                 try
                 {
-                    var command = new RefreshCommand(console, project, httpClient);
+                    var command = new RefreshCommand(context.Console, project, httpClient);
                     await command.RefreshAsync(dryRun, references);
 
                     context.ExitCode = 0;
                 }
                 catch (CLIToolException e)
                 {
-                    console.LogError(e);
+                    context.Console.LogError(e);
 
                     context.ExitCode = -1;
                 }
-            }, projectOption, dryRunOption, referencesArgument);
+            });
 
         return command;
     }

--- a/src/dotnet-grpc/Commands/RemoveCommand.cs
+++ b/src/dotnet-grpc/Commands/RemoveCommand.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using Grpc.Dotnet.Cli.Internal;
@@ -47,23 +48,27 @@ internal class RemoveCommand : CommandBase
         command.AddOption(projectOption);
         command.AddArgument(referencesArgument);
 
-        command.SetHandler<string, string[], InvocationContext, IConsole>(
-            (project, references, context, console) =>
+        command.SetHandler(
+            (context) =>
             {
+                var project = context.ParseResult.GetValueForOption(projectOption);
+                var references = context.ParseResult.GetValueForArgument(referencesArgument);
                 try
                 {
-                    var command = new RemoveCommand(console, project, httpClient);
+                    var command = new RemoveCommand(context.Console, project, httpClient);
                     command.Remove(references);
 
                     context.ExitCode = 0;
                 }
                 catch (CLIToolException e)
                 {
-                    console.LogError(e);
+                    context.Console.LogError(e);
 
                     context.ExitCode = -1;
                 }
-            }, projectOption, referencesArgument);
+
+                return Task.CompletedTask;
+            });
 
         return command;
     }

--- a/src/dotnet-grpc/Options/CommonOptions.cs
+++ b/src/dotnet-grpc/Options/CommonOptions.cs
@@ -23,7 +23,7 @@ namespace Grpc.Dotnet.Cli.Options;
 
 internal static class CommonOptions
 {
-    public static Option ProjectOption()
+    public static Option<string> ProjectOption()
     {
         var o = new Option<string>(
             aliases: new[] { "-p", "--project" },
@@ -31,7 +31,7 @@ internal static class CommonOptions
         return o;
     }
 
-    public static Option ServiceOption()
+    public static Option<Services> ServiceOption()
     {
         var o = new Option<Services>(
             aliases: new[] { "-s", "--services" },
@@ -39,7 +39,7 @@ internal static class CommonOptions
         return o;
     }
 
-    public static Option AccessOption()
+    public static Option<Access> AccessOption()
     {
         var o = new Option<Access>(
             aliases: new[] { "--access" },
@@ -47,7 +47,7 @@ internal static class CommonOptions
         return o;
     }
 
-    public static Option AdditionalImportDirsOption()
+    public static Option<string> AdditionalImportDirsOption()
     {
         var o = new Option<string>(
             aliases: new[] { "-i", "--additional-import-dirs" },

--- a/src/dotnet-grpc/dotnet-grpc.csproj
+++ b/src/dotnet-grpc/dotnet-grpc.csproj
@@ -4,7 +4,7 @@
     <PackageTags>gRPC RPC CLI</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <OutputType>exe</OutputType>
     <PackAsTool>true</PackAsTool>
@@ -15,7 +15,7 @@
     <NoWarn>$(NoWarn);CA2007</NoWarn>
 
     <!-- The roll forward policy is set to LatestMajor to allow rolling forward to latest major and minor
-      version of the runtime even if requested major (netcoreapp3.0) is present. This ensures that the runtime
+      version of the runtime even if requested major (netcoreapp3.1) is present. This ensures that the runtime
       contains assemblies that are equal or newer than neede by the SDK assemblies resolved by the MSBuild locator.
       See https://github.com/dotnet/designs/blob/main/accepted/2019/runtime-binding.md#rollforward for details-->
     <RollForward>LatestMajor</RollForward>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1906

I updated the MSBuild packages used to locate and load projects, and that fixed the commend line tool being used with .NET 7 apps.

I also updated some other packages used by the tool in this PR. System.Comandline required some reactions (as usual...)