### PR TITLE
Fix build failure on benchmark server V2

### DIFF
--- a/src/Grpc.Core.Api/IAsyncStreamWriter.cs
+++ b/src/Grpc.Core.Api/IAsyncStreamWriter.cs
@@ -37,7 +37,7 @@ public interface IAsyncStreamWriter<in T>
     /// <param name="message">The message to be written. Cannot be null.</param>
     Task WriteAsync(T message);
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
     /// <summary>
     /// Writes a message asynchronously. Only one write can be pending at a time.
     /// </summary>


### PR DESCRIPTION
Fix new error:

> C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7736\j3wrywbc.imh\grpc-dotnet\src\Grpc.AspNetCore.Server\Internal\HttpContextStreamWriter.cs(54,40): error CS0539: 'HttpContextStreamWriter<TResponse>.WriteAsync(TResponse, CancellationToken)' in explicit interface declaration is not found among members of the interface that can be implemented [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7736\j3wrywbc.imh\grpc-dotnet\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj::TargetFramework=net7.0]
