### PR TITLE
Add option to full disable client balancing

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -212,6 +212,12 @@ public sealed class GrpcChannelOptions
     public ServiceConfig? ServiceConfig { get; set; }
 
 #if SUPPORT_LOAD_BALANCING
+
+    /// <summary>
+    /// Full off all support for load balancing
+    /// </summary>
+    public bool DisableLoadBalancing { get; set; }
+
     /// <summary>
     /// Gets or sets a value indicating whether resolving a service config from the <see cref="Balancer.Resolver"/>
     /// is disabled.
@@ -240,7 +246,7 @@ public sealed class GrpcChannelOptions
     /// </para>
     /// </summary>
     public TimeSpan? MaxReconnectBackoff
-    { 
+    {
         get => _maxReconnectBackoff;
         set
         {
@@ -248,6 +254,7 @@ public sealed class GrpcChannelOptions
             {
                 throw new ArgumentException("Maximum reconnect backoff must be greater than zero.");
             }
+
             _maxReconnectBackoff = value;
         }
     }
@@ -274,6 +281,7 @@ public sealed class GrpcChannelOptions
             {
                 throw new ArgumentException("Initial reconnect backoff must be greater than zero.");
             }
+
             _initialReconnectBackoff = value;
         }
     }

--- a/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
@@ -72,7 +72,7 @@ public class PickFirstBalancerTests
         await channel.ConnectAsync();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -116,7 +116,7 @@ public class PickFirstBalancerTests
         await channel.ConnectAsync().DefaultTimeout();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -168,7 +168,7 @@ public class PickFirstBalancerTests
         _ = channel.ConnectAsync();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -236,7 +236,7 @@ public class PickFirstBalancerTests
         await connectTask.DefaultTimeout();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -280,7 +280,7 @@ public class PickFirstBalancerTests
         await channel.ConnectAsync();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -379,7 +379,7 @@ public class PickFirstBalancerTests
 
         var stateChangedTask = channel.WaitForStateChangedAsync(ConnectivityState.Idle);
 
-        var pick = await channel.ConnectionManager.PickAsync(
+        var pick = await channel.ConnectionManager!.PickAsync(
             new PickContext { Request = new HttpRequestMessage() },
             waitForReady: false,
             CancellationToken.None).AsTask().DefaultTimeout();

--- a/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
@@ -70,7 +70,7 @@ public class ResolverTests
         await channel.ConnectAsync();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
     }
 
@@ -109,7 +109,7 @@ public class ResolverTests
 
         await connectTask.DefaultTimeout();
 
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
     }
 
@@ -182,7 +182,7 @@ public class ResolverTests
 
         await connectTask.DefaultTimeout();
 
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, createdCount);
@@ -257,7 +257,7 @@ public class ResolverTests
         // Ensure that channel has processed results
         await resolver.HasResolvedTask.DefaultTimeout();
 
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
         Assert.AreEqual(ConnectivityState.Connecting, subchannels[0].State);
 
@@ -337,7 +337,7 @@ public class ResolverTests
         await channel.ConnectAsync();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(disabled, resolverOptions!.DisableServiceConfig);
@@ -410,7 +410,7 @@ public class ResolverTests
 
         // Act
         var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
-        await channel.ConnectionManager.ConnectAsync(waitForReady: false, CancellationToken.None).DefaultTimeout();
+        await channel.ConnectionManager!.ConnectAsync(waitForReady: false, CancellationToken.None).DefaultTimeout();
 
         var ex = await ExceptionAssert.ThrowsAsync<RpcException>(async () =>
         {
@@ -454,7 +454,7 @@ public class ResolverTests
 
         // Act
         var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
-        await channel.ConnectionManager.ConnectAsync(waitForReady: false, CancellationToken.None).DefaultTimeout();
+        await channel.ConnectionManager!.ConnectAsync(waitForReady: false, CancellationToken.None).DefaultTimeout();
 
         resolver.UpdateAddresses(
             new List<BalancerAddress> { new BalancerAddress("localhost", 80) },
@@ -473,7 +473,7 @@ public class ResolverTests
 
     public static T? GetInnerLoadBalancer<T>(GrpcChannel channel) where T : LoadBalancer
     {
-        var balancer = (ChildHandlerLoadBalancer)channel.ConnectionManager._balancer!;
+        var balancer = (ChildHandlerLoadBalancer)channel.ConnectionManager!._balancer!;
         return (T?)balancer._current?.LoadBalancer;
     }
 }

--- a/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
@@ -74,7 +74,7 @@ public class RoundRobinBalancerTests
         await channel.ConnectAsync().DefaultTimeout();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -134,7 +134,7 @@ public class RoundRobinBalancerTests
         await channel.ConnectAsync().DefaultTimeout();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -188,7 +188,7 @@ public class RoundRobinBalancerTests
         _ = channel.ConnectAsync();
 
         // Assert
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -268,7 +268,7 @@ public class RoundRobinBalancerTests
         logger.LogInformation("Client waiting for connect to complete.");
         await connectTask.DefaultTimeout();
 
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);
@@ -337,7 +337,7 @@ public class RoundRobinBalancerTests
         syncPoint!.Continue();
         await connectTask.DefaultTimeout();
 
-        var subchannels = channel.ConnectionManager.GetSubchannels();
+        var subchannels = channel.ConnectionManager!.GetSubchannels();
         Assert.AreEqual(2, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -761,7 +761,7 @@ public class GrpcChannelTests
         var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
 
         // Assert
-        Assert.IsInstanceOf(typeof(ChannelTestResolver), channel.ConnectionManager._resolver);
+        Assert.IsInstanceOf(typeof(ChannelTestResolver), channel.ConnectionManager!._resolver);
     }
 
     [Test]
@@ -814,9 +814,9 @@ public class GrpcChannelTests
         var channel = GrpcChannel.ForAddress("test:///localhost", channelOptions);
 
         // Assert
-        Assert.IsInstanceOf(typeof(ChannelTestResolver), channel.ConnectionManager._resolver);
+        Assert.IsInstanceOf(typeof(ChannelTestResolver), channel.ConnectionManager!._resolver);
 
-        var resolver = (ChannelTestResolver)channel.ConnectionManager._resolver;
+        var resolver = (ChannelTestResolver)channel.ConnectionManager!._resolver;
         Assert.AreEqual(expectedPort, resolver.Options.DefaultPort);
     }
 
@@ -860,7 +860,7 @@ public class GrpcChannelTests
 
         // Act
         var channel = GrpcChannel.ForAddress("https://localhost", channelOptions);
-        var backoffPolicy = channel.ConnectionManager.BackoffPolicyFactory.Create();
+        var backoffPolicy = channel.ConnectionManager!.BackoffPolicyFactory.Create();
 
         // Assert
         Assert.AreEqual(TimeSpan.FromSeconds(0.2), backoffPolicy.NextBackoff());
@@ -881,7 +881,7 @@ public class GrpcChannelTests
 
         // Act
         var channel = GrpcChannel.ForAddress("https://localhost", channelOptions);
-        var backoffPolicy = channel.ConnectionManager.BackoffPolicyFactory.Create();
+        var backoffPolicy = channel.ConnectionManager!.BackoffPolicyFactory.Create();
 
         // Assert
         for (var i = 0; i < 100; i++)


### PR DESCRIPTION
Hello.

Our company uses its own solution for balancing grpc requests, which is based on a custom handler. Similar to how it is now implemented in the current version of the library.

When version 2.44.0 was released, we faced the problem that our solution was completely overwritten by the current implementation of client balancing. There are several problems for us here:

1. It is impossible to disable the balancing handler in the current version of the library, but it interferes with our handler.

2. We could not make an adequate implementation based on the proposed api, taking into account our needs, because we use several sets of pickers and complex traffic balancing algorithms. We can't embed normally in the current API, because it is based on base classes, not interfaces.

3. We have balancing for HTPP and GPRC clients based on the same code - custom http handler. The only difference is how we find out which address is used as a balancing. We will find out the real address right before sending the request. We resolve the address we need directly in the overridden Send method. The current balancing implementation tries to connect to an address that may not exist in reality, and at this point the address liveness check immediately fails.

The solution that we propose is to add an option to the channel that would completely disable work with internal balancing, i.e. did not use these mechanisms at all and acted in the old style. Now there is only one option that disables the balancer itself, but does not disable address resolution and connection liveness check.

We also believe that experimental functionality should be disabled at runtime, not at compile time.