### PR TITLE
Detect native HttpHandler on Android

### DIFF
--- a/src/Grpc.Net.Client/Internal/RuntimeHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/RuntimeHelpers.cs
@@ -16,30 +16,18 @@
 
 #endregion
 
-using System.Runtime.InteropServices;
 
 namespace Grpc.Net.Client.Internal;
 
-internal interface IOperatingSystem
+internal static class RuntimeHelpers
 {
-    bool IsBrowser { get; }
-    bool IsAndroid { get; }
-}
-
-internal sealed class OperatingSystem : IOperatingSystem
-{
-    public static readonly OperatingSystem Instance = new OperatingSystem();
-
-    public bool IsBrowser { get; }
-    public bool IsAndroid { get; }
-
-    private OperatingSystem()
+    public static bool QueryRuntimeSettingSwitch(string switchName, bool defaultValue)
     {
-        IsBrowser = RuntimeInformation.IsOSPlatform(OSPlatform.Create("browser"));
-#if NET5_0_OR_GREATER
-        IsAndroid = System.OperatingSystem.IsAndroid();
-#else
-        IsAndroid = false;
-#endif
+        if (AppContext.TryGetSwitch(switchName, out var value))
+        {
+            return value;
+        }
+
+        return defaultValue;
     }
 }

--- a/test/Grpc.Net.Client.Tests/GetStatusTests.cs
+++ b/test/Grpc.Net.Client.Tests/GetStatusTests.cs
@@ -213,6 +213,7 @@ public class GetStatusTests
     private class TestOperatingSystem : IOperatingSystem
     {
         public bool IsBrowser { get; set; }
+        public bool IsAndroid { get; set; }
     }
 
     [Test]


### PR DESCRIPTION
Android uses a native HTTP handler if `HttpClientHandler` is specified. The native HTTP handler doesn't have enough HTTP/2 support for gRPC and can cause errors. Example: https://github.com/grpc/grpc-dotnet/issues/1923. We want Android to always use `SocketsHttpHandler`.

Detect if a native HttpHandler is being used on Android, and throw a friendly error message on Android if necessary.

Doc at https://aka.ms/aspnet/grpc/android will be added soon.