### PR TITLE
Update Grpc.Tools dependency to 2.50.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <GoogleProtobufPackageVersion>3.21.5</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.47.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.46.5</GrpcPackageVersion>
-    <GrpcToolsPackageVersion>2.49.0</GrpcToolsPackageVersion>
+    <GrpcToolsPackageVersion>2.50.0</GrpcToolsPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>7.0.0-rc.2.22476.2</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp6PackageVersion>6.0.0</MicrosoftAspNetCoreApp6PackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>


### PR DESCRIPTION
I'll cut the v2.50.x release branch right after merging this.