### PR TITLE
Revert "Update version to 2.50.0-pre1 (on v2.50.x branch)"

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.50.0-pre1</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.50.0-dev</GrpcDotnetVersion>
     
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -41,5 +41,5 @@ public static class VersionInfo
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.50.0-pre1";
+    public const string CurrentVersion = "2.50.0-dev";
 }


### PR DESCRIPTION
Reverts grpc/grpc-dotnet#1935

It was merged against the wrong branch.