### PR TITLE
Update version to 2.50.0-pre1 (on v2.50.x branch) (second attempt).

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.50.0-dev</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.50.0-pre1</GrpcDotnetVersion>
     
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -41,5 +41,5 @@ public static class VersionInfo
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.50.0-dev";
+    public const string CurrentVersion = "2.50.0-pre1";
 }


### PR DESCRIPTION
Supersedes https://github.com/grpc/grpc-dotnet/pull/1935 which targets the wrong branch.