### PR TITLE
Add .NET 8 feed to sources

### DIFF
--- a/build/sources.props
+++ b/build/sources.props
@@ -5,6 +5,7 @@
       https://api.nuget.org/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)feed')">
       $(RestoreSources);


### PR DESCRIPTION
Fix benchmarks that are targeting .NET 8