### PR TITLE
Support zero-byte read in gRPC client

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
     <GrpcPackageVersion>2.46.5</GrpcPackageVersion>
     <GrpcToolsPackageVersion>2.51.0</GrpcToolsPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>7.0.0</MicrosoftAspNetCoreAppPackageVersion>
-    <MicrosoftAspNetCoreApp6PackageVersion>6.0.0</MicrosoftAspNetCoreApp6PackageVersion>
+    <MicrosoftAspNetCoreApp6PackageVersion>6.0.11</MicrosoftAspNetCoreApp6PackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>
     <MicrosoftAspNetCoreApp31PackageVersion>3.1.3</MicrosoftAspNetCoreApp31PackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.5.5</MicrosoftBuildLocatorPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -32,7 +32,7 @@
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemIOPipelinesPackageVersion>5.0.1</SystemIOPipelinesPackageVersion>
     <SystemMemoryPackageVersion>4.5.3</SystemMemoryPackageVersion>
-    <SystemNetHttpWinHttpHandlerPackageVersion>6.0.1</SystemNetHttpWinHttpHandlerPackageVersion>
+    <SystemNetHttpWinHttpHandlerPackageVersion>7.0.0</SystemNetHttpWinHttpHandlerPackageVersion>
     <SystemSecurityPrincipalWindowsPackageVersion>4.7.0</SystemSecurityPrincipalWindowsPackageVersion>
     <SystemThreadingChannelsPackageVersion>4.6.0</SystemThreadingChannelsPackageVersion>
   </PropertyGroup>

--- a/examples/Interceptor/Client/Client.csproj
+++ b/examples/Interceptor/Client/Client.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftAspNetCoreApp6PackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftAspNetCoreApp6PackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Grpc.Net.Client.Web/Internal/Base64ResponseStream.cs
+++ b/src/Grpc.Net.Client.Web/Internal/Base64ResponseStream.cs
@@ -46,6 +46,14 @@ internal class Base64ResponseStream : Stream
         var data = buffer.AsMemory(offset, count);
 #endif
 
+        // Handle zero byte reads.
+        if (data.Length == 0)
+        {
+            var read = await StreamHelpers.ReadAsync(_inner, data, cancellationToken).ConfigureAwait(false);
+            Debug.Assert(read == 0);
+            return 0;
+        }
+
         // There is enough remaining data to fill passed in data
         if (data.Length <= _remainder)
         {

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseStream.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseStream.cs
@@ -83,9 +83,11 @@ internal class GrpcWebResponseStream : Stream
                 }
             case ResponseState.Header:
                 {
+                    Debug.Assert(_contentRemaining > 0);
+
                     headerBuffer = data.Length >= _contentRemaining ? data.Slice(0, _contentRemaining) : data;
                     var success = await TryReadDataAsync(_inner, headerBuffer, cancellationToken).ConfigureAwait(false);
-                    if (!success || headerBuffer.Length == 0)
+                    if (!success)
                     {
                         return 0;
                     }

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseStream.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseStream.cs
@@ -58,7 +58,7 @@ internal class GrpcWebResponseStream : Stream
 #if NETSTANDARD2_0
         var data = buffer.AsMemory(offset, count);
 #endif
-        Memory<byte> headerBuffer = Memory<byte>.Empty;
+        var headerBuffer = Memory<byte>.Empty;
 
         switch (_state)
         {

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -121,11 +121,11 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
 
         var resolverFactory = GetResolverFactory(channelOptions);
         ResolveCredentials(channelOptions, out _isSecure, out _callCredentials);
-            (HttpHandlerType, ConnectTimeout) = CalculateHandlerContext(address, _isSecure, channelOptions);
+        (HttpHandlerType, ConnectTimeout) = CalculateHandlerContext(address, _isSecure, channelOptions);
 
         SubchannelTransportFactory = channelOptions.ResolveService<ISubchannelTransportFactory>(new SubChannelTransportFactory(this));
 
-            if (!IsHttpOrHttpsAddress(Address) || channelOptions.ServiceConfig?.LoadBalancingConfigs.Count > 0)
+        if (!IsHttpOrHttpsAddress(Address) || channelOptions.ServiceConfig?.LoadBalancingConfigs.Count > 0)
         {
             ValidateHttpHandlerSupportsConnectivity();
         }
@@ -215,12 +215,12 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         }
     }
 
-        private static bool IsHttpOrHttpsAddress(Uri address)
+    private static bool IsHttpOrHttpsAddress(Uri address)
     {
-            return address.Scheme == Uri.UriSchemeHttps || address.Scheme == Uri.UriSchemeHttp;
+        return address.Scheme == Uri.UriSchemeHttps || address.Scheme == Uri.UriSchemeHttp;
     }
 
-        private static HttpHandlerContext CalculateHandlerContext(Uri address, bool isSecure, GrpcChannelOptions channelOptions)
+    private static HttpHandlerContext CalculateHandlerContext(Uri address, bool isSecure, GrpcChannelOptions channelOptions)
     {
         if (channelOptions.HttpHandler == null)
         {
@@ -261,17 +261,17 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
                 }
             }
 
-                // If a proxy is specified then requests could be sent via an SSL tunnel.
-                // A CONNECT request is made to the proxy to establish the transport stream and then
-                // gRPC calls are sent via stream. This feature isn't supported by load balancer.
-                // Proxy can be specified via:
-                // - SocketsHttpHandler.Proxy. Set via app code.
-                // - HttpClient.DefaultProxy. Set via environment variables, e.g. HTTPS_PROXY.
-                if (IsProxied(socketsHttpHandler, address, isSecure))
-                {
-                    type = HttpHandlerType.Custom;
-                    connectTimeout = null;
-                }
+            // If a proxy is specified then requests could be sent via an SSL tunnel.
+            // A CONNECT request is made to the proxy to establish the transport stream and then
+            // gRPC calls are sent via stream. This feature isn't supported by load balancer.
+            // Proxy can be specified via:
+            // - SocketsHttpHandler.Proxy. Set via app code.
+            // - HttpClient.DefaultProxy. Set via environment variables, e.g. HTTPS_PROXY.
+            if (IsProxied(socketsHttpHandler, address, isSecure))
+            {
+                type = HttpHandlerType.Custom;
+                connectTimeout = null;
+            }
 #else
             type = HttpHandlerType.SocketsHttpHandler;
             connectTimeout = null;
@@ -287,30 +287,30 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
     }
 
 #if NET5_0_OR_GREATER
-        private static readonly Uri HttpLoadBalancerTemporaryUri = new Uri("http://loadbalancer.temporary.invalid");
-        private static readonly Uri HttpsLoadBalancerTemporaryUri = new Uri("https://loadbalancer.temporary.invalid");
+    private static readonly Uri HttpLoadBalancerTemporaryUri = new Uri("http://loadbalancer.temporary.invalid");
+    private static readonly Uri HttpsLoadBalancerTemporaryUri = new Uri("https://loadbalancer.temporary.invalid");
 
-        private static bool IsProxied(SocketsHttpHandler socketsHttpHandler, Uri address, bool isSecure)
+    private static bool IsProxied(SocketsHttpHandler socketsHttpHandler, Uri address, bool isSecure)
+    {
+        // Check standard address directly.
+        // When load balancing the channel doesn't know the final addresses yet so use temporary address.
+        Uri resolvedAddress;
+        if (IsHttpOrHttpsAddress(address))
         {
-            // Check standard address directly.
-            // When load balancing the channel doesn't know the final addresses yet so use temporary address.
-            Uri resolvedAddress;
-            if (IsHttpOrHttpsAddress(address))
-            {
-                resolvedAddress = address;
-            }
-            else if (isSecure)
-            {
-                resolvedAddress = HttpsLoadBalancerTemporaryUri;
-            }
-            else
-            {
-                resolvedAddress = HttpLoadBalancerTemporaryUri;
-            }
-
-            var proxy = socketsHttpHandler.Proxy ?? HttpClient.DefaultProxy;
-            return proxy.GetProxy(resolvedAddress) != null;
+            resolvedAddress = address;
         }
+        else if (isSecure)
+        {
+            resolvedAddress = HttpsLoadBalancerTemporaryUri;
+        }
+        else
+        {
+            resolvedAddress = HttpLoadBalancerTemporaryUri;
+        }
+
+        var proxy = socketsHttpHandler.Proxy ?? HttpClient.DefaultProxy;
+        return proxy.GetProxy(resolvedAddress) != null;
+    }
 #endif
 
 #if SUPPORT_LOAD_BALANCING
@@ -321,7 +321,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         //
         // Even with just one address we still want to use the load balancing infrastructure. This enables
         // the connectivity APIs on channel like GrpcChannel.State and GrpcChannel.WaitForStateChanged.
-            if (IsHttpOrHttpsAddress(Address))
+        if (IsHttpOrHttpsAddress(Address))
         {
             return new StaticResolverFactory(uri => new[] { new BalancerAddress(Address.Host, Address.Port) });
         }
@@ -370,7 +370,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         {
             return serviceFactories.Union(LoadBalancerFactory.KnownLoadBalancerFactories).ToArray();
         }
-        
+
         return LoadBalancerFactory.KnownLoadBalancerFactories;
     }
 #endif
@@ -436,7 +436,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
             {
                 // GetHttpHandlerType recurses through DelegatingHandlers that may wrap the HttpClientHandler.
                 var httpClientHandler = HttpRequestHelpers.GetHttpHandlerType<HttpClientHandler>(handler);
-                
+
                 if (httpClientHandler != null && RuntimeHelpers.QueryRuntimeSettingSwitch("System.Net.Http.UseNativeHttpHandler", defaultValue: false))
                 {
                     throw new InvalidOperationException("The channel configuration isn't valid on Android devices. " +

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -62,6 +62,13 @@ internal static partial class StreamExtensions
             GrpcCallLog.ReadingMessage(call.Logger);
             cancellationToken.ThrowIfCancellationRequested();
 
+#if NET7_0_OR_GREATER
+            // Start with zero-byte read.
+            // A zero-byte read avoids renting buffer until the response is ready. Especially useful for long running streaming calls.
+            var readCount = await responseStream.ReadAsync(Memory<byte>.Empty, cancellationToken).ConfigureAwait(false);
+            Debug.Assert(readCount == 0);
+#endif
+
             // Buffer is used to read header, then message content.
             // This size was randomly chosen to hopefully be big enough for many small messages.
             // If the message is larger then the array will be replaced when the message size is known.

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -62,7 +62,7 @@ internal static partial class StreamExtensions
             GrpcCallLog.ReadingMessage(call.Logger);
             cancellationToken.ThrowIfCancellationRequested();
 
-#if NET7_0_OR_GREATER
+#if NET6_0_OR_GREATER
             // Start with zero-byte read.
             // A zero-byte read avoids renting buffer until the response is ready. Especially useful for long running streaming calls.
             var readCount = await responseStream.ReadAsync(Memory<byte>.Empty, cancellationToken).ConfigureAwait(false);

--- a/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTestsBase.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/PipeExtensionsTestsBase.cs
@@ -275,7 +275,7 @@ public abstract class PipeExtensionsTestsBase
 
         // Act 3
         var messageData3Task = pipeReader.ReadStreamMessageAsync(testServerCallContext, TestDataMarshaller.ContextualDeserializer).AsTask();
-        await requestStream.AddDataAndWait(Array.Empty<byte>()).DefaultTimeout();
+        await requestStream.EndStreamAndWait().DefaultTimeout();
 
         // Assert 3
         var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => messageData3Task).DefaultTimeout();
@@ -436,7 +436,7 @@ public abstract class PipeExtensionsTestsBase
             }
         }
 
-        await requestStream.AddDataAndWait(Array.Empty<byte>()).DefaultTimeout();
+        await requestStream.EndStreamAndWait().DefaultTimeout();
 
         var readMessageData = await readTask.DefaultTimeout();
 

--- a/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncClientStreamingCallTests.cs
@@ -209,7 +209,7 @@ public class AsyncClientStreamingCallTests
         {
             Message = "Hello world 1"
         }).DefaultTimeout()).DefaultTimeout();
-        await streamContent.AddDataAndWait(Array.Empty<byte>());
+        await streamContent.EndStreamAndWait();
 
         var result = await resultTask.DefaultTimeout();
         Assert.AreEqual("Hello world 1", result.Message);

--- a/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
@@ -169,7 +169,7 @@ public class AsyncDuplexStreamingCallTests
         var moveNextTask3 = responseStream.MoveNext(CancellationToken.None);
         Assert.IsFalse(moveNextTask3.IsCompleted);
 
-        await streamContent.AddDataAndWait(Array.Empty<byte>()).DefaultTimeout();
+        await streamContent.EndStreamAndWait().DefaultTimeout();
 
         Assert.IsFalse(await moveNextTask3.DefaultTimeout());
 

--- a/test/Grpc.Net.Client.Tests/AsyncServerStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncServerStreamingCallTests.cs
@@ -137,7 +137,7 @@ public class AsyncServerStreamingCallTests
         var moveNextTask3 = responseStream.MoveNext(CancellationToken.None);
         Assert.IsFalse(moveNextTask3.IsCompleted);
 
-        await streamContent.AddDataAndWait(Array.Empty<byte>()).DefaultTimeout();
+        await streamContent.EndStreamAndWait().DefaultTimeout();
 
         Assert.IsFalse(await moveNextTask3.DefaultTimeout());
 

--- a/test/Grpc.Net.Client.Tests/GetTrailersTests.cs
+++ b/test/Grpc.Net.Client.Tests/GetTrailersTests.cs
@@ -359,7 +359,7 @@ public class GetTrailersTests
 
                 var messageData = await ClientTestHelpers.GetResponseDataAsync(new HelloReply { Message = "Hello world" }).DefaultTimeout();
                 await stream.AddDataAndWait(messageData).DefaultTimeout();
-                await stream.AddDataAndWait(Array.Empty<byte>()).DefaultTimeout();
+                await stream.EndStreamAndWait().DefaultTimeout();
 
                 response.TrailingHeaders().Add("custom-header", "value");
                 trailingHeadersWrittenTcs.SetResult(true);

--- a/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
@@ -611,7 +611,7 @@ public class RetryTests
         {
             Message = "Hello world 1"
         }).DefaultTimeout()).DefaultTimeout();
-        await streamContent.AddDataAndWait(Array.Empty<byte>());
+        await streamContent.EndStreamAndWait();
 
         var result = await resultTask.DefaultTimeout();
         Assert.AreEqual("Hello world 1", result.Message);

--- a/test/Shared/SyncPointMemoryStream.cs
+++ b/test/Shared/SyncPointMemoryStream.cs
@@ -41,7 +41,7 @@ public class SyncPointMemoryStream : Stream
 
     /// <summary>
     /// End stream and wait for at least one more read that returns zero bytes.
-    /// Note that because of zero-byte reads, the stream maybe read multiple times.
+    /// Note that because of zero-byte reads, the stream may be read multiple times.
     /// </summary>
     public Task EndStreamAndWait()
     {

--- a/test/Shared/SyncPointMemoryStream.cs
+++ b/test/Shared/SyncPointMemoryStream.cs
@@ -28,6 +28,8 @@ public class SyncPointMemoryStream : Stream
     private SyncPoint _syncPoint;
     private Func<Task> _awaiter;
     private byte[] _currentData;
+    private bool _streamEnded;
+    private bool _streamEndedObserved;
     private Exception? _exception;
 
     public SyncPointMemoryStream(bool runContinuationsAsynchronously = true)
@@ -35,6 +37,17 @@ public class SyncPointMemoryStream : Stream
         _runContinuationsAsynchronously = runContinuationsAsynchronously;
         _currentData = Array.Empty<byte>();
         _awaiter = SyncPoint.Create(out _syncPoint, _runContinuationsAsynchronously);
+    }
+
+    /// <summary>
+    /// End stream and wait for at least one more read that returns zero bytes.
+    /// Note that because of zero-byte reads, the stream maybe read multiple times.
+    /// </summary>
+    public Task EndStreamAndWait()
+    {
+        AddDataCore(Array.Empty<byte>());
+        _streamEnded = true;
+        return _awaiter();
     }
 
     /// <summary>
@@ -73,6 +86,12 @@ public class SyncPointMemoryStream : Stream
 
     public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
+        if (_streamEndedObserved)
+        {
+            // Stream has ended and ReadAsync has been called again. Just return immediately.
+            return 0;
+        }
+
         // Still have leftover data?
         if (_currentData.Length > 0)
         {
@@ -111,6 +130,10 @@ public class SyncPointMemoryStream : Stream
 
         if (_currentData.Length == 0)
         {
+            if (_streamEnded)
+            {
+                _streamEndedObserved = true;
+            }
             ResetSyncPointAndContinuePrevious();
         }
 


### PR DESCRIPTION
Avoid renting and using a buffer until a response is available using a zero-byte read of the response.