### PR TITLE
Support running health checks in Check method

### DIFF
--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksEndpointRouteBuilderExtensions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksEndpointRouteBuilderExtensions.cs
@@ -16,7 +16,7 @@
 
 #endregion
 
-using Grpc.HealthCheck;
+using Grpc.AspNetCore.HealthChecks.Internal;
 using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -39,6 +39,6 @@ public static class GrpcHealthChecksEndpointRouteBuilderExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        return builder.MapGrpcService<HealthServiceImpl>();
+        return builder.MapGrpcService<HealthServiceIntegration>();
     }
 }

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
 namespace Grpc.AspNetCore.HealthChecks;
 
 /// <summary>
@@ -27,4 +29,11 @@ public sealed class GrpcHealthChecksOptions
     /// Gets a collection of service mappings used to map health results to gRPC health checks services.
     /// </summary>
     public ServiceMappingCollection Services { get; } = new ServiceMappingCollection();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the <c>Check</c> method runs health checks when it is called.
+    /// If <see cref="RunHealthChecksOnCheck" /> is <c>false</c> then cached health check results previously published by 
+    /// <see cref="IHealthCheckPublisher"/> are returned by the <c>Check</c> method.
+    /// </summary>
+    public bool RunHealthChecksOnCheck { get; set; } = true;
 }

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
@@ -31,9 +31,12 @@ public sealed class GrpcHealthChecksOptions
     public ServiceMappingCollection Services { get; } = new ServiceMappingCollection();
 
     /// <summary>
-    /// Gets or sets a value indicating whether the <c>Check</c> method runs health checks when it is called.
-    /// If <see cref="RunHealthChecksOnCheck" /> is <c>false</c> then cached health check results previously published by 
-    /// <see cref="IHealthCheckPublisher"/> are returned by the <c>Check</c> method.
+    /// Gets or sets a value indicating whether methods use cached health checks results. 
+    /// The default value is <c>false</c>.
     /// </summary>
-    public bool RunHealthChecksOnCheck { get; set; } = true;
+    /// <remarks>
+    /// When <c>false</c>, health checks are recalculated and returned. When <c>true</c>, cached health check results previously
+    /// published by <see cref="IHealthCheckPublisher"/> are returned.
+    /// </remarks>
+    public bool UseHealthChecksCache { get; set; }
 }

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
@@ -35,10 +35,11 @@ internal sealed class GrpcHealthChecksPublisher : IHealthCheckPublisher
 
     public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
     {
-        var serviceStatuses = GrpcHealthChecksPublisherHelpers.CalculateStatuses(report, _options);
-        foreach (var serviceStatus in serviceStatuses)
+        foreach (var registration in _options.Services)
         {
-            _healthService.SetStatus(serviceStatus.Name, serviceStatus.Status);
+            var resolvedStatus = HealthChecksStatusHelpers.GetStatus(report, registration.Predicate);
+
+            _healthService.SetStatus(registration.Name, resolvedStatus);
         }
 
         return Task.CompletedTask;

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/GrpcHealthChecksPublisherHelpers.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/GrpcHealthChecksPublisherHelpers.cs
@@ -1,0 +1,44 @@
+﻿using Grpc.AspNetCore.HealthChecks;
+using Grpc.Health.V1;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+internal static class GrpcHealthChecksPublisherHelpers
+{
+    public static List<ServiceStatus> CalculateStatuses(HealthReport report, GrpcHealthChecksOptions options)
+    {
+        var statuses = new List<ServiceStatus>();
+        foreach (var registration in options.Services)
+        {
+            var resolvedStatus = GetStatus(report, registration.Predicate);
+
+            statuses.Add(new ServiceStatus(registration.Name, resolvedStatus));
+        }
+
+        return statuses;
+    }
+
+    public static HealthCheckResponse.Types.ServingStatus GetStatus(HealthReport report, Func<HealthResult, bool> predicate)
+    {
+        var filteredResults = report.Entries
+            .Select(entry => new HealthResult(entry.Key, entry.Value.Tags, entry.Value.Status, entry.Value.Description, entry.Value.Duration, entry.Value.Exception, entry.Value.Data))
+            .Where(predicate);
+
+        var resolvedStatus = HealthCheckResponse.Types.ServingStatus.Unknown;
+        foreach (var result in filteredResults)
+        {
+            if (result.Status == HealthStatus.Unhealthy)
+            {
+                resolvedStatus = HealthCheckResponse.Types.ServingStatus.NotServing;
+
+                // No point continuing to check statuses.
+                break;
+            }
+
+            resolvedStatus = HealthCheckResponse.Types.ServingStatus.Serving;
+        }
+
+        return resolvedStatus;
+    }
+}
+
+internal record struct ServiceStatus(string Name, HealthCheckResponse.Types.ServingStatus Status);

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/HealthChecksStatusHelpers.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/HealthChecksStatusHelpers.cs
@@ -1,22 +1,27 @@
-﻿using Grpc.AspNetCore.HealthChecks;
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.AspNetCore.HealthChecks;
 using Grpc.Health.V1;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-internal static class GrpcHealthChecksPublisherHelpers
+internal static class HealthChecksStatusHelpers
 {
-    public static List<ServiceStatus> CalculateStatuses(HealthReport report, GrpcHealthChecksOptions options)
-    {
-        var statuses = new List<ServiceStatus>();
-        foreach (var registration in options.Services)
-        {
-            var resolvedStatus = GetStatus(report, registration.Predicate);
-
-            statuses.Add(new ServiceStatus(registration.Name, resolvedStatus));
-        }
-
-        return statuses;
-    }
-
     public static HealthCheckResponse.Types.ServingStatus GetStatus(HealthReport report, Func<HealthResult, bool> predicate)
     {
         var filteredResults = report.Entries
@@ -40,5 +45,3 @@ internal static class GrpcHealthChecksPublisherHelpers
         return resolvedStatus;
     }
 }
-
-internal record struct ServiceStatus(string Name, HealthCheckResponse.Types.ServingStatus Status);

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
@@ -1,0 +1,74 @@
+﻿#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.Core;
+using Grpc.Health.V1;
+using Grpc.HealthCheck;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Grpc.AspNetCore.HealthChecks.Internal;
+
+internal sealed class HealthServiceIntegration : Grpc.Health.V1.Health.HealthBase
+{
+    private readonly HealthCheckOptions _healthCheckOptions;
+    private readonly GrpcHealthChecksOptions _grpcHealthCheckOptions;
+    private readonly HealthServiceImpl _healthServiceImpl;
+    private readonly HealthCheckService _healthCheckService;
+
+    public HealthServiceIntegration(
+        HealthServiceImpl healthServiceImpl,
+        IOptions<HealthCheckOptions> healthCheckOptions,
+        IOptions<GrpcHealthChecksOptions> grpcHealthCheckOptions,
+        HealthCheckService healthCheckService)
+    {
+        _healthCheckOptions = healthCheckOptions.Value;
+        _grpcHealthCheckOptions = grpcHealthCheckOptions.Value;
+        _healthServiceImpl = healthServiceImpl;
+        _healthCheckService = healthCheckService;
+    }
+
+    public override async Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context)
+    {
+        if (_grpcHealthCheckOptions.RunHealthChecksOnCheck)
+        {
+            // Match Check behavior from Grpc.HealthCheck.HealthServiceImpl.
+            if (_grpcHealthCheckOptions.Services.TryGetServiceMapping(request.Service, out var serviceMapping))
+            {
+                var result = await _healthCheckService.CheckHealthAsync(_healthCheckOptions.Predicate, context.CancellationToken);
+
+                return new HealthCheckResponse
+                {
+                    Status = GrpcHealthChecksPublisherHelpers.GetStatus(result, serviceMapping.Predicate)
+                };
+            }
+
+            throw new RpcException(new Status(StatusCode.NotFound, ""));
+        }
+        else
+        {
+            return await _healthServiceImpl.Check(request, context);
+        }
+    }
+
+    public override Task Watch(HealthCheckRequest request, IServerStreamWriter<HealthCheckResponse> responseStream, ServerCallContext context)
+    {
+        return _healthServiceImpl.Watch(request, responseStream, context);
+    }
+}

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
@@ -55,7 +55,7 @@ internal sealed class HealthServiceIntegration : Grpc.Health.V1.Health.HealthBas
 
                 return new HealthCheckResponse
                 {
-                    Status = GrpcHealthChecksPublisherHelpers.GetStatus(result, serviceMapping.Predicate)
+                    Status = HealthChecksStatusHelpers.GetStatus(result, serviceMapping.Predicate)
                 };
             }
 

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
@@ -18,6 +18,7 @@
 
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Grpc.AspNetCore.HealthChecks;
 
@@ -35,6 +36,11 @@ public sealed class ServiceMappingCollection : IEnumerable<ServiceMapping>
     }
 
     private readonly ServiceMappingKeyedCollection _mappings = new ServiceMappingKeyedCollection();
+
+    internal bool TryGetServiceMapping(string name, [NotNullWhen(true)] out ServiceMapping? serviceMapping)
+    {
+        return _mappings.TryGetValue(name, out serviceMapping);
+    }
 
     /// <summary>
     /// Remove all service mappings.


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1963

This has a behavioral change to always run health checks when the `Check` method is called, and when the `Watch` method returns its initial results. I think the behavioral change is worth it because it stops the problem of apps calling the method before the health check publisher has published results.

Setting `UseHealthChecksCache` to true reverts behavior to always using cached health check publisher results.

New API:

```diff
namespace Grpc.AspNetCore.HealthChecks;

public sealed class GrpcHealthChecksOptions
{
+    public bool UseHealthChecksCache { get; set; }
}
```

Usage:

```cs
var services = new ServiceCollection();
services
    .AddGrpcHealthChecks(o =>
    {
        o.Services.MapService("", result => !result.Tags.Contains("exclude"));
        o.UseHealthChecksCache = true;
    });
```