### PR TITLE
Added EnabledExceptionPropagation functionality

### DIFF
--- a/src/Grpc.AspNetCore.Server.ClientFactory/ExceptionPropagationInterceptor.cs
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/ExceptionPropagationInterceptor.cs
@@ -1,0 +1,111 @@
+using System;
+using Grpc.Core;
+using Newtonsoft.Json;
+using Grpc.AspNetCore.Server;
+using Grpc.Core.Interceptors;
+using System.Threading.Tasks;
+
+namespace Grpc.AspNetCore.ClientFactory;
+
+internal class ExceptionPropagationInterceptor : Interceptor
+{
+	/// <inheritdoc/>
+	public override TResponse BlockingUnaryCall<TRequest, TResponse>(TRequest request,
+		ClientInterceptorContext<TRequest, TResponse> context,
+		BlockingUnaryCallContinuation<TRequest, TResponse> continuation) 
+		
+		=> ExecuteCallCore(() =>
+		{
+			return base.BlockingUnaryCall(request, context, continuation);
+		});
+
+	/// <inheritdoc/>
+	public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(TRequest request,
+		ClientInterceptorContext<TRequest, TResponse> context,
+		AsyncUnaryCallContinuation<TRequest, TResponse> continuation) 
+		
+		=> ExecuteCallCore(() =>
+		{
+			return base.AsyncUnaryCall(request, context, continuation);
+		});
+
+	/// <inheritdoc/>
+	public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(TRequest request,
+		ClientInterceptorContext<TRequest, TResponse> context,
+		AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation) 
+		
+		=> ExecuteCallCore(() =>
+		{
+			return base.AsyncServerStreamingCall(request, context, continuation);
+		});
+
+	/// <inheritdoc/>
+	public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context,
+			AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+		
+		=> ExecuteCallCore(() =>
+		{
+			return base.AsyncClientStreamingCall(context, continuation);
+		});
+
+	/// <inheritdoc/>
+	public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context,
+		AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+		
+		=> ExecuteCallCore(() =>
+		{
+			return base.AsyncDuplexStreamingCall(context, continuation);
+		});
+
+
+	/// <inheritdoc/>
+	public override Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream,
+		IServerStreamWriter<TResponse> responseStream, ServerCallContext context,
+		DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+
+		=> ExecuteCallCore(() =>
+		{
+			return base.DuplexStreamingServerHandler(requestStream, responseStream, context, continuation);
+		});
+
+	private static TReturn ExecuteCallCore<TReturn>(Func<TReturn> continuation)
+		where TReturn : class
+	{
+		try
+		{
+			return continuation();
+		}
+		catch (RpcException rpcEx) when (rpcEx.Status.StatusCode == StatusCode.Application)
+		{
+			var applicationException = DeserializeApplicationException(rpcEx.Trailers);
+			if (applicationException != null)
+			{
+				throw applicationException;
+			}
+			throw;
+		}
+	}
+
+	private static Exception? DeserializeApplicationException(Metadata metadata)
+	{
+		if (!TryGetExceptionInfoFromMetadata(metadata, out ExceptionMetadata exceptionMetadata))
+			return null;
+
+		return JsonConvert.DeserializeObject(exceptionMetadata.Data, exceptionMetadata.Type) as Exception;
+	}
+
+	private static bool TryGetExceptionInfoFromMetadata(Metadata metadata, out ExceptionMetadata exceptionMetadata)
+	{
+		exceptionMetadata = default;
+		var exceptionMetadataValue = metadata?.GetValue(ExceptionMetadata.PropagatedExceptionMetadataKey);
+
+		if (string.IsNullOrWhiteSpace(exceptionMetadataValue))
+			return false;
+
+		exceptionMetadata = JsonConvert.DeserializeObject<ExceptionMetadata>(exceptionMetadataValue);
+
+		return exceptionMetadata.Type != null
+			&& exceptionMetadata.Data != null
+			&& exceptionMetadata.Data.Length > 0;
+	}
+}

--- a/src/Grpc.AspNetCore.Server.ClientFactory/ExceptionPropagationInterceptor.cs
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/ExceptionPropagationInterceptor.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using Grpc.AspNetCore.Server;
 using Grpc.Core.Interceptors;
 using System.Threading.Tasks;
+using System.Runtime.ExceptionServices;
 
 namespace Grpc.AspNetCore.ClientFactory;
 
@@ -78,11 +79,12 @@ internal class ExceptionPropagationInterceptor : Interceptor
 		catch (RpcException rpcEx) when (rpcEx.Status.StatusCode == StatusCode.Application)
 		{
 			var applicationException = DeserializeApplicationException(rpcEx.Trailers);
-			if (applicationException != null)
-			{
-				throw applicationException;
-			}
-			throw;
+			
+			ExceptionDispatchInfo.Capture(
+				applicationException ?? rpcEx
+			).Throw();
+
+			return null;
 		}
 	}
 

--- a/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>	
+	
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <ProjectReference Include="..\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />

--- a/src/Grpc.AspNetCore.Server.ClientFactory/GrpcServerHttpClientBuilderExtensions.cs
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/GrpcServerHttpClientBuilderExtensions.cs
@@ -74,7 +74,33 @@ public static class GrpcServerHttpClientBuilderExtensions
         return builder;
     }
 
-    private static void EnableCallContextPropagationCore(IHttpClientBuilder builder, GrpcContextPropagationOptions options)
+	/// <summary>
+	/// Configures the server to propagate a server call's exception onto the gRPC client.
+	/// </summary>
+	/// <param name="builder">
+    /// The <see cref="IHttpClientBuilder"/>.
+    /// </param>
+	/// <returns>
+    /// An <see cref="IHttpClientBuilder"/> that can be used to configure the client.
+    /// </returns>
+	public static IHttpClientBuilder EnableExceptionPropagation(this IHttpClientBuilder builder)
+	{
+		ValidateGrpcClient(builder ?? throw new ArgumentNullException(nameof(builder)));
+
+		builder.Services.Configure<GrpcClientFactoryOptions>(builder.Name, o =>
+		{
+			o.InterceptorRegistrations.Add(new InterceptorRegistration(
+				InterceptorScope.Channel,
+				_ =>
+				{
+					return new ExceptionPropagationInterceptor();
+				}));
+		});
+
+		return builder;
+	}
+
+	private static void EnableCallContextPropagationCore(IHttpClientBuilder builder, GrpcContextPropagationOptions options)
     {
         ValidateGrpcClient(builder);
 

--- a/src/Grpc.AspNetCore.Server/ExceptionHandlingInterceptor.cs
+++ b/src/Grpc.AspNetCore.Server/ExceptionHandlingInterceptor.cs
@@ -1,0 +1,101 @@
+using System;
+using Grpc.Core;
+using Newtonsoft.Json;
+using System.Reflection;
+using Grpc.Core.Interceptors;
+using System.Threading.Tasks;
+
+namespace Grpc.AspNetCore.Server;
+
+/// <summary>
+/// Adds to the gRpc pipeline the functionality to propagate custom (or application) exceptions.
+/// </summary>
+public class ExceptionHandlingInterceptor : Interceptor
+{
+	/// <inheritdoc/>
+	public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest request,
+		ServerCallContext context,
+		UnaryServerMethod<TRequest, TResponse> continuation)
+
+		=> await ServerHandlerCore(async () =>
+		{
+			return await base.UnaryServerHandler(request, context, continuation);
+		});
+
+	/// <inheritdoc/>
+	public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream,
+		ServerCallContext context,
+		ClientStreamingServerMethod<TRequest, TResponse> continuation)
+
+		=> await ServerHandlerCore(async () =>
+		{
+			return await base.ClientStreamingServerHandler(requestStream, context, continuation);
+		});
+
+	/// <inheritdoc/>
+	public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream,
+		IServerStreamWriter<TResponse> responseStream, ServerCallContext context,
+		DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+
+		=> await ServerHandlerCore<Func<Task>>(async () =>
+		{
+			await base.DuplexStreamingServerHandler(requestStream, responseStream, context, continuation);
+		});
+
+	/// <inheritdoc/>
+	public override async Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request,
+		IServerStreamWriter<TResponse> responseStream,
+		ServerCallContext context,
+		ServerStreamingServerMethod<TRequest, TResponse> continuation)
+
+		=> await ServerHandlerCore<Func<Task>>(async () =>
+		{
+			await base.ServerStreamingServerHandler(request, responseStream, context, continuation);
+		});
+
+	private static async Task<TResult> ServerHandlerCore<TResult>(Func<Task<TResult>> continuation)
+		where TResult : class
+	{
+		try
+		{
+			return await continuation();
+		}
+		catch (Exception ex) when (ex.GetType() != typeof(RpcException))
+		{
+			var exceptionToRethrown = ConvertExceptionToRpcException(ex) ?? ex;
+			throw exceptionToRethrown;
+		}
+	}
+
+	private static async Task ServerHandlerCore<TResult>(Func<Task> continuation)
+	{
+		try
+		{
+			await continuation();
+		}
+		catch (Exception ex) when (ex.GetType() != typeof(RpcException))
+		{
+			var exceptionToRethrown = ConvertExceptionToRpcException(ex) ?? ex;
+			throw exceptionToRethrown;
+		}
+	}
+
+	private static RpcException ConvertExceptionToRpcException(Exception exception)
+	{
+		var metadata = new Metadata();
+		var exceptionMetadata = ConvertExceptionToMetadata(exception);
+		var serializedExceptionContent = JsonConvert.SerializeObject(exceptionMetadata);
+		metadata.Add(new Metadata.Entry(ExceptionMetadata.PropagatedExceptionMetadataKey, serializedExceptionContent));
+
+		return new RpcException(new Status(StatusCode.Application, ExceptionMetadata.PropagatedExceptionMetadataKey), metadata);
+	}
+
+	private static ExceptionMetadata ConvertExceptionToMetadata(Exception exception)
+	{
+		return new ExceptionMetadata
+		(
+			exception.GetType(),
+			JsonConvert.SerializeObject(exception, Formatting.Indented)
+		);
+	}
+}

--- a/src/Grpc.AspNetCore.Server/ExceptionMetadata.cs
+++ b/src/Grpc.AspNetCore.Server/ExceptionMetadata.cs
@@ -1,0 +1,41 @@
+using System;
+using Grpc.Core;
+using Grpc.Core.Utils;
+
+namespace Grpc.AspNetCore.Server;
+
+/// <summary>
+/// Represents the metadata for an <see cref="Exception"/>.
+/// </summary>
+public struct ExceptionMetadata
+{
+	/// <summary>
+	/// The key used to store the exception in the <see cref="Metadata"/>.
+	/// </summary>
+	public const string PropagatedExceptionMetadataKey = "PropagatedException";
+
+	/// <summary>
+	/// Gets the type of the exception.
+	/// </summary>
+	public Type Type { get; private set; }
+
+	/// <summary>
+	/// Gets the exception serialized in form of array of bytes.
+	/// </summary>
+	public string Data { get; private set; }
+
+	/// <summary>
+	/// Initiliazes a new instance of the <see cref="ExceptionMetadata"/> class.
+	/// </summary>
+	/// <param name="type">
+	/// The type of the exception.
+	/// </param>
+	/// <param name="data">
+	/// The serialized exception.
+	/// </param>
+	public ExceptionMetadata(Type type, string data)
+	{
+		Type = GrpcPreconditions.CheckNotNull(type, nameof(type));
+		Data = GrpcPreconditions.CheckNotNull(data, nameof(data));
+	}
+}

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -15,6 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+
+	<ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
 
     <Compile Include="..\Shared\CommonGrpcProtocolHelpers.cs" Link="Internal\CommonGrpcProtocolHelpers.cs" />

--- a/src/Grpc.Core.Api/StatusCode.cs
+++ b/src/Grpc.Core.Api/StatusCode.cs
@@ -120,5 +120,10 @@ public enum StatusCode
     Unavailable = 14,
 
     /// <summary>Unrecoverable data loss or corruption.</summary>
-    DataLoss = 15
+    DataLoss = 15,
+
+    /// <summary>
+    /// The operation throws an application exception.
+    /// </summary>
+    Application = 16
 }


### PR DESCRIPTION
The _gRpc pipeline_ has been extended with the functionality to propagate a custom exception from a gRpc server up to the client. 

At the client side, the functionality can be enabled with the extension method `EnableExceptionPropagation` like showed by the code snippet below.
```
services.AddGrpcClient<Greeter.GreeterClient>(o =>
{
	o.Address = new Uri("http://localhost:5210");
})
.EnableExceptionPropagation();
```

At the server side, the gRpc can be configured with the `ExceptionHandlingInterceptor` interceptor.
```
builder.Services.AddGrpc(o =>
{
	o.Interceptors.Add<ExceptionHandlingInterceptor>();
});
```
The goal of this functionality is to let the client capture the exception like a normal control-flow. From its point of view, it will be totally independent of the communication used (it can catch its custom exception instead of catching generic RpcException).
Ex. If a method defined in the gRpc service has been designed to throw a custom **MyException**, the client can catch it by simply doing:
```
try
{
	var whoIs = _myServiceProxy.SayHello(name:"fox");
}
catch (MyException e)
{
	Console.WriteLine(e.Message);
}
```