### PR TITLE
RpcException API improvements

### DIFF
--- a/src/Grpc.Core.Api/RpcException.cs
+++ b/src/Grpc.Core.Api/RpcException.cs
@@ -65,7 +65,7 @@ public class RpcException : Exception
     /// <param name="status">Resulting status of a call.</param>
     /// <param name="trailers">Response trailing metadata.</param>
     /// <param name="message">The exception message.</param>
-    public RpcException(Status status, Metadata trailers, string message) : base(message)
+    public RpcException(Status status, Metadata trailers, string message) : base(message, status.DebugException)
     {
         this.status = status;
         this.trailers = GrpcPreconditions.CheckNotNull(trailers);

--- a/src/Grpc.Core.Api/Status.cs
+++ b/src/Grpc.Core.Api/Status.cs
@@ -88,7 +88,8 @@ public struct Status
     {
         if (DebugException != null)
         {
-            return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\", DebugException=\"{DebugException}\")";
+            return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\"," +
+                $" DebugException=\"{DebugException.GetType().Name}: {DebugException.Message}\")";
         }
         return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\")";
     }

--- a/src/Grpc.Core.Api/Status.cs
+++ b/src/Grpc.Core.Api/Status.cs
@@ -89,7 +89,7 @@ public struct Status
         if (DebugException != null)
         {
             return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\"," +
-                $" DebugException=\"{DebugException.GetType().Name}: {DebugException.Message}\")";
+                $" DebugException=\"{DebugException.GetType()}: {DebugException.Message}\")";
         }
         return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\")";
     }

--- a/test/Grpc.Core.Api.Tests/RpcExceptionTest.cs
+++ b/test/Grpc.Core.Api.Tests/RpcExceptionTest.cs
@@ -51,10 +51,9 @@ public class RpcExceptionTest
             someExceptionWithStacktrace = caughtEx;
         }
         var ex = new RpcException(new Status(StatusCode.Internal, "abc", someExceptionWithStacktrace));
-        Console.WriteLine(ex.Message);
         // Check debug exceptions's message is contained.
         StringAssert.Contains(someExceptionWithStacktrace.Message, ex.Message);
-        StringAssert.Contains(someExceptionWithStacktrace.GetType().Name, ex.Message);
+        StringAssert.Contains(someExceptionWithStacktrace.GetType().FullName, ex.Message);
         // If name of the current method is not in the message, it probably doesn't contain the stack trace.
         StringAssert.DoesNotContain(nameof(DefaultMessageDoesntContainDebugExceptionStacktrace), ex.Message);
     }

--- a/test/Grpc.Core.Api.Tests/RpcExceptionTest.cs
+++ b/test/Grpc.Core.Api.Tests/RpcExceptionTest.cs
@@ -1,0 +1,61 @@
+#region Copyright notice and license
+
+// Copyright 2022 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests;
+
+public class RpcExceptionTest
+{
+    [Test]
+    public void StatusDebugExceptionPopulatesInnerException()
+    {
+        Assert.IsNull(new RpcException(new Status(StatusCode.Internal, "abc")).InnerException);
+
+        var debugException = new ArgumentException("test exception");
+        var ex = new RpcException(new Status(StatusCode.Internal, "abc", debugException));
+        Assert.AreSame(debugException, ex.InnerException);
+    }
+
+    [Test]
+    public void DefaultMessageDoesntContainDebugExceptionStacktrace()
+    {
+        Exception someExceptionWithStacktrace = null;
+        try
+        {
+            throw new ArgumentException("test exception");
+        }
+        catch (Exception caughtEx)
+        {
+            someExceptionWithStacktrace = caughtEx;
+        }
+        var ex = new RpcException(new Status(StatusCode.Internal, "abc", someExceptionWithStacktrace));
+        Console.WriteLine(ex.Message);
+        // Check debug exceptions's message is contained.
+        StringAssert.Contains(someExceptionWithStacktrace.Message, ex.Message);
+        StringAssert.Contains(someExceptionWithStacktrace.GetType().Name, ex.Message);
+        // If name of the current method is not in the message, it probably doesn't contain the stack trace.
+        StringAssert.DoesNotContain(nameof(DefaultMessageDoesntContainDebugExceptionStacktrace), ex.Message);
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc/issues/27066 and https://github.com/grpc/grpc/issues/25740 (in a backward compatible way).

Two options for addressing the problem in Grpc.Core as well:
- if users pull the latest versions of Grpc.Core.Api (which now lives in the grpc-dotnet repo), they'll get the fix as well.  It is fine to use Grpc.Core at e.g. 2.46.5 (currently the latest patch) and Grpc.Core.Api  2.47.x, 2.48.x, ... together.
- we could potentially backport into grpc/grpc's 1.46.x branch (which seems unnecessary due to option 1 though).
