### PR TITLE
Support writing to response stream with gRPC-Web middleware

### DIFF
--- a/src/Grpc.AspNetCore.Web/Internal/GrpcWebFeature.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/GrpcWebFeature.cs
@@ -32,6 +32,7 @@ internal class GrpcWebFeature :
     private readonly IRequestBodyPipeFeature? _initialRequestFeature;
     private readonly IHttpResetFeature? _initialResetFeature;
     private readonly IHttpResponseTrailersFeature? _initialTrailersFeature;
+    private Stream? _responseStream;
     private bool _isComplete;
 
     public GrpcWebFeature(ServerGrpcWebContext grcpWebContext, HttpContext httpContext)
@@ -90,7 +91,7 @@ internal class GrpcWebFeature :
 
     public PipeWriter Writer { get; }
 
-    public Stream Stream => throw new NotSupportedException("Writing to the response stream during a gRPC call is not supported.");
+    Stream IHttpResponseBodyFeature.Stream => _responseStream ??= Writer.AsStream();
 
     public IHeaderDictionary Trailers { get; set; }
 


### PR DESCRIPTION
Addresses https://github.com/microsoft/reverse-proxy/issues/1968

tldr; gRPC-Web server middleware can run independently of Grpc.AspNetCore. However, it only supports writing to `Response.BodyWriter` (that's what Grpc.AspNetCore uses). Update to support `Response.Body`