### PR TITLE
Set WaitForDataBeforeAllocatingBuffer to false in benchmark app

### DIFF
--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -19,6 +19,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime;
+using System.Runtime.InteropServices;
 using Common;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
@@ -96,6 +97,11 @@ public class Program
 
                     // Other gRPC servers don't include a server header
                     options.AddServerHeader = false;
+                });
+
+                webBuilder.UseSockets(options =>
+                {
+                    options.WaitForDataBeforeAllocatingBuffer = false;
                 });
             })
             .ConfigureLogging(loggerFactory =>

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/Program.cs
@@ -19,7 +19,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime;
-using System.Runtime.InteropServices;
 using Common;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;


### PR DESCRIPTION
A small throughput boost at the cost of memory usage