### PR TITLE
Fix wrong namespace

### DIFF
--- a/src/Grpc.Net.Client/Internal/RuntimeHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/RuntimeHelpers.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-
 namespace Grpc.Net.Client.Internal;
 
 internal static class RuntimeHelpers

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -22,7 +22,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Grpc.Core;
-using Grpc.Net.Client.Internal;
 using Grpc.Net.Compression;
 using Microsoft.Extensions.Logging;
 
@@ -30,7 +29,7 @@ using Microsoft.Extensions.Logging;
 using ValueTask = System.Threading.Tasks.Task;
 #endif
 
-namespace Grpc.Net.Client;
+namespace Grpc.Net.Client.Internal;
 
 internal static partial class StreamExtensions
 {


### PR DESCRIPTION
`StreamExtensions` was in the wrong namespace.