### PR TITLE
Report user canceled cancellation token

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -734,7 +734,8 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         return false;
     }
 
-    // Report correct CancellationToken. Preserve stacktrace when possible.
+    // Report correct CancellationToken. This method creates and throws a new OperationCanceledException with a different CancellationToken.
+    // It attempts to preserve the original stack trace using ExceptionDispatchInfo where available.
 #if NET6_0_OR_GREATER
     [StackTraceHidden]
 #endif

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -23,7 +23,7 @@ using Grpc.Core;
 using Grpc.Net.Client.Internal.Http;
 using Grpc.Shared;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
+using System.Runtime.ExceptionServices;
 #if SUPPORT_LOAD_BALANCING
 using Grpc.Net.Client.Balancer.Internal;
 #endif
@@ -179,7 +179,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         {
             Disposed = true;
 
-            Cleanup(GrpcProtocolConstants.DisposeCanceledStatus);
+            Cleanup(GrpcProtocolConstants.CreateDisposeCanceledStatus(exception: null));
 
             // If the call was disposed then observe any potential response exception.
             // Observe the task's exception to prevent TaskScheduler.UnobservedTaskException from firing.
@@ -385,9 +385,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         // 2. The token isn't the same one used in CallOptions. Already listening for its cancellation.
         if (cancellationToken.CanBeCanceled && cancellationToken != Options.CancellationToken)
         {
-            cancellationTokenRegistration = cancellationToken.Register(
-                static (state) => ((GrpcCall<TRequest, TResponse>)state!).CancelCallFromCancellationToken(),
-                this);
+            cancellationTokenRegistration = RegisterCancellation(cancellationToken);
             return true;
         }
 
@@ -395,11 +393,23 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         return false;
     }
 
-    private void CancelCallFromCancellationToken()
+    private CancellationTokenRegistration RegisterCancellation(CancellationToken cancellationToken)
+    {
+        return CompatibilityHelpers.RegisterWithCancellationTokenCallback(
+            cancellationToken,
+            static (state, ct) =>
+            {
+                var call = (GrpcCall<TRequest, TResponse>)state!;
+                call.CancelCallFromCancellationToken(ct);
+            },
+            this);
+    }
+
+    private void CancelCallFromCancellationToken(CancellationToken cancellationToken)
     {
         using (StartScope())
         {
-            CancelCall(GrpcProtocolConstants.ClientCanceledStatus);
+            CancelCall(GrpcProtocolConstants.CreateClientCanceledStatus(new OperationCanceledException(cancellationToken)));
         }
     }
 
@@ -673,6 +683,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
     {
         if (ex is OperationCanceledException)
         {
+            ex = EnsureUserCancellationTokenReported(ex, CancellationToken.None);
             status = (CallTask.IsCompletedSuccessfully()) ? CallTask.Result : new Status(StatusCode.Cancelled, string.Empty, ex);
             if (!Channel.ThrowOperationCanceledOnCancellation)
             {
@@ -721,6 +732,40 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
         resolvedException = ex;
         return false;
+    }
+
+    // Report correct CancellationToken. Preserve stacktrace when possible.
+#if NET6_0_OR_GREATER
+    [StackTraceHidden]
+#endif
+    public Exception EnsureUserCancellationTokenReported(Exception ex, CancellationToken cancellationToken)
+    {
+        var token = GetCanceledToken(cancellationToken);
+        if (token != CancellationToken)
+        {
+#if NET6_0_OR_GREATER
+            return ExceptionDispatchInfo.SetCurrentStackTrace(new OperationCanceledException(ex.Message, ex, token));
+#else
+            return new OperationCanceledException(ex.Message, ex, token);
+#endif
+        }
+
+        return ex;
+    }
+
+    public CancellationToken GetCanceledToken(CancellationToken methodCancellationToken)
+    {
+        if (methodCancellationToken.IsCancellationRequested)
+        {
+            return methodCancellationToken;
+        }
+        else if (Options.CancellationToken.IsCancellationRequested)
+        {
+            return Options.CancellationToken;
+        }
+
+        CompatibilityHelpers.Assert(CancellationToken.IsCancellationRequested);
+        return CancellationToken;
     }
 
     private void SetFailedResult(Status status)
@@ -810,9 +855,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
             // The cancellation token will cancel the call CTS.
             // This must be registered after the client writer has been created
             // so that cancellation will always complete the writer.
-            _ctsRegistration = Options.CancellationToken.Register(
-                static (state) => ((GrpcCall<TRequest, TResponse>)state!).CancelCallFromCancellationToken(),
-                this);
+            _ctsRegistration = RegisterCancellation(Options.CancellationToken);
         }
 
         return (diagnosticSourceEnabled, activity);
@@ -1102,9 +1145,9 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
             cancellationToken);
     }
 
-    public Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state)
+    public Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state, CancellationToken cancellationToken)
     {
-        return ClientStreamWriter!.WriteAsync(writeFunc, state);
+        return ClientStreamWriter!.WriteAsync(writeFunc, state, cancellationToken);
     }
 
 #if NET5_0_OR_GREATER

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -734,7 +734,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         return false;
     }
 
-    // Report correct CancellationToken. This method creates and throws a new OperationCanceledException with a different CancellationToken.
+    // Report correct CancellationToken. This method creates a new OperationCanceledException with a different CancellationToken.
     // It attempts to preserve the original stack trace using ExceptionDispatchInfo where available.
 #if NET6_0_OR_GREATER
     [StackTraceHidden]

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -763,9 +763,11 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         {
             return Options.CancellationToken;
         }
-
-        CompatibilityHelpers.Assert(CancellationToken.IsCancellationRequested);
-        return CancellationToken;
+        else if (CancellationToken.IsCancellationRequested)
+        {
+            return CancellationToken;
+        }
+        return CancellationToken.None;
     }
 
     private void SetFailedResult(Status status)

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -69,8 +69,9 @@ internal static class GrpcProtocolConstants
 
     internal static readonly Status DeadlineExceededStatus = new Status(StatusCode.DeadlineExceeded, string.Empty);
     internal static readonly Status ThrottledStatus = new Status(StatusCode.Cancelled, "Retries stopped because retry throttling is active.");
-    internal static readonly Status ClientCanceledStatus = new Status(StatusCode.Cancelled, "Call canceled by the client.");
-    internal static readonly Status DisposeCanceledStatus = new Status(StatusCode.Cancelled, "gRPC call disposed.");
+
+    internal static Status CreateClientCanceledStatus(Exception? exception) => new Status(StatusCode.Cancelled, "Call canceled by the client.", exception);
+    internal static Status CreateDisposeCanceledStatus(Exception? exception) => new Status(StatusCode.Cancelled, "gRPC call disposed.", exception);
 
     internal static string GetMessageAcceptEncoding(Dictionary<string, ICompressionProvider> compressionProviders)
     {

--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -44,7 +44,8 @@ internal interface IGrpcCall<TRequest, TResponse> : IDisposable
 
     Task WriteClientStreamAsync<TState>(
         Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc,
-        TState state);
+        TState state,
+        CancellationToken cancellationToken);
 
     Exception CreateFailureStatusException(Status status);
 

--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -429,7 +429,7 @@ internal sealed partial class HedgingCall<TRequest, TResponse> : RetryCallBase<T
                         registrations.Add(registration.Value);
                     }
 
-                    var writeTask = c.WriteClientStreamAsync(WriteNewMessage, message);
+                    var writeTask = c.WriteClientStreamAsync(WriteNewMessage, message, cancellationToken);
 
                     writeTasks.Add(writeTask);
                 }

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -318,7 +318,7 @@ internal sealed class RetryCall<TRequest, TResponse> : RetryCallBase<TRequest, T
             call.TryRegisterCancellation(cancellationToken, out var registration);
             try
             {
-                await call.WriteClientStreamAsync(WriteNewMessage, message).ConfigureAwait(false);
+                await call.WriteClientStreamAsync(WriteNewMessage, message, cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -392,7 +392,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
         }
     }
 
-    Task IGrpcCall<TRequest, TResponse>.WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state)
+    Task IGrpcCall<TRequest, TResponse>.WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state, CancellationToken cancellationTokens)
     {
         throw new NotSupportedException();
     }
@@ -504,7 +504,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
             else
             {
                 commitReason = CommitReason.Canceled;
-                resolvedCall = CreateStatusCall(Disposed ? GrpcProtocolConstants.DisposeCanceledStatus : GrpcProtocolConstants.ClientCanceledStatus);
+                resolvedCall = CreateStatusCall(Disposed ? GrpcProtocolConstants.CreateDisposeCanceledStatus(ex) : GrpcProtocolConstants.CreateClientCanceledStatus(ex));
             }
         }
         else

--- a/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
@@ -88,7 +88,7 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
         throw new NotSupportedException();
     }
 
-    public Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state)
+    public Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state, CancellationToken cancellationToken)
     {
         return Task.FromException(new RpcException(_status));
     }

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -317,6 +317,13 @@ internal static partial class StreamExtensions
         catch (Exception ex)
         {
             GrpcCallLog.ErrorSendingMessage(call.Logger, ex);
+
+            // Cancellation from disposing response while waiting for WriteAsync can throw ObjectDisposedException.
+            if (ex is ObjectDisposedException && call.CancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException();
+            }
+
             throw;
         }
         finally

--- a/src/Shared/CompatibilityHelpers.cs
+++ b/src/Shared/CompatibilityHelpers.cs
@@ -58,6 +58,8 @@ internal static class CompatibilityHelpers
 
     public static CancellationTokenRegistration RegisterWithCancellationTokenCallback(CancellationToken cancellationToken, Action<object?, CancellationToken> callback, object? state)
     {
+        // Register overload that provides the CT to the callback required .NET 6 or greater.
+        // Fallback to creating a closure in older platforms.
         return cancellationToken.Register(
 #if NET6_0_OR_GREATER
             callback

--- a/src/Shared/CompatibilityHelpers.cs
+++ b/src/Shared/CompatibilityHelpers.cs
@@ -55,4 +55,15 @@ internal static class CompatibilityHelpers
         }
     }
 #endif
+
+    public static CancellationTokenRegistration RegisterWithCancellationTokenCallback(CancellationToken cancellationToken, Action<object?, CancellationToken> callback, object? state)
+    {
+        return cancellationToken.Register(
+#if NET6_0_OR_GREATER
+            callback
+#else
+            (state) => callback(state, cancellationToken)
+#endif
+            , state);
+    }
 }

--- a/src/Shared/CompatibilityHelpers.cs
+++ b/src/Shared/CompatibilityHelpers.cs
@@ -60,12 +60,10 @@ internal static class CompatibilityHelpers
     {
         // Register overload that provides the CT to the callback required .NET 6 or greater.
         // Fallback to creating a closure in older platforms.
-        return cancellationToken.Register(
 #if NET6_0_OR_GREATER
-            callback
+        return cancellationToken.Register(callback, state);
 #else
-            (state) => callback(state, cancellationToken)
+        return cancellationToken.Register((state) => callback(state, cancellationToken), state);
 #endif
-            , state);
     }
 }

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -22,7 +22,6 @@ using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Tests.Shared;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using NUnit.Framework;
 using Streaming;
 

--- a/test/FunctionalTests/Client/CancellationTests.cs
+++ b/test/FunctionalTests/Client/CancellationTests.cs
@@ -439,8 +439,10 @@ public class CancellationTests : FunctionalTestBase
     public async Task Unary_CancellationAfterDelay_TokenMatchesSource()
     {
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
         async Task<DataMessage> UnaryMethod(DataMessage request, ServerCallContext context)
         {
+            cts.Cancel();
             await tcs.Task;
             return new DataMessage();
         }
@@ -456,8 +458,6 @@ public class CancellationTests : FunctionalTestBase
         var client = TestClientFactory.Create(channel, method);
 
         // Act
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5));
-
         var call = client.UnaryCall(new DataMessage(), new CallOptions(cancellationToken: cts.Token));
 
         // Assert
@@ -502,8 +502,10 @@ public class CancellationTests : FunctionalTestBase
     public async Task ServerStreaming_CancellationAfterDelay_TokenMatchesSource()
     {
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
         async Task ServerStreamingMethod(DataMessage request, IServerStreamWriter<DataMessage> writer, ServerCallContext context)
         {
+            cts.Cancel();
             await tcs.Task;
         }
 
@@ -518,7 +520,6 @@ public class CancellationTests : FunctionalTestBase
         var client = TestClientFactory.Create(channel, method);
 
         // Act
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5));
 
         var call = client.ServerStreamingCall(new DataMessage(), new CallOptions(cancellationToken: cts.Token));
 
@@ -563,8 +564,10 @@ public class CancellationTests : FunctionalTestBase
     public async Task ServerStreaming_MoveNext_CancellationAfterDelay_TokenMatchesSource()
     {
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
         async Task ServerStreamingMethod(DataMessage request, IServerStreamWriter<DataMessage> writer, ServerCallContext context)
         {
+            cts.Cancel();
             await tcs.Task;
         }
 
@@ -579,8 +582,6 @@ public class CancellationTests : FunctionalTestBase
         var client = TestClientFactory.Create(channel, method);
 
         // Act
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5));
-
         var call = client.ServerStreamingCall(new DataMessage());
 
         // Assert
@@ -624,8 +625,10 @@ public class CancellationTests : FunctionalTestBase
     public async Task ClientStreaming_CancellationAfterDelay_TokenMatchesSource()
     {
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
         async Task<DataMessage> ClientStreamingMethod(IAsyncStreamReader<DataMessage> reader, ServerCallContext context)
         {
+            cts.Cancel();
             await tcs.Task;
             return new DataMessage();
         }
@@ -641,8 +644,6 @@ public class CancellationTests : FunctionalTestBase
         var client = TestClientFactory.Create(channel, method);
 
         // Act
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5));
-
         var call = client.ClientStreamingCall(new CallOptions(cancellationToken: cts.Token));
 
         // Assert
@@ -690,8 +691,10 @@ public class CancellationTests : FunctionalTestBase
     public async Task ClientStreaming_WriteAsync_CancellationAfterDelay_TokenMatchesSource()
     {
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
         async Task<DataMessage> ClientStreamingMethod(IAsyncStreamReader<DataMessage> reader, ServerCallContext context)
         {
+            cts.Cancel();
             await tcs.Task;
             return new DataMessage();
         }
@@ -707,8 +710,6 @@ public class CancellationTests : FunctionalTestBase
         var client = TestClientFactory.Create(channel, method);
 
         // Act
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5));
-
         var call = client.ClientStreamingCall();
 
         // Assert

--- a/test/FunctionalTests/Client/HedgingTests.cs
+++ b/test/FunctionalTests/Client/HedgingTests.cs
@@ -861,7 +861,7 @@ public class HedgingTests : FunctionalTestBase
         var client = TestClientFactory.Create(channel, method);
 
         // Act
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(4));
 
         var call = client.ClientStreamingCall();
 
@@ -875,6 +875,7 @@ public class HedgingTests : FunctionalTestBase
         if (throwOperationCanceledOnCancellation)
         {
             var ex = await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => writeTask).DefaultTimeout();
+            Assert.AreEqual(cts.Token, ex.CancellationToken);
             Assert.AreEqual(StatusCode.Cancelled, call.GetStatus().StatusCode);
         }
         else

--- a/test/FunctionalTests/Client/HedgingTests.cs
+++ b/test/FunctionalTests/Client/HedgingTests.cs
@@ -861,7 +861,7 @@ public class HedgingTests : FunctionalTestBase
         var client = TestClientFactory.Create(channel, method);
 
         // Act
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(4));
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
         var call = client.ClientStreamingCall();
 
@@ -875,7 +875,6 @@ public class HedgingTests : FunctionalTestBase
         if (throwOperationCanceledOnCancellation)
         {
             var ex = await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => writeTask).DefaultTimeout();
-            Assert.AreEqual(cts.Token, ex.CancellationToken);
             Assert.AreEqual(StatusCode.Cancelled, call.GetStatus().StatusCode);
         }
         else

--- a/test/Grpc.Net.Client.Tests/CancellationTests.cs
+++ b/test/Grpc.Net.Client.Tests/CancellationTests.cs
@@ -90,7 +90,7 @@ public class CancellationTests
 
         cts.Cancel();
 
-        var ex = await ExceptionAssert.ThrowsAsync<TaskCanceledException>(() => responseTask).DefaultTimeout();
+        var ex = await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => responseTask).DefaultTimeout();
         Assert.AreEqual(StatusCode.Cancelled, call.GetStatus().StatusCode);
         Assert.AreEqual("Call canceled by the client.", call.GetStatus().Detail);
     }

--- a/test/Grpc.Net.Client.Tests/CancellationTests.cs
+++ b/test/Grpc.Net.Client.Tests/CancellationTests.cs
@@ -93,6 +93,8 @@ public class CancellationTests
         var ex = await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => responseTask).DefaultTimeout();
         Assert.AreEqual(StatusCode.Cancelled, call.GetStatus().StatusCode);
         Assert.AreEqual("Call canceled by the client.", call.GetStatus().Detail);
+        Assert.AreEqual(cts.Token, ((OperationCanceledException)call.GetStatus().DebugException!).CancellationToken);
+        Assert.AreEqual(cts.Token, ex.CancellationToken);
     }
 
     [Test]


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2014

We want to report the user specified cancellation token via `OperationCanceledException.CancellationToken` if it is the cause of cancellation. Today, an internal cancellation token is typically provided.