### PR TITLE
Trimming issue workaround in .NET 8

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,10 +20,6 @@
 
     <IsTrimmable>true</IsTrimmable>
     <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
-
-    <!-- .NET 8 issue. Unable to trim netstandard2.1 projects. See https://github.com/dotnet/linker/issues/3175 -->
-    <!-- TODO: Don't use SDK's trimming functionality. Revert once fixed in linker/SDK -->
-    <_IsTrimmingEnabled>false</_IsTrimmingEnabled>
   </PropertyGroup>
 
   <!-- IsGrpcPublishedPackage is set in csproj so related config must be in targets file -->
@@ -33,5 +29,19 @@
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
+
+  <!-- 
+    Make a netstandard2.1 copy of the .net ILLinkPack to work around a trimming issue.
+    See https://github.com/dotnet/linker/issues/3175
+  -->
+  <Target Name="_FixKnownILLinkPack"
+          BeforeTargets="ProcessFrameworkReferences">
+    <ItemGroup>
+      <KnownILLinkPack Include="@(KnownILLinkPack)"
+                       Condition="'%(TargetFramework)' == 'net8.0'"
+                       TargetFramework="netstandard2.1"
+                       ILLinkPackVersion="%(KnownILLinkPack.ILLinkPackVersion)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -33,6 +33,7 @@
   <!-- 
     Make a netstandard2.1 copy of the .net ILLinkPack to work around a trimming issue.
     See https://github.com/dotnet/linker/issues/3175
+    TODO: Remove once .NET 8 + trimming + netstandard2.1 is fixed.
   -->
   <Target Name="_FixKnownILLinkPack"
           BeforeTargets="ProcessFrameworkReferences">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,6 +20,10 @@
 
     <IsTrimmable>true</IsTrimmable>
     <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
+
+    <!-- .NET 8 issue. Unable to trim netstandard2.1 projects. See https://github.com/dotnet/linker/issues/3175 -->
+    <!-- TODO: Don't use SDK's trimming functionality. Revert once fixed in linker/SDK -->
+    <_IsTrimmingEnabled>false</_IsTrimmingEnabled>
   </PropertyGroup>
 
   <!-- IsGrpcPublishedPackage is set in csproj so related config must be in targets file -->


### PR DESCRIPTION
Benchmarks error when run with .NET 8. This is the message:

> C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-6584\u5opm2pa.sf0\sdk\8.0.100-alpha.1.23067.5\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-6584\4tx2lg3s.b24\grpc-dotnet\src\Grpc.Net.Common\Grpc.Net.Common.csproj::TargetFramework=netstandard2.1]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-6584\u5opm2pa.sf0\sdk\8.0.100-alpha.1.23067.5\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1195: Unable to optimize assemblies for size: a valid runtime package was not found. Either set the PublishTrimmed property to false, or use a supported target framework when publishing. [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-6584\4tx2lg3s.b24\grpc-dotnet\src\Grpc.Core.Api\Grpc.Core.Api.csproj::TargetFramework=netstandard2.1]

Fix copied from ~https://github.com/dotnet/runtime/pull/80234~ https://github.com/dotnet/aspnetcore/pull/45879