### PR TITLE
Generate record instead of class

### DIFF
--- a/src/Grpc.Reflection/ReflectionGrpc.cs
+++ b/src/Grpc.Reflection/ReflectionGrpc.cs
@@ -81,9 +81,9 @@ namespace Grpc.Reflection.V1Alpha {
       get { return global::Grpc.Reflection.V1Alpha.ReflectionReflection.Descriptor.Services[0]; }
     }
 
-    /// <summary>Base class for server-side implementations of ServerReflection</summary>
+    /// <summary>Base record for server-side implementations of ServerReflection</summary>
     [grpc::BindServiceMethod(typeof(ServerReflection), "BindService")]
-    public abstract partial class ServerReflectionBase
+    public abstract partial record ServerReflectionBase
     {
       /// <summary>
       /// The reflection service is structured as a bidirectional stream, ensuring


### PR DESCRIPTION
The motivation for this PR is that I'd like to make an adapter that's a record instead of a class.
But since gRPC generates a class instead of a record, it forces my hand to use a class as well, since a record can't inherit from a class.

I want to use a record in my adapter because it turns this:
```
public class XyzAdapter : XyzService.XyzServiceBase
{
	private readonly IAbc _abc;
        // x 10

	public XyzAdapter(
		IAbc abc,
                // x 10
	)
	{
		_abc = abc;
                // x 10
	}
```

into this

```
public record XyzAdapter(
	IAbc Abc,
        // x 10
) : XyzService.XyzServiceBase {
```