### PR TITLE
Fix reporting RpcException from server streaming error

### DIFF
--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -191,6 +191,10 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
                     // Return false to indicate that the stream is complete without a message.
                     return false;
                 }
+                else if (status.StatusCode != StatusCode.DeadlineExceeded && status.StatusCode != StatusCode.Cancelled)
+                {
+                    throw _call.CreateRpcException(status);
+                }
             }
             else
             {

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -930,9 +930,6 @@ public class StreamingTests : FunctionalTestBase
             return true;
         });
 
-        var firstMessageTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var serverCanceledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
         Task ServerStreamingWithError(DataMessage request, IServerStreamWriter<DataMessage> responseStream, ServerCallContext context)
         {
             throw new RpcException(new Status(StatusCode.NotFound, "NotFound"));


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2032

If all of the below are true, fix throwing the status from the server in the client:

* Channel is throwing OperationCanceledException
* Call is made to server streaming method
* Server streaming method returns non-OK status before streaming result
* Client doesn't await server headers