### PR TITLE
Wrap EventSource calls with IsEnabled

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcEventSource.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcEventSource.cs
@@ -23,7 +23,7 @@ using Grpc.Core;
 
 namespace Grpc.AspNetCore.Server.Internal;
 
-internal class GrpcEventSource : EventSource
+internal sealed class GrpcEventSource : EventSource
 {
     public static readonly GrpcEventSource Log = new GrpcEventSource();
 

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcEventSource.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcEventSource.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using Grpc.Core;
@@ -68,6 +69,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 1, Level = EventLevel.Verbose)]
     public void CallStart(string method)
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _totalCalls);
         Interlocked.Increment(ref _currentCalls);
 
@@ -78,6 +81,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 2, Level = EventLevel.Verbose)]
     public void CallStop()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Decrement(ref _currentCalls);
 
         WriteEvent(2);
@@ -87,6 +92,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 3, Level = EventLevel.Error)]
     public void CallFailed(StatusCode statusCode)
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _callsFailed);
 
         WriteEvent(3, (int)statusCode);
@@ -96,6 +103,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 4, Level = EventLevel.Error)]
     public void CallDeadlineExceeded()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _callsDeadlineExceeded);
 
         WriteEvent(4);
@@ -105,6 +114,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 5, Level = EventLevel.Verbose)]
     public void MessageSent()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _messageSent);
 
         WriteEvent(5);
@@ -114,6 +125,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 6, Level = EventLevel.Verbose)]
     public void MessageReceived()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _messageReceived);
 
         WriteEvent(6);
@@ -123,9 +136,18 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 7, Level = EventLevel.Verbose)]
     public void CallUnimplemented(string method)
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _callsUnimplemented);
 
         WriteEvent(7, method);
+    }
+
+    [Conditional("DEBUG")]
+    [NonEvent]
+    private void AssertEventSourceEnabled()
+    {
+        Debug.Assert(IsEnabled(), "Event source should be enabled.");
     }
 
     protected override void OnEventCommand(EventCommandEventArgs command)

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -56,7 +56,6 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
     internal Type RequestType { get; }
     internal Type ResponseType { get; }
     internal string? ResponseGrpcEncoding { get; private set; }
-    internal bool EventSourceEnabled { get; private set; }
 
     internal HttpContextSerializationContext SerializationContext
     {
@@ -298,12 +297,12 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
         }
         if (_status.StatusCode != StatusCode.OK)
         {
-            if (EventSourceEnabled)
+            if (GrpcEventSource.Log.IsEnabled())
             {
                 GrpcEventSource.Log.CallFailed(_status.StatusCode);
             }
         }
-        if (EventSourceEnabled)
+        if (GrpcEventSource.Log.IsEnabled())
         {
             GrpcEventSource.Log.CallStop();
         }
@@ -388,7 +387,6 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
 
         if (GrpcEventSource.Log.IsEnabled())
         {
-            EventSourceEnabled = true;
             GrpcEventSource.Log.CallStart(MethodCore);
         }
 
@@ -470,7 +468,7 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
     internal async Task DeadlineExceededAsync()
     {
         GrpcServerLog.DeadlineExceeded(Logger, GetTimeout());
-        if (EventSourceEnabled)
+        if (GrpcEventSource.Log.IsEnabled())
         {
             GrpcEventSource.Log.CallDeadlineExceeded();
         }

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -65,7 +65,10 @@ internal static partial class PipeExtensions
             serializer(response, serializationContext);
 
             GrpcServerLog.MessageSent(serverCallContext.Logger);
-            GrpcEventSource.Log.MessageSent();
+            if (serverCallContext.EventSourceEnabled)
+            {
+                GrpcEventSource.Log.MessageSent();
+            }
         }
         catch (Exception ex)
         {
@@ -112,7 +115,10 @@ internal static partial class PipeExtensions
             }
 
             GrpcServerLog.MessageSent(serverCallContext.Logger);
-            GrpcEventSource.Log.MessageSent();
+            if (serverCallContext.EventSourceEnabled)
+            {
+                GrpcEventSource.Log.MessageSent();
+            }
         }
         catch (Exception ex)
         {
@@ -226,8 +232,10 @@ internal static partial class PipeExtensions
                             serverCallContext.DeserializationContext.SetPayload(null);
 
                             GrpcServerLog.ReceivedMessage(logger);
-
-                            GrpcEventSource.Log.MessageReceived();
+                            if (serverCallContext.EventSourceEnabled)
+                            {
+                                GrpcEventSource.Log.MessageReceived();
+                            }
 
                             // Store the request
                             // Need to verify the request completes with no additional data
@@ -318,8 +326,10 @@ internal static partial class PipeExtensions
                             serverCallContext.DeserializationContext.SetPayload(null);
 
                             GrpcServerLog.ReceivedMessage(logger);
-
-                            GrpcEventSource.Log.MessageReceived();
+                            if (serverCallContext.EventSourceEnabled)
+                            {
+                                GrpcEventSource.Log.MessageReceived();
+                            }
 
                             return request;
                         }

--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -65,7 +65,7 @@ internal static partial class PipeExtensions
             serializer(response, serializationContext);
 
             GrpcServerLog.MessageSent(serverCallContext.Logger);
-            if (serverCallContext.EventSourceEnabled)
+            if (GrpcEventSource.Log.IsEnabled())
             {
                 GrpcEventSource.Log.MessageSent();
             }
@@ -115,7 +115,7 @@ internal static partial class PipeExtensions
             }
 
             GrpcServerLog.MessageSent(serverCallContext.Logger);
-            if (serverCallContext.EventSourceEnabled)
+            if (GrpcEventSource.Log.IsEnabled())
             {
                 GrpcEventSource.Log.MessageSent();
             }
@@ -232,7 +232,7 @@ internal static partial class PipeExtensions
                             serverCallContext.DeserializationContext.SetPayload(null);
 
                             GrpcServerLog.ReceivedMessage(logger);
-                            if (serverCallContext.EventSourceEnabled)
+                            if (GrpcEventSource.Log.IsEnabled())
                             {
                                 GrpcEventSource.Log.MessageReceived();
                             }
@@ -326,7 +326,7 @@ internal static partial class PipeExtensions
                             serverCallContext.DeserializationContext.SetPayload(null);
 
                             GrpcServerLog.ReceivedMessage(logger);
-                            if (serverCallContext.EventSourceEnabled)
+                            if (GrpcEventSource.Log.IsEnabled())
                             {
                                 GrpcEventSource.Log.MessageReceived();
                             }

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -118,8 +118,10 @@ internal partial class ServerCallHandlerFactory<
 
             var unimplementedMethod = httpContext.Request.RouteValues["unimplementedMethod"]?.ToString() ?? "<unknown>";
             Log.MethodUnimplemented(logger, unimplementedMethod);
-            GrpcEventSource.Log.CallUnimplemented(httpContext.Request.Path.Value!);
-
+            if (GrpcEventSource.Log.IsEnabled())
+            {
+                GrpcEventSource.Log.CallUnimplemented(httpContext.Request.Path.Value!);
+            }
             GrpcProtocolHelpers.SetStatus(GrpcProtocolHelpers.GetTrailersDestination(httpContext.Response), new Status(StatusCode.Unimplemented, "Method is unimplemented."));
             return Task.CompletedTask;
         };
@@ -146,8 +148,10 @@ internal partial class ServerCallHandlerFactory<
 
             var unimplementedService = httpContext.Request.RouteValues["unimplementedService"]?.ToString() ?? "<unknown>";
             Log.ServiceUnimplemented(logger, unimplementedService);
-            GrpcEventSource.Log.CallUnimplemented(httpContext.Request.Path.Value!);
-
+            if (GrpcEventSource.Log.IsEnabled())
+            {
+                GrpcEventSource.Log.CallUnimplemented(httpContext.Request.Path.Value!);
+            }
             GrpcProtocolHelpers.SetStatus(GrpcProtocolHelpers.GetTrailersDestination(httpContext.Response), new Status(StatusCode.Unimplemented, "Service is unimplemented."));
             return Task.CompletedTask;
         };

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -585,8 +585,10 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                         }
                         else
                         {
-                            GrpcEventSource.Log.MessageReceived();
-
+                            if (GrpcEventSource.Log.IsEnabled())
+                            {
+                                GrpcEventSource.Log.MessageReceived();
+                            }
                             FinishResponseAndCleanUp(status.Value);
                             finished = FinishCall(request, diagnosticSourceEnabled, activity, status.Value);
 
@@ -808,7 +810,10 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
     private (bool diagnosticSourceEnabled, Activity? activity) InitializeCall(HttpRequestMessage request, TimeSpan? timeout)
     {
-        GrpcCallLog.StartingCall(Logger, Method.Type, request.RequestUri!);
+        if (GrpcEventSource.Log.IsEnabled())
+        {
+            GrpcCallLog.StartingCall(Logger, Method.Type, request.RequestUri!);
+        }
         GrpcEventSource.Log.CallStart(Method.FullName);
 
         // Deadline will cancel the call CTS.
@@ -882,19 +887,26 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                     if (IsDeadlineExceededUnsynchronized())
                     {
                         GrpcCallLog.DeadlineExceeded(Logger);
-                        GrpcEventSource.Log.CallDeadlineExceeded();
-
+                        if (GrpcEventSource.Log.IsEnabled())
+                        {
+                            GrpcEventSource.Log.CallDeadlineExceeded();
+                        }
                         _deadline = DateTime.MaxValue;
                     }
                 }
             }
 
             GrpcCallLog.GrpcStatusError(Logger, status.StatusCode, status.Detail);
-            GrpcEventSource.Log.CallFailed(status.StatusCode);
+            if (GrpcEventSource.Log.IsEnabled())
+            {
+                GrpcEventSource.Log.CallFailed(status.StatusCode);
+            }
         }
         GrpcCallLog.FinishedCall(Logger);
-        GrpcEventSource.Log.CallStop();
-
+        if (GrpcEventSource.Log.IsEnabled())
+        {
+            GrpcEventSource.Log.CallStop();
+        }
         // Activity needs to be stopped in the same execution context it was started
         if (activity != null)
         {
@@ -1096,8 +1108,10 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         Debug.Assert(Monitor.IsEntered(this));
 
         GrpcCallLog.DeadlineExceeded(Logger);
-        GrpcEventSource.Log.CallDeadlineExceeded();
-
+        if (GrpcEventSource.Log.IsEnabled())
+        {
+            GrpcEventSource.Log.CallDeadlineExceeded();
+        }
         // Set _deadline to DateTime.MaxValue to signal that deadline has been exceeded.
         // This prevents duplicate logging and cancellation.
         _deadline = DateTime.MaxValue;

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -810,11 +810,11 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
     private (bool diagnosticSourceEnabled, Activity? activity) InitializeCall(HttpRequestMessage request, TimeSpan? timeout)
     {
+        GrpcCallLog.StartingCall(Logger, Method.Type, request.RequestUri!);
         if (GrpcEventSource.Log.IsEnabled())
         {
-            GrpcCallLog.StartingCall(Logger, Method.Type, request.RequestUri!);
+            GrpcEventSource.Log.CallStart(Method.FullName);
         }
-        GrpcEventSource.Log.CallStart(Method.FullName);
 
         // Deadline will cancel the call CTS.
         // Only exceed deadline/start timer after reader/writer have been created, otherwise deadline will cancel

--- a/src/Grpc.Net.Client/Internal/GrpcEventSource.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcEventSource.cs
@@ -23,7 +23,7 @@ using Grpc.Core;
 
 namespace Grpc.Net.Client.Internal;
 
-internal class GrpcEventSource : EventSource
+internal sealed class GrpcEventSource : EventSource
 {
     public static readonly GrpcEventSource Log = new GrpcEventSource();
 

--- a/src/Grpc.Net.Client/Internal/GrpcEventSource.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcEventSource.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using Grpc.Core;
@@ -68,6 +69,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 1, Level = EventLevel.Verbose)]
     public void CallStart(string method)
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _totalCalls);
         Interlocked.Increment(ref _currentCalls);
 
@@ -78,6 +81,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 2, Level = EventLevel.Verbose)]
     public void CallStop()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Decrement(ref _currentCalls);
 
         WriteEvent(2);
@@ -87,6 +92,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 3, Level = EventLevel.Error)]
     public void CallFailed(StatusCode statusCode)
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _callsFailed);
 
         WriteEvent(3, (int)statusCode);
@@ -96,6 +103,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 4, Level = EventLevel.Error)]
     public void CallDeadlineExceeded()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _callsDeadlineExceeded);
 
         WriteEvent(4);
@@ -105,6 +114,8 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 5, Level = EventLevel.Verbose)]
     public void MessageSent()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _messageSent);
 
         WriteEvent(5);
@@ -114,9 +125,18 @@ internal class GrpcEventSource : EventSource
     [Event(eventId: 6, Level = EventLevel.Verbose)]
     public void MessageReceived()
     {
+        AssertEventSourceEnabled();
+
         Interlocked.Increment(ref _messageReceived);
 
         WriteEvent(6);
+    }
+
+    [Conditional("DEBUG")]
+    [NonEvent]
+    private void AssertEventSourceEnabled()
+    {
+        Debug.Assert(IsEnabled(), "Event source should be enabled.");
     }
 
     protected override void OnEventCommand(EventCommandEventArgs command)

--- a/src/Grpc.Net.Client/Internal/Http/PushUnaryContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/PushUnaryContent.cs
@@ -47,7 +47,10 @@ internal class PushUnaryContent<TRequest, TResponse> : HttpContent
 #pragma warning restore CA2012 // Use ValueTasks correctly
         if (writeMessageTask.IsCompletedSuccessfully())
         {
-            GrpcEventSource.Log.MessageSent();
+            if (GrpcEventSource.Log.IsEnabled())
+            {
+                GrpcEventSource.Log.MessageSent();
+            }
             return Task.CompletedTask;
         }
 
@@ -57,7 +60,10 @@ internal class PushUnaryContent<TRequest, TResponse> : HttpContent
     private static async Task WriteMessageCore(ValueTask writeMessageTask)
     {
         await writeMessageTask.ConfigureAwait(false);
-        GrpcEventSource.Log.MessageSent();
+        if (GrpcEventSource.Log.IsEnabled())
+        {
+            GrpcEventSource.Log.MessageSent();
+        }
     }
 
     protected override bool TryComputeLength(out long length)

--- a/src/Grpc.Net.Client/Internal/Http/WinHttpUnaryContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/WinHttpUnaryContent.cs
@@ -54,7 +54,10 @@ internal class WinHttpUnaryContent<TRequest, TResponse> : HttpContent
 #pragma warning restore CA2012 // Use ValueTasks correctly
         if (writeMessageTask.IsCompletedSuccessfully())
         {
-            GrpcEventSource.Log.MessageSent();
+            if (GrpcEventSource.Log.IsEnabled())
+            {
+                GrpcEventSource.Log.MessageSent();
+            }
             return Task.CompletedTask;
         }
 
@@ -64,7 +67,10 @@ internal class WinHttpUnaryContent<TRequest, TResponse> : HttpContent
     private static async Task WriteMessageCore(ValueTask writeMessageTask)
     {
         await writeMessageTask.ConfigureAwait(false);
-        GrpcEventSource.Log.MessageSent();
+        if (GrpcEventSource.Log.IsEnabled())
+        {
+            GrpcEventSource.Log.MessageSent();
+        }
     }
 
     protected override bool TryComputeLength(out long length)

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -173,8 +173,10 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
                 Current = null!;
                 return false;
             }
-
-            GrpcEventSource.Log.MessageReceived();
+            if (GrpcEventSource.Log.IsEnabled())
+            {
+                GrpcEventSource.Log.MessageReceived();
+            }
             Current = readMessage!;
             return true;
         }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -174,8 +174,10 @@ internal class HttpContentClientStreamWriter<TRequest, TResponse> : ClientStream
 
             // Flush stream to ensure messages are sent immediately.
             await writeStream.FlushAsync(_call.CancellationToken).ConfigureAwait(false);
-
-            GrpcEventSource.Log.MessageSent();
+            if (GrpcEventSource.Log.IsEnabled())
+            {
+                GrpcEventSource.Log.MessageSent();
+            }
         }
         catch (OperationCanceledException ex)
         {


### PR DESCRIPTION
Wrap event source calls with IsEnabled to avoid `Interlocked.Increment` calls inside the methods.

Small perf improvement:
* **Before** 956,933
* **After** 966,092

The perf improvement will be much bigger with AOT + ARM: https://github.com/dotnet/runtime/issues/73246