### PR TITLE
Improve error message with invalid headers

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpResponseExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpResponseExtensions.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -31,7 +31,14 @@ internal static class HttpResponseExtensions
             foreach (var trailer in context.ResponseTrailers)
             {
                 var value = (trailer.IsBinary) ? Convert.ToBase64String(trailer.ValueBytes) : trailer.Value;
-                trailersDestination.Append(trailer.Key, value);
+                try
+                {
+                    trailersDestination.Append(trailer.Key, value);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"Error adding response trailer '{trailer.Key}'.", ex);
+                }
             }
         }
 

--- a/test/FunctionalTests/Client/TrailerMetadataTests.cs
+++ b/test/FunctionalTests/Client/TrailerMetadataTests.cs
@@ -21,7 +21,6 @@ using Greet;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Tests.Shared;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 namespace Grpc.AspNetCore.FunctionalTests.Server;


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/32577

The error message makes debugging which trailer has an invalid character easier.