### PR TITLE
Change proxy detection to log a message

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -269,11 +269,11 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
             // - HttpClient.DefaultProxy. Set via environment variables, e.g. HTTPS_PROXY.
             if (type == HttpHandlerType.SocketsHttpHandler)
             {
-                if (IsProxied(socketsHttpHandler, address, isSecure) is { } proxyUri)
+                if (IsProxied(socketsHttpHandler, address, isSecure))
                 {
-                    logger.LogInformation("A proxy is detected. The way the gRPC client creates connections can cause unexpected behavior when a proxy is configured. " +
-                        "To ensure a proxy is correctly used by the client, configure GrpcChannelOptions.HttpHandler to use HttpClientHandler. " +
-                        "Note that HttpClientHandler isn't compatible with load balancing.", proxyUri);
+                    logger.LogInformation("Proxy configuration is detected. How the gRPC client creates connections can cause unexpected behavior when configuring a proxy. " +
+                        "To ensure the client correctly uses a proxy, configure GrpcChannelOptions.HttpHandler to use HttpClientHandler. " +
+                        "Note that HttpClientHandler isn't compatible with load balancing.");
                 }
             }
 #else

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -271,7 +271,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
             {
                 if (IsProxied(socketsHttpHandler, address, isSecure))
                 {
-                    logger.LogInformation("Proxy configuration is detected. How the gRPC client creates connections can cause unexpected behavior when configuring a proxy. " +
+                    logger.LogInformation("Proxy configuration is detected. How the gRPC client creates connections can cause unexpected behavior when a proxy is configured. " +
                         "To ensure the client correctly uses a proxy, configure GrpcChannelOptions.HttpHandler to use HttpClientHandler. " +
                         "Note that HttpClientHandler isn't compatible with load balancing.");
                 }


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/2075. Still looking for a good solution. In the meantime, keep the old behavior and log a message.

This reverts the functional change in https://github.com/grpc/grpc-dotnet/pull/1863