### PR TITLE
Update Grpc.Tools dependency to 2.53.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <GoogleProtobufPackageVersion>3.22.0</GoogleProtobufPackageVersion>
     <GrpcDotNetPackageVersion>2.49.0</GrpcDotNetPackageVersion>  <!-- Used by example projects -->
     <GrpcPackageVersion>2.46.6</GrpcPackageVersion>
-    <GrpcToolsPackageVersion>2.52.0</GrpcToolsPackageVersion>
+    <GrpcToolsPackageVersion>2.53.0</GrpcToolsPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>7.0.0</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp6PackageVersion>6.0.11</MicrosoftAspNetCoreApp6PackageVersion>
     <MicrosoftAspNetCoreApp5PackageVersion>5.0.3</MicrosoftAspNetCoreApp5PackageVersion>


### PR DESCRIPTION
I'm going to cut the 2.53.x release branch right after merging.