### PR TITLE
Enable NRTs throughout

### DIFF
--- a/perf/benchmarkapps/QpsWorker/Infrastructure/ClientRunner.cs
+++ b/perf/benchmarkapps/QpsWorker/Infrastructure/ClientRunner.cs
@@ -304,7 +304,7 @@ public class ClientRunner
             return RunGenericStreamingAsync(channel, timer);
         }
 
-        GrpcPreconditions.CheckNotNull(_payloadConfig.SimpleParams);
+        GrpcPreconditions.CheckNotNull(_payloadConfig.SimpleParams, "SimpleParams");
         if (_clientType == ClientType.SyncClient)
         {
             GrpcPreconditions.CheckArgument(_rpcType == RpcType.Unary, "Sync client can only be used for Unary calls in C#");
@@ -326,7 +326,7 @@ public class ClientRunner
 
     private SimpleRequest CreateSimpleRequest()
     {
-        GrpcPreconditions.CheckNotNull(_payloadConfig.SimpleParams);
+        GrpcPreconditions.CheckNotNull(_payloadConfig.SimpleParams, "SimpleParams");
         return new SimpleRequest
         {
             Payload = CreateZerosPayload(_payloadConfig.SimpleParams.ReqSize),

--- a/src/Grpc.Auth/GoogleAuthInterceptors.cs
+++ b/src/Grpc.Auth/GoogleAuthInterceptors.cs
@@ -16,9 +16,6 @@
 
 #endregion
 
-using System.Threading;
-using System.Threading.Tasks;
-
 using Google.Apis.Auth.OAuth2;
 using Grpc.Core;
 using Grpc.Core.Utils;
@@ -83,7 +80,7 @@ public static class GoogleAuthInterceptors
     /// <returns>The interceptor.</returns>
     public static AsyncAuthInterceptor FromAccessToken(string accessToken)
     {
-        GrpcPreconditions.CheckNotNull(accessToken);
+        GrpcPreconditions.CheckNotNull(accessToken, nameof(accessToken));
         return new AsyncAuthInterceptor((context, metadata) =>
         {
             metadata.Add(CreateBearerTokenHeader(accessToken));

--- a/src/Grpc.Core.Api/AsyncAuthInterceptor.cs
+++ b/src/Grpc.Core.Api/AsyncAuthInterceptor.cs
@@ -16,11 +16,7 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-
-using Grpc.Core.Internal;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core;
@@ -46,8 +42,8 @@ public class AuthInterceptorContext
     /// </summary>
     public AuthInterceptorContext(string serviceUrl, string methodName)
     {
-        this.serviceUrl = GrpcPreconditions.CheckNotNull(serviceUrl);
-        this.methodName = GrpcPreconditions.CheckNotNull(methodName);
+        this.serviceUrl = GrpcPreconditions.CheckNotNull(serviceUrl, nameof(serviceUrl));
+        this.methodName = GrpcPreconditions.CheckNotNull(methodName, nameof(methodName));
     }
 
     /// <summary>

--- a/src/Grpc.Core.Api/AuthContext.cs
+++ b/src/Grpc.Core.Api/AuthContext.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Grpc.Core.Utils;
@@ -31,8 +30,8 @@ namespace Grpc.Core;
 /// </summary>
 public class AuthContext
 {
-    string? peerIdentityPropertyName;
-    Dictionary<string, List<AuthProperty>> properties;
+    private readonly string? peerIdentityPropertyName;
+    private readonly Dictionary<string, List<AuthProperty>> properties;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="T:Grpc.Core.AuthContext"/> class.
@@ -42,7 +41,7 @@ public class AuthContext
     public AuthContext(string? peerIdentityPropertyName, Dictionary<string, List<AuthProperty>> properties)
     {
         this.peerIdentityPropertyName = peerIdentityPropertyName;
-        this.properties = GrpcPreconditions.CheckNotNull(properties);
+        this.properties = GrpcPreconditions.CheckNotNull(properties, nameof(properties));
     }
 
     /// <summary>
@@ -101,8 +100,7 @@ public class AuthContext
     /// </summary>
     public IEnumerable<AuthProperty> FindPropertiesByName(string propertyName)
     {
-        List<AuthProperty>? result;
-        if (!properties.TryGetValue(propertyName, out result))
+        if (!properties.TryGetValue(propertyName, out var result))
         {
             return Enumerable.Empty<AuthProperty>();
         }

--- a/src/Grpc.Core.Api/AuthProperty.cs
+++ b/src/Grpc.Core.Api/AuthProperty.cs
@@ -29,14 +29,15 @@ namespace Grpc.Core;
 public class AuthProperty
 {
     static readonly Encoding EncodingUTF8 = System.Text.Encoding.UTF8;
-    string name;
-    byte[] valueBytes;
-    string? lazyValue;
+
+    private readonly string name;
+    private readonly byte[] valueBytes;
+    private string? lazyValue;
 
     private AuthProperty(string name, byte[] valueBytes)
     {
-        this.name = GrpcPreconditions.CheckNotNull(name);
-        this.valueBytes = GrpcPreconditions.CheckNotNull(valueBytes);
+        this.name = GrpcPreconditions.CheckNotNull(name, nameof(name));
+        this.valueBytes = GrpcPreconditions.CheckNotNull(valueBytes, nameof(valueBytes));
     }
 
     /// <summary>
@@ -57,7 +58,7 @@ public class AuthProperty
     {
         get
         {
-            return lazyValue ?? (lazyValue = EncodingUTF8.GetString(this.valueBytes));
+            return lazyValue ??= EncodingUTF8.GetString(this.valueBytes);
         }
     }
 
@@ -81,7 +82,7 @@ public class AuthProperty
     /// <param name="valueBytes">the binary value of the property</param>
     public static AuthProperty Create(string name, byte[] valueBytes)
     {
-        GrpcPreconditions.CheckNotNull(valueBytes);
+        GrpcPreconditions.CheckNotNull(valueBytes, nameof(valueBytes));
         var valueCopy = new byte[valueBytes.Length];
         Buffer.BlockCopy(valueBytes, 0, valueCopy, 0, valueBytes.Length);
         return new AuthProperty(name, valueCopy);

--- a/src/Grpc.Core.Api/CallCredentials.cs
+++ b/src/Grpc.Core.Api/CallCredentials.cs
@@ -17,9 +17,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-
-using Grpc.Core.Internal;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core;
@@ -78,7 +75,7 @@ public abstract class CallCredentials
 
         public AsyncAuthInterceptorCredentials(AsyncAuthInterceptor interceptor)
         {
-            this.interceptor = GrpcPreconditions.CheckNotNull(interceptor);
+            this.interceptor = GrpcPreconditions.CheckNotNull(interceptor, nameof(interceptor));
         }
 
         public override void InternalPopulateConfiguration(CallCredentialsConfiguratorBase configurator, object? state)

--- a/src/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/Grpc.Core.Api/ChannelCredentials.cs
@@ -16,11 +16,6 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Threading.Tasks;
-using Grpc.Core.Internal;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core;
@@ -121,8 +116,8 @@ public abstract class ChannelCredentials
         /// <param name="callCredentials">channelCredentials to compose</param>
         public CompositeChannelCredentials(ChannelCredentials channelCredentials, CallCredentials callCredentials)
         {
-            this.channelCredentials = GrpcPreconditions.CheckNotNull(channelCredentials);
-            this.callCredentials = GrpcPreconditions.CheckNotNull(callCredentials);
+            this.channelCredentials = GrpcPreconditions.CheckNotNull(channelCredentials, nameof(channelCredentials));
+            this.callCredentials = GrpcPreconditions.CheckNotNull(callCredentials, nameof(callCredentials));
         }
 
         public override void InternalPopulateConfiguration(ChannelCredentialsConfiguratorBase configurator, object state)

--- a/src/Grpc.Core.Api/ClientBase.cs
+++ b/src/Grpc.Core.Api/ClientBase.cs
@@ -212,7 +212,7 @@ public abstract class ClientBase
 
         internal ClientBaseConfiguration(CallInvoker undecoratedCallInvoker, string? host)
         {
-            this.undecoratedCallInvoker = GrpcPreconditions.CheckNotNull(undecoratedCallInvoker);
+            this.undecoratedCallInvoker = GrpcPreconditions.CheckNotNull(undecoratedCallInvoker, nameof(undecoratedCallInvoker));
             this.host = host;
         }
 

--- a/src/Grpc.Core.Api/Grpc.Core.Api.csproj
+++ b/src/Grpc.Core.Api/Grpc.Core.Api.csproj
@@ -9,7 +9,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>enable</Nullable>
     <!-- grpc-dotnet global usings break the build. -->
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>

--- a/src/Grpc.Core.Api/Metadata.cs
+++ b/src/Grpc.Core.Api/Metadata.cs
@@ -149,7 +149,6 @@ public sealed class Metadata : IList<Metadata.Entry>
 
     #region IList members
 
-
     /// <summary>
     /// <see cref="T:IList`1"/>
     /// </summary>
@@ -163,7 +162,7 @@ public sealed class Metadata : IList<Metadata.Entry>
     /// </summary>
     public void Insert(int index, Metadata.Entry item)
     {
-        GrpcPreconditions.CheckNotNull(item);
+        GrpcPreconditions.CheckNotNull(item, nameof(item));
         CheckWriteable();
         entries.Insert(index, item);
     }
@@ -189,7 +188,7 @@ public sealed class Metadata : IList<Metadata.Entry>
 
         set
         {
-            GrpcPreconditions.CheckNotNull(value);
+            GrpcPreconditions.CheckNotNull(value, nameof(value));
             CheckWriteable();
             entries[index] = value;
         }
@@ -200,7 +199,7 @@ public sealed class Metadata : IList<Metadata.Entry>
     /// </summary>
     public void Add(Metadata.Entry item)
     {
-        GrpcPreconditions.CheckNotNull(item);
+        GrpcPreconditions.CheckNotNull(item, nameof(item));
         CheckWriteable();
         entries.Add(item);
     }
@@ -462,8 +461,10 @@ public sealed class Metadata : IList<Metadata.Entry>
                     '0' <= c && c <= '9' ||
                     c == '.' ||
                     c == '_' ||
-                    c == '-' )
+                    c == '-')
+                {
                     continue;
+                }
 
                 if ('A' <= c && c <= 'Z')
                 {

--- a/src/Grpc.Core.Api/RpcException.cs
+++ b/src/Grpc.Core.Api/RpcException.cs
@@ -68,7 +68,7 @@ public class RpcException : Exception
     public RpcException(Status status, Metadata trailers, string message) : base(message, status.DebugException)
     {
         this.status = status;
-        this.trailers = GrpcPreconditions.CheckNotNull(trailers);
+        this.trailers = GrpcPreconditions.CheckNotNull(trailers, nameof(trailers));
     }
 
     /// <summary>

--- a/src/Grpc.Core.Api/Utils/GrpcPreconditions.cs
+++ b/src/Grpc.Core.Api/Utils/GrpcPreconditions.cs
@@ -33,8 +33,11 @@ public static class GrpcPreconditions
     {
         if (!condition)
         {
-            throw new ArgumentException();
+            Throw();
         }
+
+        static void Throw()
+            => throw new ArgumentException();
     }
 
     /// <summary>
@@ -46,21 +49,32 @@ public static class GrpcPreconditions
     {
         if (!condition)
         {
-            throw new ArgumentException(errorMessage);
+            Throw(errorMessage);
         }
+
+        static void Throw(string errorMessage)
+            => throw new ArgumentException(errorMessage);
     }
 
     /// <summary>
     /// Throws <see cref="ArgumentNullException"/> if reference is null.
     /// </summary>
     /// <param name="reference">The reference.</param>
+#if DEBUG
+    // this method is on the public API; don't want to break anything
+    // external, but: prevent additional usage locally (i.e. in DEBUG mode)
+    [Obsolete("Specify parameter name when possible", error: true)]
+#endif
     public static T CheckNotNull<T>(T reference)
     {
-        if (reference == null)
+        if (reference is null)
         {
-            throw new ArgumentNullException();
+            Throw();
         }
         return reference;
+
+        static void Throw()
+            => throw new ArgumentNullException();
     }
 
     /// <summary>
@@ -70,11 +84,14 @@ public static class GrpcPreconditions
     /// <param name="paramName">The parameter name.</param>
     public static T CheckNotNull<T>(T reference, string paramName)
     {
-        if (reference == null)
+        if (reference is null)
         {
-            throw new ArgumentNullException(paramName);
+            Throw(paramName);
         }
         return reference;
+
+        static void Throw(string paramName)
+            => throw new ArgumentNullException(paramName);
     }
 
     /// <summary>
@@ -85,8 +102,10 @@ public static class GrpcPreconditions
     {
         if (!condition)
         {
-            throw new InvalidOperationException();
+            Throw();
         }
+        static void Throw()
+            => throw new InvalidOperationException();
     }
 
     /// <summary>
@@ -98,7 +117,9 @@ public static class GrpcPreconditions
     {
         if (!condition)
         {
-            throw new InvalidOperationException(errorMessage);
+            Throw(errorMessage);
         }
+        static void Throw(string errorMessage)
+            => throw new InvalidOperationException(errorMessage);
     }
 }

--- a/src/Grpc.HealthCheck/Grpc.HealthCheck.csproj
+++ b/src/Grpc.HealthCheck/Grpc.HealthCheck.csproj
@@ -7,9 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>net462;netstandard1.5;netstandard2.0</TargetFrameworks>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-
-    <!-- TODO(jtattermusch): re-enable nullable -->
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc.HealthCheck/HealthServiceImpl.cs
+++ b/src/Grpc.HealthCheck/HealthServiceImpl.cs
@@ -14,13 +14,10 @@
 // limitations under the License.
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 
 using Grpc.Core;
+using Grpc.Core.Utils;
 using Grpc.Health.V1;
 
 namespace Grpc.HealthCheck;
@@ -227,11 +224,10 @@ public class HealthServiceImpl : Grpc.Health.V1.Health.HealthBase
 
     private HealthCheckResponse GetHealthCheckResponse(string service, bool throwOnNotFound)
     {
-        HealthCheckResponse response = null;
+        HealthCheckResponse response;
         lock (statusLock)
         {
-            HealthCheckResponse.Types.ServingStatus status;
-            if (!statusMap.TryGetValue(service, out status))
+            if (!statusMap.TryGetValue(service, out HealthCheckResponse.Types.ServingStatus status))
             {
                 if (throwOnNotFound)
                 {
@@ -251,6 +247,7 @@ public class HealthServiceImpl : Grpc.Health.V1.Health.HealthBase
 
     private HealthCheckResponse.Types.ServingStatus GetServiceStatus(string service)
     {
+        GrpcPreconditions.CheckNotNull(service, nameof(service));
         if (statusMap.TryGetValue(service, out HealthCheckResponse.Types.ServingStatus s))
         {
             return s;

--- a/src/Grpc.Reflection/Grpc.Reflection.csproj
+++ b/src/Grpc.Reflection/Grpc.Reflection.csproj
@@ -7,9 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>net462;netstandard1.5;netstandard2.0</TargetFrameworks>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-
-    <!-- TODO(jtattermusch): re-enable nullable -->
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc.Reflection/ReflectionServiceImpl.cs
+++ b/src/Grpc.Reflection/ReflectionServiceImpl.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 // Copyright 2015 gRPC authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +14,9 @@
 // limitations under the License.
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Grpc.Core;
-using Grpc.Core.Utils;
-using Grpc.Reflection.V1Alpha;
 using Google.Protobuf.Reflection;
+using Grpc.Core;
+using Grpc.Reflection.V1Alpha;
 
 namespace Grpc.Reflection;
 
@@ -91,8 +84,8 @@ public class ReflectionServiceImpl : Grpc.Reflection.V1Alpha.ServerReflection.Se
 
     ServerReflectionResponse FileByFilename(string filename)
     {
-        FileDescriptor file = symbolRegistry.FileByName(filename);
-        if (file == null)
+        FileDescriptor? file = symbolRegistry.FileByName(filename);
+        if (file is null)
         {
             return CreateErrorResponse(StatusCode.NotFound, "File not found.");
         }
@@ -108,8 +101,8 @@ public class ReflectionServiceImpl : Grpc.Reflection.V1Alpha.ServerReflection.Se
 
     ServerReflectionResponse FileContainingSymbol(string symbol)
     {
-        FileDescriptor file = symbolRegistry.FileContainingSymbol(symbol);
-        if (file == null)
+        FileDescriptor? file = symbolRegistry.FileContainingSymbol(symbol);
+        if (file is null)
         {
             return CreateErrorResponse(StatusCode.NotFound, "Symbol not found.");
         }
@@ -126,7 +119,7 @@ public class ReflectionServiceImpl : Grpc.Reflection.V1Alpha.ServerReflection.Se
     ServerReflectionResponse ListServices()
     {
         var serviceResponses = new ListServiceResponse();
-        foreach (string serviceName in services)
+        foreach (var serviceName in services)
         {
             serviceResponses.Service.Add(new ServiceResponse { Name = serviceName });
         }

--- a/src/Grpc.Reflection/SymbolRegistry.cs
+++ b/src/Grpc.Reflection/SymbolRegistry.cs
@@ -38,7 +38,7 @@ public class SymbolRegistry
     /// <returns>A symbol registry for the given files.</returns>
     public static SymbolRegistry FromFiles(IEnumerable<FileDescriptor> fileDescriptors)
     {
-        GrpcPreconditions.CheckNotNull(fileDescriptors);
+        GrpcPreconditions.CheckNotNull(fileDescriptors, nameof(fileDescriptors));
         var builder = new Builder();
         foreach (var file in fileDescriptors)
         {
@@ -50,20 +50,18 @@ public class SymbolRegistry
     /// <summary>
     /// Gets file descriptor for given file name (including package path). Returns <c>null</c> if not found.
     /// </summary>
-    public FileDescriptor FileByName(string filename)
+    public FileDescriptor? FileByName(string filename)
     {
-        FileDescriptor file;
-        filesByName.TryGetValue(filename, out file);
+        filesByName.TryGetValue(filename, out var file);
         return file;
     }
 
     /// <summary>
     /// Gets file descriptor that contains definition of given symbol full name (including package path). Returns <c>null</c> if not found.
     /// </summary>
-    public FileDescriptor FileContainingSymbol(string symbol)
+    public FileDescriptor? FileContainingSymbol(string symbol)
     {
-        FileDescriptor file;
-        filesBySymbol.TryGetValue(symbol, out file);
+        filesBySymbol.TryGetValue(symbol, out var file);
         return file;
     }
 

--- a/test/Grpc.AspNetCore.Server.Tests/HealthChecks/GrpcHealthChecksPublisherTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/HealthChecks/GrpcHealthChecksPublisherTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -41,7 +41,7 @@ public class GrpcHealthChecksPublisherTests
         HealthCheckResponse response;
 
         // Act 1
-        var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => healthService.Check(new HealthCheckRequest { Service = "" }, context: null));
+        var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => healthService.Check(new HealthCheckRequest { Service = "" }, context: null!));
 
         // Assert 1
         Assert.AreEqual(StatusCode.NotFound, ex.StatusCode);
@@ -50,7 +50,7 @@ public class GrpcHealthChecksPublisherTests
         var report = CreateSimpleHealthReport(HealthStatus.Healthy);
         await publisher.PublishAsync(report, CancellationToken.None);
 
-        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null!);
 
         // Assert 2
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
@@ -59,7 +59,7 @@ public class GrpcHealthChecksPublisherTests
         report = CreateSimpleHealthReport(HealthStatus.Unhealthy);
         await publisher.PublishAsync(report, CancellationToken.None);
 
-        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null!);
 
         // Act 3
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.NotServing, response.Status);
@@ -80,7 +80,7 @@ public class GrpcHealthChecksPublisherTests
         HealthCheckResponse response;
 
         // Act 1
-        var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => healthService.Check(new HealthCheckRequest { Service = "" }, context: null));
+        var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => healthService.Check(new HealthCheckRequest { Service = "" }, context: null!));
 
         // Assert 1
         Assert.AreEqual(StatusCode.NotFound, ex.StatusCode);
@@ -91,7 +91,7 @@ public class GrpcHealthChecksPublisherTests
             new HealthResult("other", HealthStatus.Healthy, new[] { "exclude" }));
         await publisher.PublishAsync(report, CancellationToken.None);
 
-        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null!);
 
         // Assert 2
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
@@ -102,7 +102,7 @@ public class GrpcHealthChecksPublisherTests
             new HealthResult("other", HealthStatus.Unhealthy, new[] { "exclude" }));
         await publisher.PublishAsync(report, CancellationToken.None);
 
-        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null!);
 
         // Act 3
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
@@ -113,7 +113,7 @@ public class GrpcHealthChecksPublisherTests
             new HealthResult("other", HealthStatus.Unhealthy, new[] { "exclude" }));
         await publisher.PublishAsync(report, CancellationToken.None);
 
-        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = "" }, context: null!);
 
         // Act 4
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.NotServing, response.Status);
@@ -164,13 +164,13 @@ public class GrpcHealthChecksPublisherTests
         await publisher.PublishAsync(report, CancellationToken.None);
 
         // Assert
-        response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Healthy) }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Healthy) }, context: null!);
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
 
-        response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Degraded) }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Degraded) }, context: null!);
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
 
-        response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Unhealthy) }, context: null);
+        response = await healthService.Check(new HealthCheckRequest { Service = nameof(HealthStatus.Unhealthy) }, context: null!);
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.NotServing, response.Status);
     }
 

--- a/test/Grpc.Core.Api.Tests/AuthContextTest.cs
+++ b/test/Grpc.Core.Api.Tests/AuthContextTest.cs
@@ -16,11 +16,9 @@
 
 #endregion
 
-using System;
 using System.Collections.Generic;
-using NUnit.Framework;
-using Grpc.Core;
 using System.Linq;
+using NUnit.Framework;
 
 namespace Grpc.Core.Tests;
 

--- a/test/Grpc.Core.Api.Tests/AuthPropertyTest.cs
+++ b/test/Grpc.Core.Api.Tests/AuthPropertyTest.cs
@@ -26,15 +26,15 @@ public class AuthPropertyTest
     [Test]
     public void Create_NameIsNotNull()
     {
-        Assert.Throws(typeof(ArgumentNullException), () => AuthProperty.Create(null, new byte[0]));
-        Assert.Throws(typeof(ArgumentNullException), () => AuthProperty.CreateUnsafe(null, new byte[0]));
+        Assert.AreEqual("name", Assert.Throws<ArgumentNullException>(() => AuthProperty.Create(null!, new byte[0]))!.ParamName);
+        Assert.AreEqual("name", Assert.Throws<ArgumentNullException>(() => AuthProperty.CreateUnsafe(null!, new byte[0]))!.ParamName);
     }
 
     [Test]
     public void Create_ValueIsNotNull()
     {
-        Assert.Throws(typeof(ArgumentNullException), () => AuthProperty.Create("abc", null));
-        Assert.Throws(typeof(ArgumentNullException), () => AuthProperty.CreateUnsafe("abc", null));
+        Assert.AreEqual("valueBytes", Assert.Throws<ArgumentNullException>(() => AuthProperty.Create("abc", null!))!.ParamName);
+        Assert.AreEqual("valueBytes", Assert.Throws<ArgumentNullException>(() => AuthProperty.CreateUnsafe("abc", null!))!.ParamName);
     }
 
     [Test]

--- a/test/Grpc.Core.Api.Tests/CallOptionsTest.cs
+++ b/test/Grpc.Core.Api.Tests/CallOptionsTest.cs
@@ -17,11 +17,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
-using Grpc.Core;
 using Grpc.Core.Internal;
-using Grpc.Core.Utils;
 using NUnit.Framework;
 
 namespace Grpc.Core.Tests;
@@ -37,7 +34,7 @@ public class CallOptionsTest
         Assert.AreSame(metadata, options.WithHeaders(metadata).Headers);
 
         var deadline = DateTime.UtcNow;
-        Assert.AreEqual(deadline, options.WithDeadline(deadline).Deadline.Value);
+        Assert.AreEqual(deadline, options.WithDeadline(deadline).Deadline!.Value);
 
         var cancellationToken = new CancellationTokenSource().Token;
         Assert.AreEqual(cancellationToken, options.WithCancellationToken(cancellationToken).CancellationToken);

--- a/test/Grpc.Core.Api.Tests/ChannelCredentialsTest.cs
+++ b/test/Grpc.Core.Api.Tests/ChannelCredentialsTest.cs
@@ -17,7 +17,6 @@
 #endregion
 
 using System;
-using Grpc.Core.Internal;
 using NUnit.Framework;
 
 namespace Grpc.Core.Tests;
@@ -30,7 +29,7 @@ public class ChannelCredentialsTest
         var composite = ChannelCredentials.Create(new FakeChannelCredentials(true), new FakeCallCredentials());
         Assert.IsFalse(composite.IsComposable);
 
-        Assert.Throws(typeof(ArgumentNullException), () => ChannelCredentials.Create(null, new FakeCallCredentials()));
-        Assert.Throws(typeof(ArgumentNullException), () => ChannelCredentials.Create(new FakeChannelCredentials(true), null));
+        Assert.AreEqual("channelCredentials", Assert.Throws<ArgumentNullException>(() => ChannelCredentials.Create(null!, new FakeCallCredentials()))!.ParamName);
+        Assert.AreEqual("callCredentials", Assert.Throws<ArgumentNullException>(() => ChannelCredentials.Create(new FakeChannelCredentials(true), null!))!.ParamName);
     }
 }

--- a/test/Grpc.Core.Api.Tests/FakeCredentials.cs
+++ b/test/Grpc.Core.Api.Tests/FakeCredentials.cs
@@ -16,8 +16,6 @@
 
 #endregion
 
-using Grpc.Core.Internal;
-
 namespace Grpc.Core.Tests;
 
 internal class FakeChannelCredentials : ChannelCredentials
@@ -42,7 +40,7 @@ internal class FakeChannelCredentials : ChannelCredentials
 
 internal class FakeCallCredentials : CallCredentials
 {
-    public override void InternalPopulateConfiguration(CallCredentialsConfiguratorBase configurator, object state)
+    public override void InternalPopulateConfiguration(CallCredentialsConfiguratorBase configurator, object? state)
     {
         // not invoking the configurator on purpose
     }

--- a/test/Grpc.Core.Api.Tests/Grpc.Core.Api.Tests.csproj
+++ b/test/Grpc.Core.Api.Tests/Grpc.Core.Api.Tests.csproj
@@ -4,7 +4,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <Nullable>disable</Nullable>
     <!-- grpc-dotnet global usings break the build. -->
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>

--- a/test/Grpc.Core.Api.Tests/MarshallerTest.cs
+++ b/test/Grpc.Core.Api.Tests/MarshallerTest.cs
@@ -17,16 +17,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
-using Grpc.Core;
-using Grpc.Core.Internal;
-using Grpc.Core.Utils;
 using NUnit.Framework;
 
 namespace Grpc.Core.Tests;
@@ -49,7 +39,8 @@ public class MarshallerTest
         var serializationContext = new FakeSerializationContext();
         marshaller.ContextualSerializer(origMsg, serializationContext);
 
-        var deserializationContext = new FakeDeserializationContext(serializationContext.Payload);
+        Assert.NotNull(serializationContext.Payload);
+        var deserializationContext = new FakeDeserializationContext(serializationContext.Payload!);
         Assert.AreEqual(origMsg, marshaller.ContextualDeserializer(deserializationContext));
     }
 
@@ -75,7 +66,7 @@ public class MarshallerTest
 
     class FakeSerializationContext : SerializationContext
     {
-        public byte[] Payload;
+        public byte[]? Payload;
         public override void Complete(byte[] payload)
         {
             this.Payload = payload;

--- a/test/Grpc.Core.Api.Tests/MetadataTest.cs
+++ b/test/Grpc.Core.Api.Tests/MetadataTest.cs
@@ -17,15 +17,8 @@
 #endregion
 
 using System;
-using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Grpc.Core;
-using Grpc.Core.Internal;
-using Grpc.Core.Utils;
 using NUnit.Framework;
 
 namespace Grpc.Core.Tests;
@@ -94,9 +87,9 @@ public class MetadataTest
     [Test]
     public void Entry_ConstructionPreconditions()
     {
-        Assert.Throws(typeof(ArgumentNullException), () => new Metadata.Entry(null, "xyz"));
-        Assert.Throws(typeof(ArgumentNullException), () => new Metadata.Entry("abc", (string)null));
-        Assert.Throws(typeof(ArgumentNullException), () => new Metadata.Entry("abc-bin", (byte[])null));
+        Assert.AreEqual("key", Assert.Throws<ArgumentNullException>(() => new Metadata.Entry(null!, "xyz"))!.ParamName);
+        Assert.AreEqual("value", Assert.Throws<ArgumentNullException>(() => new Metadata.Entry("abc", (string)null!))!.ParamName);
+        Assert.AreEqual("valueBytes", Assert.Throws<ArgumentNullException>(() => new Metadata.Entry("abc-bin", (byte[])null!))!.ParamName);
     }
 
     [Test]
@@ -218,7 +211,7 @@ public class MetadataTest
     {
         var metadata = CreateMetadata();
         var enumerator = (metadata as System.Collections.IEnumerable).GetEnumerator();
-        
+
         int i = 0;
         while (enumerator.MoveNext())
         {
@@ -279,13 +272,16 @@ public class MetadataTest
         };
 
         var abcEntry = metadata.Get("abc");
-        Assert.AreEqual("abc-value2", abcEntry.Value);
+        Assert.NotNull(abcEntry);
+        Assert.AreEqual("abc-value2", abcEntry!.Value);
 
         var xyzEntry = metadata.Get("xyz");
-        Assert.AreEqual("xyz-value1", xyzEntry.Value);
+        Assert.NotNull(xyzEntry);
+        Assert.AreEqual("xyz-value1", xyzEntry!.Value);
 
         var abcUppercaseEntry = metadata.Get("AbC");
-        Assert.AreEqual("abc-value2", abcUppercaseEntry.Value);
+        Assert.NotNull(abcUppercaseEntry);
+        Assert.AreEqual("abc-value2", abcUppercaseEntry!.Value);
 
         var notFound = metadata.Get("not-found");
         Assert.AreEqual(null, notFound);

--- a/test/Grpc.Core.Api.Tests/RpcExceptionTest.cs
+++ b/test/Grpc.Core.Api.Tests/RpcExceptionTest.cs
@@ -17,11 +17,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using Grpc.Core;
-using Grpc.Core.Internal;
-using Grpc.Core.Utils;
 using NUnit.Framework;
 
 namespace Grpc.Core.Tests;
@@ -41,7 +36,7 @@ public class RpcExceptionTest
     [Test]
     public void DefaultMessageDoesntContainDebugExceptionStacktrace()
     {
-        Exception someExceptionWithStacktrace = null;
+        Exception someExceptionWithStacktrace;
         try
         {
             throw new ArgumentException("test exception");

--- a/test/Grpc.Core.Api.Tests/VersionInfoTest.cs
+++ b/test/Grpc.Core.Api.Tests/VersionInfoTest.cs
@@ -16,12 +16,8 @@
 
 #endregion
 
-using System;
 using System.Diagnostics;
 using System.Reflection;
-using Grpc.Core;
-using Grpc.Core.Internal;
-using Grpc.Core.Utils;
 using NUnit.Framework;
 
 namespace Grpc.Core.Tests;
@@ -33,16 +29,16 @@ public class VersionInfoTest
     {
         var assembly = typeof(Status).Assembly;  // the Grpc.Core.Api assembly
 
-        var assemblyVersion = assembly.GetName().Version.ToString();
+        var assemblyVersion = assembly!.GetName()!.Version!.ToString()!;
         Assert.AreEqual(VersionInfo.CurrentAssemblyVersion, assemblyVersion);
 
-        string assemblyFileVersion = FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion;
-        string assemblyFileVersionFromAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        string assemblyFileVersion = FileVersionInfo.GetVersionInfo(assembly.Location)!.FileVersion;
+        string assemblyFileVersionFromAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()!.Version;
         Assert.AreEqual(VersionInfo.CurrentAssemblyFileVersion, assemblyFileVersion);
         Assert.AreEqual(VersionInfo.CurrentAssemblyFileVersion, assemblyFileVersionFromAttribute);
 
-        string productVersion = FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion;
-        string informationalVersionFromAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+        string productVersion = FileVersionInfo.GetVersionInfo(assembly.Location)!.ProductVersion;
+        string informationalVersionFromAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
         Assert.AreEqual(productVersion, informationalVersionFromAttribute);
         // grpc-dotnet appends commit SHA to the product version (e.g. "2.45.0-dev+e30038495bd26b812b6684049353c045d1049d3c")
         string productVersionWithoutCommitSha = productVersion.Split('+')[0];

--- a/test/Grpc.HealthCheck.Tests/Grpc.HealthCheck.Tests.csproj
+++ b/test/Grpc.HealthCheck.Tests/Grpc.HealthCheck.Tests.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
-    <!-- TODO(jtattermusch): re-enable nullable -->
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grpc.HealthCheck.Tests/HealthClientServerTest.cs
+++ b/test/Grpc.HealthCheck.Tests/HealthClientServerTest.cs
@@ -14,12 +14,6 @@
 // limitations under the License.
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using Grpc.Core;
 using Grpc.Health.V1;
 using NUnit.Framework;
@@ -32,10 +26,10 @@ namespace Grpc.HealthCheck.Tests;
 public class HealthClientServerTest
 {
     const string Host = "localhost";
-    Server server;
-    Channel channel;
-    Grpc.Health.V1.Health.HealthClient client;
-    Grpc.HealthCheck.HealthServiceImpl serviceImpl;
+    Server? server;
+    Channel? channel;
+    Grpc.Health.V1.Health.HealthClient? client;
+    Grpc.HealthCheck.HealthServiceImpl? serviceImpl;
 
     [OneTimeSetUp]
     public void Init()
@@ -57,24 +51,27 @@ public class HealthClientServerTest
     [OneTimeTearDown]
     public void Cleanup()
     {
-        channel.ShutdownAsync().Wait();
+        channel?.ShutdownAsync().Wait();
 
-        server.ShutdownAsync().Wait();
+        server?.ShutdownAsync().Wait();
     }
 
     [Test]
     public void ServiceIsRunning()
     {
-        serviceImpl.SetStatus("", HealthCheckResponse.Types.ServingStatus.Serving);
+        Assert.NotNull(serviceImpl);
+        serviceImpl!.SetStatus("", HealthCheckResponse.Types.ServingStatus.Serving);
 
-        var response = client.Check(new HealthCheckRequest { Service = "" });
+        Assert.NotNull(client);
+        var response = client!.Check(new HealthCheckRequest { Service = "" });
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
     }
 
     [Test]
     public void ServiceDoesntExist()
     {
-        var ex = Assert.Throws<RpcException>(() => client.Check(new HealthCheckRequest { Service = "nonexistent.service" }));
+        Assert.NotNull(client);
+        var ex = Assert.Throws<RpcException>(() => client!.Check(new HealthCheckRequest { Service = "nonexistent.service" }))!;
         Assert.AreEqual(StatusCode.NotFound, ex.Status.StatusCode);
     }
 

--- a/test/Grpc.HealthCheck.Tests/HealthServiceImplTest.cs
+++ b/test/Grpc.HealthCheck.Tests/HealthServiceImplTest.cs
@@ -14,14 +14,6 @@
 // limitations under the License.
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Grpc.Core;
 using Grpc.Health.V1;
 using NUnit.Framework;
@@ -59,7 +51,7 @@ public class HealthServiceImplTest
 
         impl.ClearStatus("");
 
-        var ex = Assert.Throws<RpcException>(() => GetStatusHelper(impl, ""));
+        var ex = Assert.Throws<RpcException>(() => GetStatusHelper(impl, ""))!;
         Assert.AreEqual(StatusCode.NotFound, ex.Status.StatusCode);
         Assert.AreEqual(HealthCheckResponse.Types.ServingStatus.Unknown, GetStatusHelper(impl, "grpc.test.TestService"));
     }
@@ -80,9 +72,8 @@ public class HealthServiceImplTest
     public void NullsRejected()
     {
         var impl = new HealthServiceImpl();
-        Assert.Throws(typeof(ArgumentNullException), () => impl.SetStatus(null, HealthCheckResponse.Types.ServingStatus.Serving));
-
-        Assert.Throws(typeof(ArgumentNullException), () => impl.ClearStatus(null));
+        Assert.AreEqual("service", Assert.Throws<ArgumentNullException>(() => impl.SetStatus(null!, HealthCheckResponse.Types.ServingStatus.Serving))!.ParamName);
+        Assert.AreEqual("service", Assert.Throws<ArgumentNullException>(() => impl.ClearStatus(null!))!.ParamName);
     }
 
     [Test]
@@ -252,6 +243,6 @@ public class HealthServiceImplTest
 
     private static HealthCheckResponse.Types.ServingStatus GetStatusHelper(HealthServiceImpl impl, string service)
     {
-        return impl.Check(new HealthCheckRequest { Service = service }, null).Result.Status;
+        return impl.Check(new HealthCheckRequest { Service = service }, null!).Result.Status;
     }
 }

--- a/test/Grpc.HealthCheck.Tests/TestServerCallContext.cs
+++ b/test/Grpc.HealthCheck.Tests/TestServerCallContext.cs
@@ -14,10 +14,6 @@
 // limitations under the License.
 #endregion
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Grpc.Core;
 
 namespace Grpc.HealthCheck.Tests;
@@ -31,18 +27,18 @@ internal class TestServerCallContext : ServerCallContext
         _cancellationToken = cancellationToken;
     }
 
-    protected override string MethodCore { get; }
-    protected override string HostCore { get; }
-    protected override string PeerCore { get; }
+    protected override string MethodCore => "";
+    protected override string HostCore => "";
+    protected override string PeerCore => "";
     protected override DateTime DeadlineCore { get; }
-    protected override Metadata RequestHeadersCore { get; }
+    protected override Metadata RequestHeadersCore => Metadata.Empty;
     protected override CancellationToken CancellationTokenCore => _cancellationToken;
-    protected override Metadata ResponseTrailersCore { get; }
+    protected override Metadata ResponseTrailersCore => Metadata.Empty;
     protected override Status StatusCore { get; set; }
-    protected override WriteOptions WriteOptionsCore { get; set; }
-    protected override AuthContext AuthContextCore { get; }
+    protected override WriteOptions? WriteOptionsCore { get; set; }
+    protected override AuthContext AuthContextCore => null!;
 
-    protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions options)
+    protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions? options)
     {
         throw new NotImplementedException();
     }

--- a/test/Grpc.Reflection.Tests/Grpc.Reflection.Tests.csproj
+++ b/test/Grpc.Reflection.Tests/Grpc.Reflection.Tests.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
-    <!-- TODO(jtattermusch): re-enable nullable -->
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Grpc.Reflection.Tests/ReflectionClientServerTest.cs
+++ b/test/Grpc.Reflection.Tests/ReflectionClientServerTest.cs
@@ -14,14 +14,7 @@
 // limitations under the License.
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using Grpc.Core;
-using Grpc.Reflection;
 using Grpc.Reflection.V1Alpha;
 using NUnit.Framework;
 
@@ -33,10 +26,10 @@ namespace Grpc.Reflection.Tests;
 public class ReflectionClientServerTest
 {
     const string Host = "localhost";
-    Server server;
-    Channel channel;
-    ServerReflection.ServerReflectionClient client;
-    ReflectionServiceImpl serviceImpl;
+    Server? server;
+    Channel? channel;
+    ServerReflection.ServerReflectionClient? client;
+    ReflectionServiceImpl? serviceImpl;
 
     [OneTimeSetUp]
     public void Init()
@@ -58,8 +51,8 @@ public class ReflectionClientServerTest
     [OneTimeTearDown]
     public void Cleanup()
     {
-        channel.ShutdownAsync().Wait();
-        server.ShutdownAsync().Wait();
+        channel?.ShutdownAsync().Wait();
+        server?.ShutdownAsync().Wait();
     }
 
     [Test]
@@ -127,7 +120,8 @@ public class ReflectionClientServerTest
 
     private async Task<ServerReflectionResponse> SingleRequestAsync(ServerReflectionRequest request)
     {
-        var call = client.ServerReflectionInfo();
+        Assert.NotNull(client);
+        var call = client!.ServerReflectionInfo();
         await call.RequestStream.WriteAsync(request);
         Assert.IsTrue(await call.ResponseStream.MoveNext());
 


### PR DESCRIPTION
NRTs are not universally enabled; fix #2071

also:

- fixup GrpcPrecondition: avoid direct throw (for better inlining); always pass arg-name when possible
- fixup some "clean build" errors (using directives, etc)