### PR TITLE
Output detailed Status to retry debug log

### DIFF
--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -198,7 +198,7 @@ internal sealed class RetryCall<TRequest, TResponse> : RetryCallBase<TRequest, T
                 }
 
                 var result = EvaluateRetry(status, retryPushbackMS);
-                Log.RetryEvaluated(Logger, status.StatusCode, AttemptCount, result == null);
+                Log.RetryEvaluated(Logger, status, AttemptCount, result == null);
 
                 if (result == null)
                 {

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseLog.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseLog.cs
@@ -23,8 +23,8 @@ namespace Grpc.Net.Client.Internal.Retry;
 
 internal static class RetryCallBaseLog
 {
-    private static readonly Action<ILogger, StatusCode, int, bool, Exception?> _retryEvaluated =
-        LoggerMessage.Define<StatusCode, int, bool>(LogLevel.Debug, new EventId(1, "RetryEvaluated"), "Evaluated retry for failed gRPC call. Status code: '{StatusCode}', Attempt: {AttemptCount}, Retry: {WillRetry}");
+    private static readonly Action<ILogger, Status, int, bool, Exception?> _retryEvaluated =
+        LoggerMessage.Define<Status, int, bool>(LogLevel.Debug, new EventId(1, "RetryEvaluated"), "Evaluated retry for failed gRPC call. {Status}, Attempt: {AttemptCount}, Retry: {WillRetry}");
 
     private static readonly Action<ILogger, string, Exception?> _retryPushbackReceived =
         LoggerMessage.Define<string>(LogLevel.Debug, new EventId(2, "RetryPushbackReceived"), "Retry pushback of '{RetryPushback}' received from the failed gRPC call.");
@@ -62,9 +62,9 @@ internal static class RetryCallBaseLog
     private static readonly Action<ILogger, Exception?> _canceledRetry =
         LoggerMessage.Define(LogLevel.Debug, new EventId(13, "CanceledRetry"), "gRPC retry call canceled.");
 
-    internal static void RetryEvaluated(ILogger logger, StatusCode statusCode, int attemptCount, bool willRetry)
+    internal static void RetryEvaluated(ILogger logger, Status status, int attemptCount, bool willRetry)
     {
-        _retryEvaluated(logger, statusCode, attemptCount, willRetry, null);
+        _retryEvaluated(logger, status, attemptCount, willRetry, null);
     }
 
     internal static void RetryPushbackReceived(ILogger logger, string retryPushback)


### PR DESCRIPTION
As per #2103 

This small change passes the entire struct to the debug logging delegate. If debug logging is enabled we will capture the detailed status, including cause exception if available.