### PR TITLE
Change some gRPC client error logs to debug level

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -23,6 +23,7 @@ using Grpc.Core;
 using Grpc.Net.Client.Internal.Http;
 using Grpc.Shared;
 using Microsoft.Extensions.Logging;
+using System.Runtime.ExceptionServices;
 #if SUPPORT_LOAD_BALANCING
 using Grpc.Net.Client.Balancer.Internal;
 #endif

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -23,7 +23,6 @@ using Grpc.Core;
 using Grpc.Net.Client.Internal.Http;
 using Grpc.Shared;
 using Microsoft.Extensions.Logging;
-using System.Runtime.ExceptionServices;
 #if SUPPORT_LOAD_BALANCING
 using Grpc.Net.Client.Balancer.Internal;
 #endif

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -503,7 +503,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                     }
                     else
                     {
-                        GrpcCallLog.ErrorStartingCall(Logger, ex);
+                        GrpcCallLog.ErrorStartingCall(Logger);
                         throw;
                     }
                 }
@@ -900,7 +900,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                 }
             }
 
-            GrpcCallLog.GrpcStatusError(Logger, status.StatusCode, status.Detail);
+            GrpcCallLog.GrpcStatusError(Logger, status.StatusCode, status.Detail, status.DebugException);
             if (GrpcEventSource.Log.IsEnabled())
             {
                 GrpcEventSource.Log.CallFailed(status.StatusCode);

--- a/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -39,7 +39,7 @@ internal static class GrpcCallLog
         LoggerMessage.Define<TimeSpan>(LogLevel.Trace, new EventId(5, "StartingDeadlineTimeout"), "Starting deadline timeout. Duration: {DeadlineTimeout}.");
 
     private static readonly Action<ILogger, Exception?> _errorStartingCall =
-        LoggerMessage.Define(LogLevel.Error, new EventId(6, "ErrorStartingCall"), "Error starting gRPC call.");
+        LoggerMessage.Define(LogLevel.Debug, new EventId(6, "ErrorStartingCall"), "Error starting gRPC call.");
 
     private static readonly Action<ILogger, Exception?> _deadlineExceeded =
         LoggerMessage.Define(LogLevel.Warning, new EventId(7, "DeadlineExceeded"), "gRPC call deadline exceeded.");
@@ -48,13 +48,9 @@ internal static class GrpcCallLog
         LoggerMessage.Define(LogLevel.Debug, new EventId(8, "CanceledCall"), "gRPC call canceled.");
 
     private static readonly Action<ILogger, Exception?> _messageNotReturned =
-        LoggerMessage.Define(LogLevel.Error, new EventId(9, "MessageNotReturned"), "Message not returned from unary or client streaming call.");
+        LoggerMessage.Define(LogLevel.Debug, new EventId(9, "MessageNotReturned"), "Message not returned from unary or client streaming call.");
 
-    private static readonly Action<ILogger, Exception?> _errorValidatingResponseHeaders =
-        LoggerMessage.Define(LogLevel.Error, new EventId(10, "ErrorValidatingResponseHeaders"), "Error validating response headers.");
-
-    private static readonly Action<ILogger, Exception?> _errorFetchingGrpcStatus =
-        LoggerMessage.Define(LogLevel.Error, new EventId(11, "ErrorFetchingGrpcStatus"), "Error fetching gRPC status.");
+    // 10, 11 unused.
 
     private static readonly Action<ILogger, Exception?> _callCredentialsNotUsed =
         LoggerMessage.Define(LogLevel.Warning, new EventId(12, "CallCredentialsNotUsed"), "The configured CallCredentials were not used because the call does not use TLS.");
@@ -151,16 +147,6 @@ internal static class GrpcCallLog
     public static void MessageNotReturned(ILogger logger)
     {
         _messageNotReturned(logger, null);
-    }
-
-    public static void ErrorValidatingResponseHeaders(ILogger logger, Exception ex)
-    {
-        _errorValidatingResponseHeaders(logger, ex);
-    }
-
-    public static void ErrorFetchingGrpcStatus(ILogger logger, Exception ex)
-    {
-        _errorFetchingGrpcStatus(logger, ex);
     }
 
     public static void CallCredentialsNotUsed(ILogger logger)

--- a/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallLog.cs
@@ -114,9 +114,9 @@ internal static class GrpcCallLog
         _responseHeadersReceived(logger, null);
     }
 
-    public static void GrpcStatusError(ILogger logger, StatusCode status, string message)
+    public static void GrpcStatusError(ILogger logger, StatusCode status, string message, Exception? debugException)
     {
-        _grpcStatusError(logger, status, message, null);
+        _grpcStatusError(logger, status, message, debugException);
     }
 
     public static void FinishedCall(ILogger logger)
@@ -129,9 +129,9 @@ internal static class GrpcCallLog
         _startingDeadlineTimeout(logger, deadlineTimeout, null);
     }
 
-    public static void ErrorStartingCall(ILogger logger, Exception ex)
+    public static void ErrorStartingCall(ILogger logger)
     {
-        _errorStartingCall(logger, ex);
+        _errorStartingCall(logger, null);
     }
 
     public static void DeadlineExceeded(ILogger logger)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2098

Move exception from `ErrorStartingCall` to `GrpcStatusError`. Previously some errors, such as errors from a user call credentials interceptor, wouldn't be fully logged. `GrpcStatusError` reports all errors while making a call.

Changed `ErrorStartingCall` to debug. Now that only indicates that the error was thrown while getting a response.