### PR TITLE
Make CancellationToken available in call credentials interceptor

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -77,12 +77,7 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
         get
         {
             // Follows the standard at https://github.com/grpc/grpc/blob/master/doc/naming.md
-            if (_peer == null)
-            {
-                _peer = BuildPeer();
-            }
-
-            return _peer;
+            return _peer ??= BuildPeer();
         }
     }
 
@@ -291,10 +286,7 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
 
     private void LogCallEnd()
     {
-        if (_activity != null)
-        {
-            _activity.AddTag(GrpcServerConstants.ActivityStatusCodeTag, _status.StatusCode.ToTrailerString());
-        }
+        _activity?.AddTag(GrpcServerConstants.ActivityStatusCodeTag, _status.StatusCode.ToTrailerString());
         if (_status.StatusCode != StatusCode.OK)
         {
             if (GrpcEventSource.Log.IsEnabled())
@@ -387,10 +379,7 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
     public void Initialize(ISystemClock? clock = null)
     {
         _activity = GetHostActivity();
-        if (_activity != null)
-        {
-            _activity.AddTag(GrpcServerConstants.ActivityMethodTag, MethodCore);
-        }
+        _activity?.AddTag(GrpcServerConstants.ActivityMethodTag, MethodCore);
 
         if (GrpcEventSource.Log.IsEnabled())
         {

--- a/src/Grpc.Core.Api/AsyncAuthInterceptor.cs
+++ b/src/Grpc.Core.Api/AsyncAuthInterceptor.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core.Utils;
 
@@ -34,16 +35,25 @@ public delegate Task AsyncAuthInterceptor(AuthInterceptorContext context, Metada
 /// </summary>
 public class AuthInterceptorContext
 {
-    readonly string serviceUrl;
-    readonly string methodName;
+    private readonly string serviceUrl;
+    private readonly string methodName;
+    private readonly CancellationToken cancellationToken;
 
     /// <summary>
     /// Initializes a new instance of <c>AuthInterceptorContext</c>.
     /// </summary>
-    public AuthInterceptorContext(string serviceUrl, string methodName)
+    public AuthInterceptorContext(string serviceUrl, string methodName) : this(serviceUrl, methodName, CancellationToken.None)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <c>AuthInterceptorContext</c>.
+    /// </summary>
+    public AuthInterceptorContext(string serviceUrl, string methodName, CancellationToken cancellationToken)
     {
         this.serviceUrl = GrpcPreconditions.CheckNotNull(serviceUrl, nameof(serviceUrl));
         this.methodName = GrpcPreconditions.CheckNotNull(methodName, nameof(methodName));
+        this.cancellationToken = cancellationToken;
     }
 
     /// <summary>
@@ -60,5 +70,13 @@ public class AuthInterceptorContext
     public string MethodName
     {
         get { return methodName; }
+    }
+
+    /// <summary>
+    /// The cancellation token of the RPC being called.
+    /// </summary>
+    public CancellationToken CancellationToken
+    {
+        get { return cancellationToken; }
     }
 }

--- a/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
+++ b/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
@@ -25,10 +25,10 @@ internal sealed class DefaultCallCredentialsConfigurator : CallCredentialsConfig
     public AsyncAuthInterceptor? Interceptor { get; private set; }
     public IReadOnlyList<CallCredentials>? CompositeCredentials { get; private set; }
 
-    // A place to cache context to avoid creating a new context for each auth interceptor call.
+    // A place to cache the context to avoid creating a new instance for each auth interceptor call.
     public AuthInterceptorContext? CachedContext { get; set; }
 
-    public void Reset()
+    public void ResetPerCallCredentialState()
     {
         Interceptor = null;
         CompositeCredentials = null;

--- a/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
+++ b/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -20,15 +20,18 @@ using Grpc.Core;
 
 namespace Grpc.Net.Client.Internal;
 
-internal class DefaultCallCredentialsConfigurator : CallCredentialsConfiguratorBase
+internal sealed class DefaultCallCredentialsConfigurator : CallCredentialsConfiguratorBase
 {
     public AsyncAuthInterceptor? Interceptor { get; private set; }
-    public IReadOnlyList<CallCredentials>? Credentials { get; private set; }
+    public IReadOnlyList<CallCredentials>? CompositeCredentials { get; private set; }
+
+    // A place to cache context to avoid creating a new context for each auth interceptor call.
+    public AuthInterceptorContext? CachedContext { get; set; }
 
     public void Reset()
     {
         Interceptor = null;
-        Credentials = null;
+        CompositeCredentials = null;
     }
 
     public override void SetAsyncAuthInterceptorCredentials(object? state, AsyncAuthInterceptor interceptor)
@@ -38,6 +41,6 @@ internal class DefaultCallCredentialsConfigurator : CallCredentialsConfiguratorB
 
     public override void SetCompositeCredentials(object? state, IReadOnlyList<CallCredentials> credentials)
     {
-        Credentials = credentials;
+        CompositeCredentials = credentials;
     }
 }

--- a/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
+++ b/src/Grpc.Net.Client/Internal/DefaultCallCredentialsConfigurator.cs
@@ -26,6 +26,7 @@ internal sealed class DefaultCallCredentialsConfigurator : CallCredentialsConfig
     public IReadOnlyList<CallCredentials>? CompositeCredentials { get; private set; }
 
     // A place to cache the context to avoid creating a new instance for each auth interceptor call.
+    // It's ok not to reset this state because the context is only used for the lifetime of the call.
     public AuthInterceptorContext? CachedContext { get; set; }
 
     public void ResetPerCallCredentialState()

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -955,13 +955,13 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
             if (Options.Credentials != null)
             {
-                await GrpcProtocolHelpers.ReadCredentialMetadata(configurator, Channel, request, Method, Options.Credentials).ConfigureAwait(false);
+                await GrpcProtocolHelpers.ReadCredentialMetadata(configurator, Channel, request, Method, Options.Credentials, _callCts.Token).ConfigureAwait(false);
             }
             if (Channel.CallCredentials?.Count > 0)
             {
                 foreach (var credentials in Channel.CallCredentials)
                 {
-                    await GrpcProtocolHelpers.ReadCredentialMetadata(configurator, Channel, request, Method, credentials).ConfigureAwait(false);
+                    await GrpcProtocolHelpers.ReadCredentialMetadata(configurator, Channel, request, Method, credentials, _callCts.Token).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -121,13 +121,34 @@ internal static class GrpcProtocolHelpers
     /* round an integer up to the next value with three significant figures */
     private static long TimeoutRoundUpToThreeSignificantFigures(long x)
     {
-        if (x < 1000) return x;
-        if (x < 10000) return RoundUp(x, 10);
-        if (x < 100000) return RoundUp(x, 100);
-        if (x < 1000000) return RoundUp(x, 1000);
-        if (x < 10000000) return RoundUp(x, 10000);
-        if (x < 100000000) return RoundUp(x, 100000);
-        if (x < 1000000000) return RoundUp(x, 1000000);
+        if (x < 1000)
+        {
+            return x;
+        }
+        if (x < 10000)
+        {
+            return RoundUp(x, 10);
+        }
+        if (x < 100000)
+        {
+            return RoundUp(x, 100);
+        }
+        if (x < 1000000)
+        {
+            return RoundUp(x, 1000);
+        }
+        if (x < 10000000)
+        {
+            return RoundUp(x, 10000);
+        }
+        if (x < 100000000)
+        {
+            return RoundUp(x, 100000);
+        }
+        if (x < 1000000000)
+        {
+            return RoundUp(x, 1000000);
+        }
         return RoundUp(x, 10000000);
 
         static long RoundUp(long x, long divisor)
@@ -235,7 +256,7 @@ internal static class GrpcProtocolHelpers
         return canCompress;
     }
 
-    internal static AuthInterceptorContext CreateAuthInterceptorContext(Uri baseAddress, IMethod method)
+    internal static AuthInterceptorContext CreateAuthInterceptorContext(Uri baseAddress, IMethod method, CancellationToken cancellationToken)
     {
         var authority = baseAddress.Authority;
         if (baseAddress.Scheme == Uri.UriSchemeHttps && authority.EndsWith(":443", StringComparison.Ordinal))
@@ -252,7 +273,7 @@ internal static class GrpcProtocolHelpers
             serviceUrl += "/";
         }
         serviceUrl += method.ServiceName;
-        return new AuthInterceptorContext(serviceUrl, method.Name);
+        return new AuthInterceptorContext(serviceUrl, method.Name, cancellationToken);
     }
 
     internal static async Task ReadCredentialMetadata(
@@ -260,15 +281,16 @@ internal static class GrpcProtocolHelpers
         GrpcChannel channel,
         HttpRequestMessage message,
         IMethod method,
-        CallCredentials credentials)
+        CallCredentials credentials,
+        CancellationToken cancellationToken)
     {
         credentials.InternalPopulateConfiguration(configurator, null);
 
         if (configurator.Interceptor != null)
         {
-            var authInterceptorContext = GrpcProtocolHelpers.CreateAuthInterceptorContext(channel.Address, method);
+            configurator.CachedContext ??= CreateAuthInterceptorContext(channel.Address, method, cancellationToken);
             var metadata = new Metadata();
-            await configurator.Interceptor(authInterceptorContext, metadata).ConfigureAwait(false);
+            await configurator.Interceptor(configurator.CachedContext, metadata).ConfigureAwait(false);
 
             foreach (var entry in metadata)
             {
@@ -276,14 +298,14 @@ internal static class GrpcProtocolHelpers
             }
         }
 
-        if (configurator.Credentials != null)
+        if (configurator.CompositeCredentials != null)
         {
             // Copy credentials locally. ReadCredentialMetadata will update it.
-            var callCredentials = configurator.Credentials;
-            foreach (var c in callCredentials)
+            var compositeCredentials = configurator.CompositeCredentials;
+            foreach (var callCredentials in compositeCredentials)
             {
                 configurator.Reset();
-                await ReadCredentialMetadata(configurator, channel, message, method, c).ConfigureAwait(false);
+                await ReadCredentialMetadata(configurator, channel, message, method, callCredentials, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/test/Grpc.Net.Client.Tests/CallCredentialTests.cs
+++ b/test/Grpc.Net.Client.Tests/CallCredentialTests.cs
@@ -83,8 +83,8 @@ public class CallCredentialTests
         var syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
         var callCredentials = CallCredentials.FromInterceptor(async (context, metadata) =>
         {
-            // The operation is asynchronous to ensure delegate is awaited.
-
+            // The operation is asynchronous to ensure auth interceptor is awaited.
+            // Sending the request and returning a response is blocked until the auth interceptor completes.
             await syncPoint.WaitToContinue();
 
             // Set header.


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/2108

Adds `AuthInterceptorContext.CancellationToken` property. The context is passed to call credential interceptors.

This change allows call credentials that do async work to be canceled when the gRPC call is canceled:

```csharp
var callCredentials = CallCredentials.FromInterceptor(async (context, metadata) =>
{
    metadata["authorize"] = await GetTokenAsync(context.CancellationToken);
});
```