### PR TITLE
Fix bugs related to channel dispose while there are active calls

### DIFF
--- a/src/Grpc.Net.Client/Configuration/HedgingPolicy.cs
+++ b/src/Grpc.Net.Client/Configuration/HedgingPolicy.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -37,7 +37,7 @@ public sealed class HedgingPolicy : ConfigObject
     internal const string HedgingDelayPropertyName = "hedgingDelay";
     internal const string NonFatalStatusCodesPropertyName = "nonFatalStatusCodes";
 
-    private ConfigProperty<Values<StatusCode, object>, IList<object>> _nonFatalStatusCodes =
+    private readonly ConfigProperty<Values<StatusCode, object>, IList<object>> _nonFatalStatusCodes =
         new(i => new Values<StatusCode, object>(i ?? new List<object>(), s => ConvertHelpers.ConvertStatusCode(s), s => ConvertHelpers.ConvertStatusCode(s.ToString()!)), NonFatalStatusCodesPropertyName);
 
     /// <summary>

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -484,7 +484,10 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         lock (_lock)
         {
             // Test disposed flag inside lock to ensure there is no chance of adding a call after dispose.
-            ObjectDisposedThrowHelper.ThrowIf(Disposed, typeof(GrpcChannel));
+            if (Disposed)
+            {
+                throw new ObjectDisposedException(nameof(GrpcChannel));
+            }
 
             ActiveCalls.Add(grpcCall);
         }

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -483,7 +483,8 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
     {
         lock (_lock)
         {
-            // Test disposed flag inside lock to ensure there is no chance of adding a call after dispose.
+            // Test the disposed flag inside the lock to ensure there is no chance of a race and adding a call after dispose.
+            // Note that a GrpcCall has been created but hasn't been started. The error will prevent it from starting.
             if (Disposed)
             {
                 throw new ObjectDisposedException(nameof(GrpcChannel));

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -742,7 +742,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         IDisposable[]? activeCallsCopy = null;
         lock (_lock)
         {
-            // Check and set disposed flag inside lock;
+            // Check and set disposed flag inside lock.
             if (Disposed)
             {
                 return;

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -129,10 +129,20 @@ internal sealed class HttpClientCallInvoker : CallInvoker
 
         if (retryPolicy != null)
         {
+            if (channel.Disposed)
+            {
+                throw new ObjectDisposedException(nameof(GrpcChannel));
+            }
+
             return new RetryCall<TRequest, TResponse>(retryPolicy, channel, method, options);
         }
         else if (hedgingPolicy != null)
         {
+            if (channel.Disposed)
+            {
+                throw new ObjectDisposedException(nameof(GrpcChannel));
+            }
+
             return new HedgingCall<TRequest, TResponse>(hedgingPolicy, channel, method, options);
         }
         else

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -129,20 +129,10 @@ internal sealed class HttpClientCallInvoker : CallInvoker
 
         if (retryPolicy != null)
         {
-            if (channel.Disposed)
-            {
-                throw new ObjectDisposedException(nameof(GrpcChannel));
-            }
-
             return new RetryCall<TRequest, TResponse>(retryPolicy, channel, method, options);
         }
         else if (hedgingPolicy != null)
         {
-            if (channel.Disposed)
-            {
-                throw new ObjectDisposedException(nameof(GrpcChannel));
-            }
-
             return new HedgingCall<TRequest, TResponse>(hedgingPolicy, channel, method, options);
         }
         else

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -150,11 +150,6 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         where TRequest : class
         where TResponse : class
     {
-        if (channel.Disposed)
-        {
-            throw new ObjectDisposedException(nameof(GrpcChannel));
-        }
-
         var methodInfo = channel.GetCachedGrpcMethodInfo(method);
         var call = new GrpcCall<TRequest, TResponse>(method, methodInfo, options, channel, attempt);
 

--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -54,6 +54,8 @@ internal sealed partial class HedgingCall<TRequest, TResponse> : RetryCallBase<T
             _delayInterruptTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
             _hedgingDelayCts = new CancellationTokenSource();
         }
+
+        Channel.RegisterActiveCall(this);
     }
 
     private async Task StartCall(Action<GrpcCall<TRequest, TResponse>> startCallFunc)

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -42,6 +42,8 @@ internal sealed class RetryCall<TRequest, TResponse> : RetryCallBase<TRequest, T
         _retryPolicy = retryPolicy;
 
         _nextRetryDelayMilliseconds = Convert.ToInt32(retryPolicy.InitialBackoff.TotalMilliseconds);
+
+        Channel.RegisterActiveCall(this);
     }
 
     private int CalculateNextRetryDelay()

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -440,6 +440,8 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
 
     protected void Cleanup()
     {
+        Channel.FinishActiveCall(this);
+
         _ctsRegistration?.Dispose();
         _ctsRegistration = null;
         CancellationTokenSource.Cancel();

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -108,6 +108,8 @@ public class RetryTests : FunctionalTestBase
 
         // Assert
         Assert.IsTrue(result.Data.Span.SequenceEqual(sentData.ToArray()));
+
+        Assert.AreEqual(0, channel.ActiveCalls.Count);
     }
 
     [Test]

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -390,6 +390,8 @@ public class RetryTests : FunctionalTestBase
         await MakeCallsAsync(channel, method, references, cts.Token).DefaultTimeout();
 
         // Assert
+        Assert.AreEqual(0, channel.ActiveCalls.Count);
+
         // There is a race when cleaning up cancellation token registry.
         // Retry a few times to ensure GC is run after unregister.
         await TestHelpers.AssertIsTrueRetryAsync(() =>

--- a/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
+++ b/test/Grpc.Net.Client.Tests/AsyncDuplexStreamingCallTests.cs
@@ -181,9 +181,8 @@ public class AsyncDuplexStreamingCallTests
         Assert.IsFalse(await moveNextTask3.DefaultTimeout());
     }
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task AsyncDuplexStreamingCall_CancellationDisposeRace_Success(bool disposeCall)
+    [Test]
+    public async Task AsyncDuplexStreamingCall_CancellationDisposeRace_Success()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -191,52 +190,71 @@ public class AsyncDuplexStreamingCallTests
         var loggerFactory = services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
         var logger = loggerFactory.CreateLogger(GetType());
 
-        var tcs = new TaskCompletionSource<HttpResponseMessage>();
-        var handler = TestHttpMessageHandler.Create(request =>
-        {
-            return tcs.Task;
-        });
-        var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
-        {
-            HttpHandler = handler,
-            LoggerFactory = loggerFactory
-        });
-        var invoker = channel.CreateCallInvoker();
-        var actTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var tasks = new List<Task>();
-
         for (var i = 0; i < 20; i++)
         {
+            // Let's mimic a real call first to get GrpcCall.RunCall where we need to for reproducing the deadlock.
+            var streamContent = new SyncPointMemoryStream();
+            var requestContentTcs = new TaskCompletionSource<Task<Stream>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            PushStreamContent<HelloRequest, HelloReply>? content = null;
+
+            var handler = TestHttpMessageHandler.Create(async request =>
+            {
+                content = (PushStreamContent<HelloRequest, HelloReply>)request.Content!;
+                var streamTask = content.ReadAsStreamAsync();
+                requestContentTcs.SetResult(streamTask);
+                // Wait for RequestStream.CompleteAsync()
+                await streamTask;
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, new StreamContent(streamContent));
+            });
+            var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+            {
+                HttpHandler = handler,
+                LoggerFactory = loggerFactory
+            });
+            var invoker = channel.CreateCallInvoker();
+
             var cts = new CancellationTokenSource();
+
             var call = invoker.AsyncDuplexStreamingCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(cancellationToken: cts.Token));
-            tasks.Add(Task.Run(async () =>
+            await call.RequestStream.WriteAsync(new HelloRequest { Name = "1" }).DefaultTimeout();
+            await call.RequestStream.CompleteAsync().DefaultTimeout();
+
+            // Let's read a response
+            var deserializationContext = new DefaultDeserializationContext();
+            var requestContent = await await requestContentTcs.Task.DefaultTimeout();
+            var requestMessage = await StreamSerializationHelper.ReadMessageAsync(
+                requestContent,
+                ClientTestHelpers.ServiceMethod.RequestMarshaller.ContextualDeserializer,
+                GrpcProtocolConstants.IdentityGrpcEncoding,
+                maximumMessageSize: null,
+                GrpcProtocolConstants.DefaultCompressionProviders,
+                singleMessage: false,
+                CancellationToken.None).DefaultTimeout();
+            Assert.AreEqual("1", requestMessage!.Name);
+
+            var actTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var cancellationTask = Task.Run(async () =>
             {
                 await actTcs.Task;
-                if (disposeCall)
-                {
-                    call.Dispose();
-                }
-                else
-                {
-                    cts.Cancel();
-                }
-            }));
+                cts.Cancel();
+            });
+            var disposingTask = Task.Run(async () =>
+            {
+                await actTcs.Task;
+                channel.Dispose();
+            });
+
+            // Small pause to make sure we're waiting at the TCS everywhere.
+            await Task.Delay(50);
+
+            // Act
+            actTcs.SetResult(null);
+
+            // Assert
+            // Cancellation and disposing should both complete quickly. If there is a deadlock then the await will timeout.
+            await Task.WhenAll(cancellationTask, disposingTask).DefaultTimeout();
         }
-
-        tasks.Add(Task.Run(async () =>
-        {
-            await actTcs.Task;
-            channel.Dispose();
-        }));
-
-        // Small pause to make sure we're waiting at the TCS everywhere.
-        await Task.Delay(50);
-
-        // Act
-        actTcs.SetResult(true);
-
-        // Assert
-        await Task.WhenAll(tasks).DefaultTimeout();
     }
 }

--- a/test/Grpc.Net.Client.Tests/Retry/HedgingTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/HedgingTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -72,6 +72,8 @@ public class HedgingTests
         var rs = await call.ResponseAsync.DefaultTimeout();
         Assert.AreEqual("Hello world", rs.Message);
         Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
+
+        Assert.AreEqual(0, invoker.Channel.ActiveCalls.Count);
     }
 
     [Test]

--- a/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
@@ -419,38 +419,6 @@ public class RetryTests
     }
 
     [Test]
-    public async Task AsyncUnaryCall_ChannelDisposeDuringBackoff_CanceledStatus()
-    {
-        // Arrange
-        var callCount = 0;
-        var httpClient = ClientTestHelpers.CreateTestClient(async request =>
-        {
-            callCount++;
-
-            await request.Content!.CopyToAsync(new MemoryStream());
-            return ResponseUtils.CreateHeadersOnlyResponse(HttpStatusCode.OK, StatusCode.Unavailable, retryPushbackHeader: TimeSpan.FromSeconds(10).TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
-        });
-        var serviceConfig = ServiceConfigHelpers.CreateRetryServiceConfig();
-        var invoker = HttpClientCallInvokerFactory.Create(httpClient, serviceConfig: serviceConfig);
-        var cts = new CancellationTokenSource();
-
-        // Act
-        var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(cancellationToken: cts.Token), new HelloRequest { Name = "World" });
-
-        var delayTask = Task.Delay(100);
-        var completedTask = await Task.WhenAny(call.ResponseAsync, delayTask);
-
-        // Assert
-        Assert.AreEqual(delayTask, completedTask); // Ensure that we're waiting for retry
-
-        invoker.Channel.Dispose();
-
-        var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
-        Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
-        Assert.AreEqual("gRPC call disposed.", ex.Status.Detail);
-    }
-
-    [Test]
     public async Task AsyncUnaryCall_PushbackExplicitDelayExceedAttempts_Failure()
     {
         // Arrange
@@ -1060,6 +1028,38 @@ public class RetryTests
         // Act & Assert
         invoker.Channel.Dispose();
         Assert.Throws<ObjectDisposedException>(() => invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "World" }));
+    }
+
+    [Test]
+    public async Task AsyncUnaryCall_ChannelDisposeDuringBackoff_CanceledStatus()
+    {
+        // Arrange
+        var callCount = 0;
+        var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+        {
+            callCount++;
+
+            await request.Content!.CopyToAsync(new MemoryStream());
+            return ResponseUtils.CreateHeadersOnlyResponse(HttpStatusCode.OK, StatusCode.Unavailable, retryPushbackHeader: TimeSpan.FromSeconds(10).TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+        });
+        var serviceConfig = ServiceConfigHelpers.CreateRetryServiceConfig();
+        var invoker = HttpClientCallInvokerFactory.Create(httpClient, serviceConfig: serviceConfig);
+        var cts = new CancellationTokenSource();
+
+        // Act
+        var call = invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(cancellationToken: cts.Token), new HelloRequest { Name = "World" });
+
+        var delayTask = Task.Delay(100);
+        var completedTask = await Task.WhenAny(call.ResponseAsync, delayTask);
+
+        // Assert
+        Assert.AreEqual(delayTask, completedTask); // Ensure that we're waiting for retry
+
+        invoker.Channel.Dispose();
+
+        var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync).DefaultTimeout();
+        Assert.AreEqual(StatusCode.Cancelled, ex.StatusCode);
+        Assert.AreEqual("gRPC call disposed.", ex.Status.Detail);
     }
 
     private static Task<HelloRequest?> ReadRequestMessage(Stream requestContent)

--- a/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
+++ b/test/Grpc.Net.Client.Tests/Retry/RetryTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -1012,6 +1012,22 @@ public class RetryTests
         Assert.AreEqual("2", requestMessage!.Name);
         requestMessage = await ReadRequestMessage(requestContent).DefaultTimeout();
         Assert.IsNull(requestMessage);
+    }
+
+    [Test]
+    public void AsyncUnaryCall_DisposedChannel_Error()
+    {
+        // Arrange
+        var httpClient = ClientTestHelpers.CreateTestClient(request =>
+        {
+            return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK));
+        });
+        var serviceConfig = ServiceConfigHelpers.CreateRetryServiceConfig();
+        var invoker = HttpClientCallInvokerFactory.Create(httpClient, serviceConfig: serviceConfig);
+
+        // Act & Assert
+        invoker.Channel.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => invoker.AsyncUnaryCall<HelloRequest, HelloReply>(ClientTestHelpers.ServiceMethod, string.Empty, new CallOptions(), new HelloRequest { Name = "World" }));
     }
 
     private static Task<HelloRequest?> ReadRequestMessage(Stream requestContent)

--- a/test/Shared/ServiceConfigHelpers.cs
+++ b/test/Shared/ServiceConfigHelpers.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2119

~@amanda-tarafa I tried to recreate this in a unit test without success. I went with your suggestion. Also, I modified the dispose check when starting gRPC calls to remove the chance of a new active call being added after dispose.~

**Update:** Deadlock reproduced in a unit test. Fix in PR confirmed to work.

---

This PR fixes a number of bugs related to disposing a channel while there are ongoing active calls:

* Fix potential deadlock when a call and channel are disposed at the same time.
* Fix race that could allow call to be added to the channel's active call collection after dispose.
* Fix hedge/retry calls not immediately throwing `ObjectDisposedException` after channel dispose.
* Fix hedge/retry calls not immediately canceling after channel dispose.