### PR TITLE
Fix capturing ExecutionContext by timers and background tasks

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.201"
+    "version": "7.0.201",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\Shared\Server\UnaryServerMethodInvoker.cs" Link="Model\Internal\UnaryServerMethodInvoker.cs" />
     <Compile Include="..\Shared\NullableAttributes.cs" Link="Internal\NullableAttributes.cs" />
     <Compile Include="..\Shared\CodeAnalysisAttributes.cs" Link="Internal\CodeAnalysisAttributes.cs" />
+    <Compile Include="..\Shared\NonCapturingTimer.cs" Link="Internal\NonCapturingTimer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallDeadlineManager.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallDeadlineManager.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -91,12 +91,12 @@ internal sealed class ServerCallDeadlineManager : IAsyncDisposable
             // Ensures there is no weird situation where the timer triggers
             // before the field is set. Shouldn't happen because only long deadlines
             // will take this path but better to be safe than sorry.
-            _longDeadlineTimer = new Timer(DeadlineExceededLongDelegate, (this, maxTimerDueTime), Timeout.Infinite, Timeout.Infinite);
+            _longDeadlineTimer = NonCapturingTimer.Create(DeadlineExceededLongDelegate, (this, maxTimerDueTime), Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             _longDeadlineTimer.Change(timerMilliseconds, Timeout.Infinite);
         }
         else
         {
-            _longDeadlineTimer = new Timer(DeadlineExceededDelegate, this, timerMilliseconds, Timeout.Infinite);
+            _longDeadlineTimer = NonCapturingTimer.Create(DeadlineExceededDelegate, this, TimeSpan.FromMilliseconds(timerMilliseconds), Timeout.InfiniteTimeSpan);
         }
     }
 

--- a/src/Grpc.Net.Client/Balancer/DnsResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/DnsResolver.cs
@@ -68,7 +68,7 @@ internal sealed class DnsResolver : PollingResolver
 
         if (_refreshInterval != Timeout.InfiniteTimeSpan)
         {
-            _timer = new Timer(OnTimerCallback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            _timer = NonCapturingTimer.Create(OnTimerCallback, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             _timer.Change(_refreshInterval, _refreshInterval);
         }
     }

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -77,7 +77,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
         ConnectTimeout = connectTimeout;
         _socketConnect = socketConnect ?? OnConnect;
         _activeStreams = new List<ActiveStream>();
-        _socketConnectedTimer = new Timer(OnCheckSocketConnection, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        _socketConnectedTimer = NonCapturingTimer.Create(OnCheckSocketConnection, state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
     }
 
     private object Lock => _subchannel.Lock;

--- a/src/Grpc.Net.Client/Balancer/PollingResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/PollingResolver.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -86,7 +86,7 @@ public abstract class PollingResolver : Resolver
     /// </para>
     /// </summary>
     /// <param name="listener">The callback used to receive updates on the target.</param>
-    public override sealed void Start(Action<ResolverResult> listener)
+    public sealed override void Start(Action<ResolverResult> listener)
     {
         if (listener == null)
         {

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -233,7 +233,21 @@ public sealed class Subchannel : IDisposable
             }
         }
 
-        _ = ConnectTransportAsync();
+        // Don't capture the current ExecutionContext and its AsyncLocals onto the connect
+        bool restoreFlow = false;
+        if (!ExecutionContext.IsFlowSuppressed())
+        {
+            ExecutionContext.SuppressFlow();
+            restoreFlow = true;
+        }
+
+        _ = Task.Run(ConnectTransportAsync);
+
+        // Restore the current ExecutionContext
+        if (restoreFlow)
+        {
+            ExecutionContext.RestoreFlow();
+        }
     }
 
     private void CancelInProgressConnect()

--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>.NET client for gRPC</Description>
@@ -35,6 +35,7 @@
     <Compile Include="..\Shared\NullableAttributes.cs" Link="Internal\NullableAttributes.cs" />
     <Compile Include="..\Shared\Http2ErrorCode.cs" Link="Internal\Http2ErrorCode.cs" />
     <Compile Include="..\Shared\Http3ErrorCode.cs" Link="Internal\Http3ErrorCode.cs" />
+    <Compile Include="..\Shared\NonCapturingTimer.cs" Link="Internal\NonCapturingTimer.cs" />
     <Compile Include="..\Shared\NonDisposableMemoryStream.cs" Link="Internal\NonDisposableMemoryStream.cs" />
   </ItemGroup>
 

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -17,7 +17,6 @@
 #endregion
 
 using System.Collections.Concurrent;
-using System.Net.Mail;
 using Grpc.Core;
 #if SUPPORT_LOAD_BALANCING
 using Grpc.Net.Client.Balancer;

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -838,7 +838,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                 GrpcCallLog.StartingDeadlineTimeout(Logger, timeout.Value);
 
                 var dueTime = CommonGrpcProtocolHelpers.GetTimerDueTime(timeout.Value, Channel.MaxTimerDueTime);
-                _deadlineTimer = new Timer(DeadlineExceededCallback, null, dueTime, Timeout.Infinite);
+                _deadlineTimer = NonCapturingTimer.Create(DeadlineExceededCallback, state: null, TimeSpan.FromMilliseconds(dueTime), Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/src/Shared/NonCapturingTimer.cs
+++ b/src/Shared/NonCapturingTimer.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Grpc.Shared;
+
+// A convenience API for interacting with System.Threading.Timer in a way
+// that doesn't capture the ExecutionContext. We should be using this (or equivalent)
+// everywhere we use timers to avoid rooting any values stored in asynclocals.
+internal static class NonCapturingTimer
+{
+    public static Timer Create(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        if (callback is null)
+        {
+            throw new ArgumentNullException(nameof(callback));
+        }
+
+        // Don't capture the current ExecutionContext and its AsyncLocals onto the timer
+        bool restoreFlow = false;
+        try
+        {
+            if (!ExecutionContext.IsFlowSuppressed())
+            {
+                ExecutionContext.SuppressFlow();
+                restoreFlow = true;
+            }
+
+            return new Timer(callback, state, dueTime, period);
+        }
+        finally
+        {
+            // Restore the current ExecutionContext
+            if (restoreFlow)
+            {
+                ExecutionContext.RestoreFlow();
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -352,7 +352,7 @@ public class ConnectionTests : FunctionalTestBase
 
         await channel.ConnectAsync().DefaultTimeout();
 
-        await BalancerHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
 
         var client = TestClientFactory.Create(channel, endpoint1.Method);
 

--- a/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -67,7 +67,7 @@ public class LeastUsedBalancerTests : FunctionalTestBase
 
         var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new LoadBalancingConfig("least_used"), new[] { endpoint1.Address, endpoint2.Address }, connect: true);
 
-        await BalancerHelpers.WaitForSubchannelsToBeReadyAsync(
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(
             Logger,
             channel,
             expectedCount: 2,

--- a/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/RoundRobinBalancerTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -65,7 +65,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         await channel.ConnectAsync().DefaultTimeout();
 
-        var subchannel = await BalancerHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+        var subchannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
 
         // Act
         endpoint.Dispose();
@@ -160,8 +160,8 @@ public class RoundRobinBalancerTests : FunctionalTestBase
         // Use failure as backup status.
         var expectedStates = new[] { ConnectivityState.Connecting, ConnectivityState.TransientFailure };
         var waitForConnectingTask = Task.WhenAll(
-            BalancerHelpers.WaitForChannelStatesAsync(Logger, channel1, expectedStates, channelId: 1),
-            BalancerHelpers.WaitForChannelStatesAsync(Logger, channel2, expectedStates, channelId: 2));
+            BalancerWaitHelpers.WaitForChannelStatesAsync(Logger, channel1, expectedStates, channelId: 1),
+            BalancerWaitHelpers.WaitForChannelStatesAsync(Logger, channel2, expectedStates, channelId: 2));
 
         Logger.LogInformation("Ending " + endpoint.Address);
         endpoint.Dispose();
@@ -203,7 +203,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), new[] { endpoint1.Address, endpoint2.Address }, connect: true);
 
-        await BalancerHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
 
         var client = TestClientFactory.Create(channel, endpoint1.Method);
 
@@ -254,7 +254,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), new[] { endpoint1.Address, endpoint2.Address }, connect: true);
 
-        await BalancerHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
 
         var client = TestClientFactory.Create(channel, endpoint1.Method);
 
@@ -271,7 +271,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         endpoint1.Dispose();
 
-        var subChannel = await BalancerHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+        var subChannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
         Assert.AreEqual(50052, subChannel.CurrentAddress?.EndPoint.Port);
 
         reply1 = await client.UnaryCall(new HelloRequest { Name = "Balancer" });
@@ -313,7 +313,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), resolver, connect: true);
 
-        await BalancerHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 2).DefaultTimeout();
 
         var waitForRefreshTask = syncPoint.WaitForSyncPoint();
 
@@ -328,7 +328,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         syncPoint.Continue();
 
-        await BalancerHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 1).DefaultTimeout();
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(Logger, channel, 1).DefaultTimeout();
     }
 
     [Test]
@@ -359,7 +359,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), resolver, connect: true);
 
-        var disposedSubchannel = await BalancerHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+        var disposedSubchannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
 
         var client = TestClientFactory.Create(channel, endpoint1.Method);
 
@@ -381,7 +381,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
         Subchannel? newSubchannel = null;
         while (true)
         {
-            newSubchannel = await BalancerHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+            newSubchannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
 
             if (newSubchannel.CurrentAddress?.EndPoint.Equals(endpoint2.EndPoint) ?? false)
             {
@@ -439,7 +439,7 @@ public class RoundRobinBalancerTests : FunctionalTestBase
 
         var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), resolver, connect: true);
 
-        var disposedSubchannel = await BalancerHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+        var disposedSubchannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
 
         Assert.IsNotNull(((SocketConnectivitySubchannelTransport)disposedSubchannel.Transport)._initialSocket);
 

--- a/test/FunctionalTests/Client/HedgingTests.cs
+++ b/test/FunctionalTests/Client/HedgingTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //

--- a/test/FunctionalTests/Client/RetryTests.cs
+++ b/test/FunctionalTests/Client/RetryTests.cs
@@ -19,7 +19,6 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Channels;
 using Google.Protobuf;
 using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
@@ -24,6 +24,7 @@
     <Compile Include="..\Shared\TestHelpers.cs" Link="Infrastructure\TestHelpers.cs" />
     <Compile Include="..\Shared\TestResolver.cs" Link="Infrastructure\Balancer\TestResolver.cs" />
     <Compile Include="..\Shared\TestResolverFactory.cs" Link="Infrastructure\Balancer\TestResolverFactory.cs" />
+    <Compile Include="..\Shared\BalancerWaitHelpers.cs" Link="Infrastructure\Balancer\BalancerWaitHelpers.cs" />
     <Compile Include="..\Shared\CallbackInterceptor.cs" Link="Infrastructure\CallbackInterceptor.cs" />
     <Compile Include="..\Shared\HttpEventSourceListener.cs" Link="Infrastructure\HttpEventSourceListener.cs" />
   </ItemGroup>

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net472;net6.0;net7.0</TargetFrameworks>
@@ -26,6 +26,7 @@
     <Compile Include="..\Shared\TestHelpers.cs" Link="Infrastructure\TestHelpers.cs" />
     <Compile Include="..\Shared\TestResolver.cs" Link="Infrastructure\Balancer\TestResolver.cs" />
     <Compile Include="..\Shared\TestResolverFactory.cs" Link="Infrastructure\Balancer\TestResolverFactory.cs" />
+    <Compile Include="..\Shared\BalancerWaitHelpers.cs" Link="Infrastructure\Balancer\BalancerWaitHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -388,7 +388,7 @@ public class GrpcChannelTests
 
         var exTask = ExceptionAssert.ThrowsAsync<RpcException>(() => call.ResponseAsync);
         Assert.IsFalse(exTask.IsCompleted);
-        Assert.AreEqual(1, channel.ActiveCalls.Count);
+        Assert.AreEqual(1, channel.GetActiveCalls().Length);
 
         // Act
         channel.Dispose();
@@ -399,7 +399,7 @@ public class GrpcChannelTests
         Assert.AreEqual("gRPC call disposed.", ex.Status.Detail);
 
         Assert.IsTrue(channel.Disposed);
-        Assert.AreEqual(0, channel.ActiveCalls.Count);
+        Assert.AreEqual(0, channel.GetActiveCalls().Length);
     }
 
     [TestCase(true)]

--- a/test/Shared/BalancerWaitHelpers.cs
+++ b/test/Shared/BalancerWaitHelpers.cs
@@ -1,0 +1,111 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if SUPPORT_LOAD_BALANCING
+using System.Diagnostics;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Grpc.Net.Client.Balancer;
+using Grpc.Net.Client.Balancer.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Grpc.Tests.Shared;
+
+public static class BalancerWaitHelpers
+{
+    public static Task WaitForChannelStateAsync(ILogger logger, GrpcChannel channel, ConnectivityState state, int channelId = 1)
+    {
+        return WaitForChannelStatesAsync(logger, channel, new[] { state }, channelId);
+    }
+
+    public static async Task WaitForChannelStatesAsync(ILogger logger, GrpcChannel channel, ConnectivityState[] states, int channelId = 1)
+    {
+        var statesText = string.Join(", ", states.Select(s => $"'{s}'"));
+        logger.LogInformation($"Channel id {channelId}: Waiting for channel states {statesText}.");
+
+        var currentState = channel.State;
+
+        while (!states.Contains(currentState))
+        {
+            logger.LogInformation($"Channel id {channelId}: Current channel state '{currentState}' doesn't match expected states {statesText}.");
+
+            await channel.WaitForStateChangedAsync(currentState).DefaultTimeout();
+            currentState = channel.State;
+        }
+
+        logger.LogInformation($"Channel id {channelId}: Current channel state '{currentState}' matches expected states {statesText}.");
+    }
+
+    public static async Task<Subchannel> WaitForSubchannelToBeReadyAsync(ILogger logger, GrpcChannel channel, Func<SubchannelPicker?, Subchannel[]>? getPickerSubchannels = null, Func<Subchannel, bool>? validateSubchannel = null)
+    {
+        var subChannel = (await WaitForSubchannelsToBeReadyAsync(logger, channel, expectedCount: 1, getPickerSubchannels, validateSubchannel)).Single();
+        return subChannel;
+    }
+
+    public static async Task<Subchannel[]> WaitForSubchannelsToBeReadyAsync(ILogger logger, GrpcChannel channel, int expectedCount, Func<SubchannelPicker?, Subchannel[]>? getPickerSubchannels = null, Func<Subchannel, bool>? validateSubchannel = null)
+    {
+        if (getPickerSubchannels == null)
+        {
+            getPickerSubchannels = (picker) =>
+            {
+                return picker switch
+                {
+                    RoundRobinPicker roundRobinPicker => roundRobinPicker._subchannels.ToArray(),
+                    PickFirstPicker pickFirstPicker => new[] { pickFirstPicker.Subchannel },
+                    EmptyPicker emptyPicker => Array.Empty<Subchannel>(),
+                    null => Array.Empty<Subchannel>(),
+                    _ => throw new Exception("Unexpected picker type: " + picker.GetType().FullName)
+                };
+            };
+        }
+
+        logger.LogInformation($"Waiting for subchannel ready count: {expectedCount}");
+
+        Subchannel[]? subChannelsCopy = null;
+        await TestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            var picker = channel.ConnectionManager._picker;
+            subChannelsCopy = getPickerSubchannels(picker);
+            logger.LogInformation($"Current subchannel ready count: {subChannelsCopy.Length}");
+            for (var i = 0; i < subChannelsCopy.Length; i++)
+            {
+                var c = subChannelsCopy[i];
+                if (validateSubchannel != null)
+                {
+                    var validationResult = validateSubchannel(c);
+                    logger.LogInformation($"Validation result for subchannel '{c}': {validationResult}");
+                    if (!validationResult)
+                    {
+                        logger.LogInformation("Returning false because of validation failure.");
+                        return false;
+                    }
+                }
+                logger.LogInformation($"Ready subchannel: {c}");
+            }
+
+            return subChannelsCopy.Length == expectedCount;
+        }, "Wait for all subconnections to be connected.");
+
+        logger.LogInformation($"Finished waiting for subchannel ready.");
+
+        Debug.Assert(subChannelsCopy != null);
+        return subChannelsCopy;
+    }
+
+}
+#endif


### PR DESCRIPTION
Capturing `ExecutionContext` can cause a memory leak of async locals values.