### PR TITLE
Call Complete on SubchannelCallTracker after HttpContent has been disposed

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
@@ -1,0 +1,71 @@
+using System.Net;
+
+namespace Grpc.Net.Client.Balancer.Internal;
+
+internal sealed class HttpContentWrapper : HttpContent
+{
+    private readonly HttpContent _inner;
+    private readonly Action _disposeAction;
+    private bool _disposed;
+
+    public HttpContentWrapper(HttpContent inner, Action disposeAction)
+    {
+        _inner = inner;
+        _disposeAction = disposeAction;
+
+        foreach (var kvp in inner.Headers)
+        {
+            Headers.TryAddWithoutValidation(kvp.Key, kvp.Value.ToArray());
+        }
+    }
+
+#if NET5_0_OR_GREATER
+
+    protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+    {
+        using var content = _inner.ReadAsStream(cancellationToken);
+        content.CopyTo(stream);
+    }
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+    {
+        var content = await _inner.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (content.ConfigureAwait(false))
+        {
+            await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+#endif
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        var content = await _inner.ReadAsStreamAsync().ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        await using (content.ConfigureAwait(false))
+#else
+        using (content)
+#endif
+        {
+            await content.CopyToAsync(stream).ConfigureAwait(false);
+        }
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = 0;
+        return false;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing && !_disposed)
+        {
+            _disposeAction();
+            _inner.Dispose();
+            _disposed = true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2133

As described in that issue, the `SubchannelCallTracker.Complete` method is currently called right after the request headers are sent to the server. This does not actually correspond to the full length of the call, especially in streaming calls. 

This change uses a wrapped `HttpContent` (like [here](https://gist.github.com/JamesNK/9cd342b3a547bc2f7963d8de5c18385c), but only on `Dispose`) to detect when the user code is actually done with the response data. 

I have tested the change with our own application and it behaves as expected. I am aware that it causes some additional allocations and a virtual method call (performance impact), but it's only relevant for users of the `ISubchannelCallTracker`-interface, which is only used by some (!) custom load balancers. Given that these will not have worked correctly so far, I'd wager the cost acceptable to consider this quick fix for now, and improve on the performance later.