### PR TITLE
Refactor healthchecks service mapping to support filtering on check

### DIFF
--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
@@ -50,7 +50,7 @@ internal sealed class GrpcHealthChecksPublisher : IHealthCheckPublisher
             {
                 serviceEntries = serviceEntries.Where(entry =>
                 {
-                    var context = new HealthCheckFilterContext(entry.Key, entry.Value.Tags);
+                    var context = new HealthCheckMapContext(entry.Key, entry.Value.Tags);
                     return serviceMapping.HealthCheckPredicate(context);
                 });
             }

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
@@ -47,14 +47,14 @@ internal sealed class GrpcHealthChecksPublisher : IHealthCheckPublisher
             serviceEntries ??= new();
             serviceEntries.AddRange(report.Entries);
 
-            if (serviceMapping.FilterPredicate != null)
+            if (serviceMapping.HealthCheckPredicate != null)
             {
                 for (var i = serviceEntries.Count - 1; i >= 0; i--)
                 {
                     var entry = serviceEntries[i];
                     var registration = new HealthCheckFilterContext(entry.Key, entry.Value.Tags);
 
-                    if (!serviceMapping.FilterPredicate(registration))
+                    if (!serviceMapping.HealthCheckPredicate(registration))
                     {
                         serviceEntries.RemoveAt(i);
                     }

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -18,6 +18,7 @@
 
 using Grpc.HealthCheck;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Grpc.AspNetCore.HealthChecks;
@@ -25,21 +26,46 @@ namespace Grpc.AspNetCore.HealthChecks;
 internal sealed class GrpcHealthChecksPublisher : IHealthCheckPublisher
 {
     private readonly HealthServiceImpl _healthService;
+    private readonly ILogger _logger;
     private readonly GrpcHealthChecksOptions _options;
 
-    public GrpcHealthChecksPublisher(HealthServiceImpl healthService, IOptions<GrpcHealthChecksOptions> options)
+    public GrpcHealthChecksPublisher(HealthServiceImpl healthService, IOptions<GrpcHealthChecksOptions> options, ILoggerFactory loggerFactory)
     {
         _healthService = healthService;
+        _logger = loggerFactory.CreateLogger<GrpcHealthChecksPublisher>();
         _options = options.Value;
     }
 
     public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
     {
-        foreach (var registration in _options.Services)
+        foreach (var serviceMapping in _options.Services)
         {
-            var resolvedStatus = HealthChecksStatusHelpers.GetStatus(report, registration.Predicate);
+            var entries = report.Entries.ToList();
 
-            _healthService.SetStatus(registration.Name, resolvedStatus);
+            if (serviceMapping.FilterPredicate != null)
+            {
+                for (var i = entries.Count - 1; i >= 0; i--)
+                {
+                    var entry = entries[i];
+                    var registration = new HealthCheckFilterContext(entry.Key, entry.Value.Tags);
+
+                    if (!serviceMapping.FilterPredicate(registration))
+                    {
+                        entries.RemoveAt(i);
+                    }
+                }
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            var results = entries.Select(entry => new HealthResult(entry.Key, entry.Value.Tags, entry.Value.Status, entry.Value.Description, entry.Value.Duration, entry.Value.Exception, entry.Value.Data));
+            if (serviceMapping.Predicate != null)
+            {
+                results = results.Where(serviceMapping.Predicate);
+            }
+            var resolvedStatus = HealthChecksStatusHelpers.GetStatus(results);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            _healthService.SetStatus(serviceMapping.Name, resolvedStatus);
         }
 
         return Task.CompletedTask;

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksServiceExtensions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -79,7 +79,7 @@ public static class GrpcHealthChecksServiceExtensions
         services.Configure<GrpcHealthChecksOptions>(options =>
         {
             // Add default registration that uses all results for default service: ""
-            options.Services.MapService(string.Empty, r => true);
+            options.Services.Map(string.Empty, r => true);
         });
 
         return services.AddHealthChecks();

--- a/src/Grpc.AspNetCore.HealthChecks/HealthCheckFilterContext.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/HealthCheckFilterContext.cs
@@ -1,0 +1,46 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Grpc.AspNetCore.HealthChecks;
+
+/// <summary>
+/// Context used to filter health check registrations.
+/// </summary>
+public sealed class HealthCheckFilterContext
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="HealthCheckFilterContext"/>.
+    /// </summary>
+    /// <param name="name">The health check name.</param>
+    /// <param name="tags">Tags associated with the health check.</param>
+    public HealthCheckFilterContext(string name, IEnumerable<string> tags)
+    {
+        Name = name;
+        Tags = tags;
+    }
+
+    /// <summary>
+    /// Gets the health check name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the tags associated with the health check.
+    /// </summary>
+    public IEnumerable<string> Tags { get; }
+}

--- a/src/Grpc.AspNetCore.HealthChecks/HealthCheckMapContext.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/HealthCheckMapContext.cs
@@ -19,16 +19,16 @@
 namespace Grpc.AspNetCore.HealthChecks;
 
 /// <summary>
-/// Context used to filter health check registrations.
+/// Context used to map health check registrations to a service.
 /// </summary>
-public sealed class HealthCheckFilterContext
+public sealed class HealthCheckMapContext
 {
     /// <summary>
-    /// Creates a new instance of <see cref="HealthCheckFilterContext"/>.
+    /// Creates a new instance of <see cref="HealthCheckMapContext"/>.
     /// </summary>
     /// <param name="name">The health check name.</param>
     /// <param name="tags">Tags associated with the health check.</param>
-    public HealthCheckFilterContext(string name, IEnumerable<string> tags)
+    public HealthCheckMapContext(string name, IEnumerable<string> tags)
     {
         Name = name;
         Tags = tags;

--- a/src/Grpc.AspNetCore.HealthChecks/HealthResult.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/HealthResult.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -23,6 +23,7 @@ namespace Grpc.AspNetCore.HealthChecks;
 /// <summary>
 /// Represents the result of a single <see cref="IHealthCheck"/>.
 /// </summary>
+[Obsolete($"HealthResult is obsolete and will be removed in a future release. Use {nameof(HealthCheckFilterContext)} instead.")]
 public sealed class HealthResult
 {
     /// <summary>

--- a/src/Grpc.AspNetCore.HealthChecks/HealthResult.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/HealthResult.cs
@@ -23,7 +23,7 @@ namespace Grpc.AspNetCore.HealthChecks;
 /// <summary>
 /// Represents the result of a single <see cref="IHealthCheck"/>.
 /// </summary>
-[Obsolete($"HealthResult is obsolete and will be removed in a future release. Use {nameof(HealthCheckFilterContext)} instead.")]
+[Obsolete($"HealthResult is obsolete and will be removed in a future release. Use {nameof(HealthCheckMapContext)} instead.")]
 public sealed class HealthResult
 {
     /// <summary>

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/HealthChecksStatusHelpers.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/HealthChecksStatusHelpers.cs
@@ -16,14 +16,12 @@
 
 #endregion
 
-using Grpc.AspNetCore.HealthChecks;
 using Grpc.Health.V1;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 internal static class HealthChecksStatusHelpers
 {
-    [Obsolete("Remove with HealthResult.")]
-    public static (HealthCheckResponse.Types.ServingStatus status, int resultCount) GetStatus(IEnumerable<HealthResult> results)
+    public static (HealthCheckResponse.Types.ServingStatus status, int resultCount) GetStatus(IEnumerable<KeyValuePair<string, HealthReportEntry>> results)
     {
         var resultCount = 0;
         var resolvedStatus = HealthCheckResponse.Types.ServingStatus.Unknown;
@@ -37,7 +35,7 @@ internal static class HealthChecksStatusHelpers
                 continue;
             }
 
-            if (result.Status == HealthStatus.Unhealthy)
+            if (result.Value.Status == HealthStatus.Unhealthy)
             {
                 resolvedStatus = HealthCheckResponse.Types.ServingStatus.NotServing;
             }

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/HealthChecksStatusHelpers.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/HealthChecksStatusHelpers.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -22,14 +22,11 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 internal static class HealthChecksStatusHelpers
 {
-    public static HealthCheckResponse.Types.ServingStatus GetStatus(HealthReport report, Func<HealthResult, bool> predicate)
+    [Obsolete("Remove with HealthResult.")]
+    public static HealthCheckResponse.Types.ServingStatus GetStatus(IEnumerable<HealthResult> results)
     {
-        var filteredResults = report.Entries
-            .Select(entry => new HealthResult(entry.Key, entry.Value.Tags, entry.Value.Status, entry.Value.Description, entry.Value.Duration, entry.Value.Exception, entry.Value.Data))
-            .Where(predicate);
-
         var resolvedStatus = HealthCheckResponse.Types.ServingStatus.Unknown;
-        foreach (var result in filteredResults)
+        foreach (var result in results)
         {
             if (result.Status == HealthStatus.Unhealthy)
             {

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
@@ -81,7 +81,7 @@ internal sealed class HealthServiceIntegration : Grpc.Health.V1.Health.HealthBas
                     return false;
                 }
 
-                if (serviceMapping.HealthCheckPredicate != null && !serviceMapping.HealthCheckPredicate(new HealthCheckFilterContext(registration.Name, registration.Tags)))
+                if (serviceMapping.HealthCheckPredicate != null && !serviceMapping.HealthCheckPredicate(new HealthCheckMapContext(registration.Name, registration.Tags)))
                 {
                     return false;
                 }

--- a/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/Internal/HealthServiceIntegration.cs
@@ -81,7 +81,7 @@ internal sealed class HealthServiceIntegration : Grpc.Health.V1.Health.HealthBas
                     return false;
                 }
 
-                if (serviceMapping.FilterPredicate != null && !serviceMapping.FilterPredicate(new HealthCheckFilterContext(registration.Name, registration.Tags)))
+                if (serviceMapping.HealthCheckPredicate != null && !serviceMapping.HealthCheckPredicate(new HealthCheckFilterContext(registration.Name, registration.Tags)))
                 {
                     return false;
                 }

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
@@ -39,11 +39,23 @@ public sealed class ServiceMapping
     /// Creates a new instance of <see cref="ServiceMapping"/>.
     /// </summary>
     /// <param name="name">The service name.</param>
-    /// <param name="predicate">The predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.</param>
+    /// <param name="predicate">
+    /// The predicate used to filter health checks when the <c>Health</c> service <c>Check</c> and <c>Watch</c> methods are called.
+    /// <para>
+    /// The <c>Health</c> service methods have different behavior:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>Check</c> uses the predicate to determine which health checks are run for a service.</description></item>
+    /// <item><description><c>Watch</c> periodically runs all health checks. The predicate filters the health results for a service.</description></item>
+    /// </list>
+    /// <para>
+    /// The health result for the service is based on the health check results.
+    /// </para>
+    /// </param>
     public ServiceMapping(string name, Func<HealthCheckFilterContext, bool> predicate)
     {
         Name = name;
-        FilterPredicate = predicate;
+        HealthCheckPredicate = predicate;
     }
 
     /// <summary>
@@ -52,16 +64,23 @@ public sealed class ServiceMapping
     public string Name { get; }
 
     /// <summary>
-    /// Gets the predicate used to filter registered health check instances. These results determine service health.
+    /// Gets the predicate used to filter health checks when the <c>Health</c> service <c>Check</c> and <c>Watch</c> methods are called.
     /// <para>
-    /// 
+    /// The <c>Health</c> service methods have different behavior:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>Check</c> uses the predicate to determine which health checks are run for a service.</description></item>
+    /// <item><description><c>Watch</c> periodically runs all health checks. The predicate filters the health results for a service.</description></item>
+    /// </list>
+    /// <para>
+    /// The health result for the service is based on the health check results.
     /// </para>
     /// </summary>
-    public Func<HealthCheckFilterContext, bool>? FilterPredicate { get; }
+    public Func<HealthCheckFilterContext, bool>? HealthCheckPredicate { get; }
 
     /// <summary>
     /// Gets the predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.
     /// </summary>
-    [Obsolete($"This member is obsolete and will be removed in the future. Use {nameof(FilterPredicate)} to map service names to .NET health checks.")]
+    [Obsolete($"This member is obsolete and will be removed in the future. Use {nameof(HealthCheckPredicate)} to map service names to .NET health checks.")]
     public Func<HealthResult, bool>? Predicate { get; }
 }

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
@@ -65,18 +65,3 @@ public sealed class ServiceMapping
     [Obsolete($"This member is obsolete and will be removed in the future. Use {nameof(FilterPredicate)} to map service names to .NET health checks.")]
     public Func<HealthResult, bool>? Predicate { get; }
 }
-
-/// <summary>
-/// 
-/// </summary>
-public readonly struct HealthCheckFilterContext
-{
-    public HealthCheckFilterContext(string name, IEnumerable<string> tags)
-    {
-        Name = name;
-        Tags = tags;
-    }
-
-    public string Name { get; }
-    public IEnumerable<string> Tags { get; }
-}

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -28,10 +28,22 @@ public sealed class ServiceMapping
     /// </summary>
     /// <param name="name">The service name.</param>
     /// <param name="predicate">The predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.</param>
+    [Obsolete("This constructor is obsolete and will be removed in the future. Use ServiceMapping(string name, Func<HealthCheckRegistration, bool> predicate) to map service names to .NET health checks.")]
     public ServiceMapping(string name, Func<HealthResult, bool> predicate)
     {
         Name = name;
         Predicate = predicate;
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ServiceMapping"/>.
+    /// </summary>
+    /// <param name="name">The service name.</param>
+    /// <param name="predicate">The predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.</param>
+    public ServiceMapping(string name, Func<HealthCheckFilterContext, bool> predicate)
+    {
+        Name = name;
+        FilterPredicate = predicate;
     }
 
     /// <summary>
@@ -40,7 +52,31 @@ public sealed class ServiceMapping
     public string Name { get; }
 
     /// <summary>
+    /// Gets the predicate used to filter registered health check instances. These results determine service health.
+    /// <para>
+    /// 
+    /// </para>
+    /// </summary>
+    public Func<HealthCheckFilterContext, bool>? FilterPredicate { get; }
+
+    /// <summary>
     /// Gets the predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.
     /// </summary>
-    public Func<HealthResult, bool> Predicate { get; }
+    [Obsolete($"This member is obsolete and will be removed in the future. Use {nameof(FilterPredicate)} to map service names to .NET health checks.")]
+    public Func<HealthResult, bool>? Predicate { get; }
+}
+
+/// <summary>
+/// 
+/// </summary>
+public readonly struct HealthCheckFilterContext
+{
+    public HealthCheckFilterContext(string name, IEnumerable<string> tags)
+    {
+        Name = name;
+        Tags = tags;
+    }
+
+    public string Name { get; }
+    public IEnumerable<string> Tags { get; }
 }

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMapping.cs
@@ -52,7 +52,7 @@ public sealed class ServiceMapping
     /// The health result for the service is based on the health check results.
     /// </para>
     /// </param>
-    public ServiceMapping(string name, Func<HealthCheckFilterContext, bool> predicate)
+    public ServiceMapping(string name, Func<HealthCheckMapContext, bool> predicate)
     {
         Name = name;
         HealthCheckPredicate = predicate;
@@ -76,7 +76,7 @@ public sealed class ServiceMapping
     /// The health result for the service is based on the health check results.
     /// </para>
     /// </summary>
-    public Func<HealthCheckFilterContext, bool>? HealthCheckPredicate { get; }
+    public Func<HealthCheckMapContext, bool>? HealthCheckPredicate { get; }
 
     /// <summary>
     /// Gets the predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -70,7 +70,19 @@ public sealed class ServiceMappingCollection : IEnumerable<ServiceMapping>
     /// </summary>
     /// <param name="name">The service name.</param>
     /// <param name="predicate">The predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.</param>
+    [Obsolete("This method is obsolete and will be removed in the future. Use Map(string name, Func<HealthCheckRegistration, bool> predicate) to map service names to .NET health checks.")]
     public void MapService(string name, Func<HealthResult, bool> predicate)
+    {
+        _mappings.Remove(name);
+        _mappings.Add(new ServiceMapping(name, predicate));
+    }
+
+    /// <summary>
+    /// Add a service mapping to the collection with the specified name and predicate.
+    /// </summary>
+    /// <param name="name">The service name.</param>
+    /// <param name="predicate">The predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.</param>
+    public void Map(string name, Func<HealthCheckFilterContext, bool> predicate)
     {
         _mappings.Remove(name);
         _mappings.Add(new ServiceMapping(name, predicate));

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
@@ -25,7 +25,7 @@ namespace Grpc.AspNetCore.HealthChecks;
 /// <summary>
 /// A collection of <see cref="ServiceMapping"/> used to map health results to gRPC health checks services.
 /// </summary>
-public sealed class ServiceMappingCollection : IEnumerable<ServiceMapping>
+public sealed class ServiceMappingCollection : ICollection<ServiceMapping>
 {
     private sealed class ServiceMappingKeyedCollection : KeyedCollection<string, ServiceMapping>
     {
@@ -36,6 +36,13 @@ public sealed class ServiceMappingCollection : IEnumerable<ServiceMapping>
     }
 
     private readonly ServiceMappingKeyedCollection _mappings = new ServiceMappingKeyedCollection();
+
+    /// <summary>
+    /// Gets the number of service mappings.
+    /// </summary>
+    public int Count => _mappings.Count;
+
+    bool ICollection<ServiceMapping>.IsReadOnly => false;
 
     internal bool TryGetServiceMapping(string name, [NotNullWhen(true)] out ServiceMapping? serviceMapping)
     {
@@ -97,5 +104,20 @@ public sealed class ServiceMappingCollection : IEnumerable<ServiceMapping>
     IEnumerator IEnumerable.GetEnumerator()
     {
         return _mappings.GetEnumerator();
+    }
+
+    bool ICollection<ServiceMapping>.Contains(ServiceMapping item)
+    {
+        return _mappings.Contains(item);
+    }
+
+    void ICollection<ServiceMapping>.CopyTo(ServiceMapping[] array, int arrayIndex)
+    {
+        _mappings.CopyTo(array, arrayIndex);
+    }
+
+    bool ICollection<ServiceMapping>.Remove(ServiceMapping item)
+    {
+        return _mappings.Remove(item);
     }
 }

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
@@ -101,7 +101,7 @@ public sealed class ServiceMappingCollection : ICollection<ServiceMapping>
     /// The health result for the service is based on the health check results.
     /// </para>
     /// </param>
-    public void Map(string name, Func<HealthCheckFilterContext, bool> predicate)
+    public void Map(string name, Func<HealthCheckMapContext, bool> predicate)
     {
         _mappings.Remove(name);
         _mappings.Add(new ServiceMapping(name, predicate));

--- a/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/ServiceMappingCollection.cs
@@ -88,7 +88,19 @@ public sealed class ServiceMappingCollection : ICollection<ServiceMapping>
     /// Add a service mapping to the collection with the specified name and predicate.
     /// </summary>
     /// <param name="name">The service name.</param>
-    /// <param name="predicate">The predicate used to filter <see cref="HealthResult"/> instances. These results determine service health.</param>
+    /// <param name="predicate">
+    /// The predicate used to filter health checks when the <c>Health</c> service <c>Check</c> and <c>Watch</c> methods are called.
+    /// <para>
+    /// The <c>Health</c> service methods have different behavior:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>Check</c> uses the predicate to determine which health checks are run for a service.</description></item>
+    /// <item><description><c>Watch</c> periodically runs all health checks. The predicate filters the health results for a service.</description></item>
+    /// </list>
+    /// <para>
+    /// The health result for the service is based on the health check results.
+    /// </para>
+    /// </param>
     public void Map(string name, Func<HealthCheckFilterContext, bool> predicate)
     {
         _mappings.Remove(name);

--- a/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/DefaultGrpcClientFactory.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -17,7 +17,6 @@
 #endregion
 
 using System.Diagnostics.CodeAnalysis;
-using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
@@ -26,6 +26,7 @@
     <Compile Include="..\Shared\TestRequestBodyPipeFeature.cs" Link="Infrastructure\TestRequestBodyPipeFeature.cs" />
     <Compile Include="..\Shared\TestResponseBodyFeature.cs" Link="Infrastructure\TestResponseBodyFeature.cs" />
     <Compile Include="..\Shared\TestServerCallContext.cs" Link="Infrastructure\TestServerCallContext.cs" />
+    <Compile Include="..\Shared\NUnitLogger.cs" Link="Infrastructure\NUnitLogger.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\Shared\SyncPointMemoryStream.cs" Link="Infrastructure\SyncPointMemoryStream.cs" />
     <Compile Include="..\Shared\TestHttpMessageHandler.cs" Link="Infrastructure\TestHttpMessageHandler.cs" />
     <Compile Include="..\Shared\TestHelpers.cs" Link="Infrastructure\TestHelpers.cs" />
+    <Compile Include="..\Shared\NUnitLogger.cs" Link="Infrastructure\NUnitLogger.cs" />
     <Compile Include="..\Shared\TestResolver.cs" Link="Infrastructure\Balancer\TestResolver.cs" />
     <Compile Include="..\Shared\TestResolverFactory.cs" Link="Infrastructure\Balancer\TestResolverFactory.cs" />
     <Compile Include="..\Shared\BalancerWaitHelpers.cs" Link="Infrastructure\Balancer\BalancerWaitHelpers.cs" />

--- a/test/Shared/NUnitLogger.cs
+++ b/test/Shared/NUnitLogger.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -20,7 +20,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Grpc.Net.Client.Tests.Infrastructure;
+namespace Grpc.Tests.Shared;
 
 internal static class NUnitLoggerExtensions
 {
@@ -107,5 +107,10 @@ internal class NUnitLogger : ILogger, IDisposable
 
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public IDisposable BeginScope<TState>(TState state) => this;
+#pragma warning disable CS8633 // Nullability in constraints for type parameter doesn't match the constraints for type parameter in implicitly implemented interface method'.
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return this;
+    }
+#pragma warning restore CS8633 // Nullability in constraints for type parameter doesn't match the constraints for type parameter in implicitly implemented interface method'.
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2141

* Previously, all health checks were run when `Check` was called, and then they were filtered. This PR changes the filter to happen before health checks are run. Now health checks can be selectly run depending on `Check`'s service name argument.
* Previous health result filtering is now obsolete. The new predicate is based on the information available when a health check is registered (its name and tags).
* Add some logging to the health check publisher.

API changes:

```diff
namespace Grpc.AspNetCore.HealthChecks;

+public sealed class HealthCheckMapContext
+{
+   public HealthCheckMapContext(string name, IEnumerable<string> tags);
+   public string Name { get; }
+   public IEnumerable<string> Tags { get; }
+}

+[Obsolete($"HealthResult is obsolete and will be removed in a future release. Use {nameof(HealthCheckMapContext)} instead.")]
public sealed class HealthResult
{
    public HealthResult(string name, IEnumerable<string> tags, HealthStatus status, string? description, TimeSpan duration, Exception? exception, IReadOnlyDictionary<string, object> data);
    public string Name { get; }
    public IEnumerable<string> Tags { get; }
    public HealthStatus Status { get; }
    public string? Description { get; }
    public IReadOnlyDictionary<string, object> Data { get; }
    public Exception? Exception { get; }
    public TimeSpan Duration { get; }
}

public sealed class ServiceMapping
{
+   [Obsolete("This constructor is obsolete and will be removed in the future. Use ServiceMapping(string name, Func<HealthCheckRegistration, bool> predicate) to map service names to .NET health checks.")]
    public ServiceMapping(string name, Func<HealthResult, bool> predicate);
+   public ServiceMapping(string name, Func<HealthCheckMapContext, bool> predicate);
+   public Func<HealthCheckMapContext, bool>? HealthCheckPredicate { get; }
+   [Obsolete($"This member is obsolete and will be removed in the future. Use {nameof(HealthCheckPredicate)} to map service names to .NET health checks.")]
    public Func<HealthResult, bool>? Predicate { get; }
}

-public sealed class ServiceMappingCollection : IEnumerable<ServiceMapping>
+public sealed class ServiceMappingCollection : ICollection<ServiceMapping>
{
+   [Obsolete("This method is obsolete and will be removed in the future. Use Map(string name, Func<HealthCheckRegistration, bool> predicate) to map service names to .NET health checks.")]
    public void MapService(string name, Func<HealthResult, bool> predicate);
+   public void Map(string name, Func<HealthCheckMapContext, bool> predicate);
}
```

Usage:

```csharp
builder.Services.AddGrpcHealthChecks(o =>
{
    o.Services.Map("greet.Greeter", c => c.Tags.Contains("greeter"));
    o.Services.Map("count.Counter", c => c.Tags.Contains("counter"));
});
```