### PR TITLE
Call Complete on SubchannelCallTracker after HttpContent has been disposed

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
@@ -29,17 +29,10 @@ internal sealed class HttpContentWrapper : HttpContent
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
     {
-        try
+        var content = await _inner.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (content.ConfigureAwait(false))
         {
-            var content = await _inner.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            await using (content.ConfigureAwait(false))
-            {
-                await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex)
-        {
-            throw new Exception("", ex);
+            await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -47,21 +40,14 @@ internal sealed class HttpContentWrapper : HttpContent
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
-        try
-        {
-            var content = await _inner.ReadAsStreamAsync().ConfigureAwait(false);
+        var content = await _inner.ReadAsStreamAsync().ConfigureAwait(false);
 #if NET5_0_OR_GREATER
-            await using (content.ConfigureAwait(false))
+        await using (content.ConfigureAwait(false))
 #else
-            using (content)
+        using (content)
 #endif
-            {
-                await content.CopyToAsync(stream).ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex)
         {
-            throw new Exception("", ex);
+            await content.CopyToAsync(stream).ConfigureAwait(false);
         }
     }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
@@ -29,10 +29,17 @@ internal sealed class HttpContentWrapper : HttpContent
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
     {
-        var content = await _inner.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        await using (content.ConfigureAwait(false))
+        try
         {
-            await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+            var content = await _inner.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using (content.ConfigureAwait(false))
+            {
+                await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("", ex);
         }
     }
 
@@ -40,14 +47,21 @@ internal sealed class HttpContentWrapper : HttpContent
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
-        var content = await _inner.ReadAsStreamAsync().ConfigureAwait(false);
-#if NET5_0_OR_GREATER
-        await using (content.ConfigureAwait(false))
-#else
-        using (content)
-#endif
+        try
         {
-            await content.CopyToAsync(stream).ConfigureAwait(false);
+            var content = await _inner.ReadAsStreamAsync().ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+            await using (content.ConfigureAwait(false))
+#else
+            using (content)
+#endif
+            {
+                await content.CopyToAsync(stream).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("", ex);
         }
     }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/HttpContentWrapper.cs
@@ -1,0 +1,71 @@
+using System.Net;
+
+namespace Grpc.Net.Client.Balancer.Internal;
+
+internal sealed class HttpContentWrapper : HttpContent
+{
+    private readonly HttpContent _inner;
+    private readonly Action _disposeAction;
+    private bool _disposed;
+
+    public HttpContentWrapper(HttpContent inner, Action disposeAction)
+    {
+        _inner = inner;
+        _disposeAction = disposeAction;
+
+        foreach (var kvp in inner.Headers)
+        {
+            Headers.TryAddWithoutValidation(kvp.Key, kvp.Value.ToArray());
+        }
+    }
+
+#if NET5_0_OR_GREATER
+
+    protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+    {
+        using var content = _inner.ReadAsStream(cancellationToken);
+        content.CopyTo(stream);
+    }
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+    {
+        var content = await _inner.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (content.ConfigureAwait(false))
+        {
+            await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+#endif
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        var content = await _inner.ReadAsStreamAsync().ConfigureAwait(false);
+#if NET5_0_OR_GREATER
+        await using (content.ConfigureAwait(false))
+#else
+        using (content)
+#endif
+        {
+            await content.CopyToAsync(stream).ConfigureAwait(false);
+        }
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = 0;
+        return false;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing && !_disposed)
+        {
+            _disposeAction();
+            _inner.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -555,11 +555,12 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                 }
                 else
                 {
+                    var responseStream = await HttpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
                     if (_responseTcs != null)
                     {
                         // Read entire response body immediately and read status from trailers
                         // Trailers are only available once the response body had been read
-                        var responseStream = await HttpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
                         var message = await ReadMessageAsync(
                             responseStream,
                             GrpcProtocolHelpers.GetGrpcEncoding(HttpResponse),
@@ -614,7 +615,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                     {
                         // Duplex or server streaming call
                         CompatibilityHelpers.Assert(ClientStreamReader != null);
-                        ClientStreamReader.HttpResponseTcs.TrySetResult((HttpResponse, status));
+                        ClientStreamReader.HttpResponseTcs.TrySetResult((HttpResponse, responseStream, status));
 
                         // Wait until the response has been read and status read from trailers.
                         // TCS will also be set in Dispose.

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -555,6 +555,10 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
                 }
                 else
                 {
+                    // Always start reading the content as a stream.
+                    // Unary and client streaming calls immediately use the stream to read the response message.
+                    // Server streaming and bidirectional streaming calls don't immediately use the stream but it should be accessed
+                    // so that there is a way for the client to receive a notification of a possible server abort.
                     var responseStream = await HttpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
                     if (_responseTcs != null)

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -135,7 +135,7 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
             }
 
             CompatibilityHelpers.Assert(_grpcEncoding != null, "Encoding should have been calculated the from response.");
-            CompatibilityHelpers.Assert(_responseStream != null, "Response stream should have created the from response.");
+            CompatibilityHelpers.Assert(_responseStream != null, "Response stream should have been created the from response.");
 
             var readMessage = await _call.ReadMessageAsync(
                 _responseStream,

--- a/test/FunctionalTests/Balancer/LeastUsedBalancer.cs
+++ b/test/FunctionalTests/Balancer/LeastUsedBalancer.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -43,7 +43,7 @@ public class LeastUsedBalancer : SubchannelsLoadBalancer
 
 internal class LeastUsedPicker : SubchannelPicker
 {
-    private static readonly BalancerAttributesKey<AtomicCounter> CounterKey = new BalancerAttributesKey<AtomicCounter>("ActiveRequestsCount");
+    internal static readonly BalancerAttributesKey<AtomicCounter> CounterKey = new BalancerAttributesKey<AtomicCounter>("ActiveRequestsCount");
 
     // Internal for testing
     internal readonly List<Subchannel> _subchannels;
@@ -115,43 +115,43 @@ internal class LeastUsedPicker : SubchannelPicker
             _counter.Increment();
         }
     }
+}
 
-    private sealed class AtomicCounter
+internal sealed class AtomicCounter
+{
+    private int _value;
+
+    /// <summary>
+    /// Gets the current value of the counter.
+    /// </summary>
+    public int Value
     {
-        private int _value;
+        get => Volatile.Read(ref _value);
+        set => Volatile.Write(ref _value, value);
+    }
 
-        /// <summary>
-        /// Gets the current value of the counter.
-        /// </summary>
-        public int Value
-        {
-            get => Volatile.Read(ref _value);
-            set => Volatile.Write(ref _value, value);
-        }
+    /// <summary>
+    /// Atomically increments the counter value by 1.
+    /// </summary>
+    public int Increment()
+    {
+        return Interlocked.Increment(ref _value);
+    }
 
-        /// <summary>
-        /// Atomically increments the counter value by 1.
-        /// </summary>
-        public int Increment()
-        {
-            return Interlocked.Increment(ref _value);
-        }
+    /// <summary>
+    /// Atomically decrements the counter value by 1.
+    /// </summary>
+    public int Decrement()
+    {
+        return Interlocked.Decrement(ref _value);
+    }
 
-        /// <summary>
-        /// Atomically decrements the counter value by 1.
-        /// </summary>
-        public int Decrement()
-        {
-            return Interlocked.Decrement(ref _value);
-        }
-
-        /// <summary>
-        /// Atomically resets the counter value to 0.
-        /// </summary>
-        public void Reset()
-        {
-            Interlocked.Exchange(ref _value, 0);
-        }
+    /// <summary>
+    /// Atomically resets the counter value to 0.
+    /// </summary>
+    public void Reset()
+    {
+        Interlocked.Exchange(ref _value, 0);
     }
 }
 

--- a/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/LeastUsedBalancerTests.cs
@@ -29,6 +29,7 @@ using Grpc.AspNetCore.FunctionalTests.Infrastructure;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Net.Client.Balancer;
+using Grpc.Net.Client.Balancer.Internal;
 using Grpc.Net.Client.Configuration;
 using Grpc.Tests.Shared;
 using Microsoft.Extensions.Logging;
@@ -40,7 +41,7 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer;
 public class LeastUsedBalancerTests : FunctionalTestBase
 {
     [Test]
-    public async Task UnaryCall_MultipleCalls_RoundRobin()
+    public async Task UnaryCall_MultipleCalls_PickLeastUsed()
     {
         // Ignore errors
         SetExpectedErrorsFilter(writeContext =>
@@ -89,24 +90,185 @@ public class LeastUsedBalancerTests : FunctionalTestBase
 
         // Act
         var sp1 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
-        var pendingCall1 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
+        using var pendingCall1 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
         // Assert
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
         Assert.AreEqual("127.0.0.1:50051", host);
 
         // Act
         var sp2 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
-        var pendingCall2 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
+        using var pendingCall2 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
         // Assert
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
         Assert.AreEqual("127.0.0.1:50052", host);
 
         // Act
         var sp3 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
-        var pendingCall3 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
+        using var pendingCall3 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
         // Assert
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
         Assert.AreEqual("127.0.0.1:50051", host);
+
+        sp1.Continue();
+        sp2.Continue();
+        sp3.Continue();
+    }
+
+    [Test]
+    public async Task UnaryCall_FlushHeaders_MultipleCalls_ClientAbort_PickLeastUsed()
+    {
+        // Ignore errors
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        SyncPoint? syncPoint = null;
+        string? host = null;
+        async Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)
+        {
+            await context.WriteResponseHeadersAsync(Metadata.Empty);
+
+            host = context.Host;
+            if (syncPoint != null)
+            {
+                await syncPoint.WaitToContinue();
+            }
+
+            return new HelloReply { Message = request.Name };
+        }
+
+        // Arrange
+        using var endpoint1 = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod));
+        using var endpoint2 = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50052, UnaryMethod, nameof(UnaryMethod));
+
+        var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new LoadBalancingConfig("least_used"), new[] { endpoint1.Address, endpoint2.Address }, connect: true);
+
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(
+            Logger,
+            channel,
+            expectedCount: 2,
+            getPickerSubchannels: picker => (picker as LeastUsedPicker)?._subchannels.ToArray() ?? Array.Empty<Subchannel>()).DefaultTimeout();
+
+        var client = TestClientFactory.Create(channel, endpoint1.Method);
+
+        // Act
+        var sp1 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+        using var pendingCall1 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
+        await pendingCall1.ResponseHeadersAsync.DefaultTimeout();
+        // Assert
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.AreEqual("127.0.0.1:50051", host);
+
+        // Act
+        var sp2 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+        using var pendingCall2 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
+        await pendingCall2.ResponseHeadersAsync.DefaultTimeout();
+        // Assert
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.AreEqual("127.0.0.1:50052", host);
+
+        var picker = (LeastUsedPicker)channel.ConnectionManager._picker!;
+        Assert.True(picker._subchannels[0].Attributes.TryGetValue(LeastUsedPicker.CounterKey, out var counter1));
+        Assert.True(picker._subchannels[1].Attributes.TryGetValue(LeastUsedPicker.CounterKey, out var counter2));
+
+        Assert.AreEqual(1, counter1!.Value);
+        Assert.AreEqual(1, counter2!.Value);
+
+        pendingCall2.Dispose();
+
+        Assert.AreEqual(0, counter2!.Value);
+
+        // Act
+        var sp3 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+        using var pendingCall3 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
+        // Assert
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.AreEqual("127.0.0.1:50052", host);
+
+        sp1.Continue();
+        sp2.Continue();
+        sp3.Continue();
+    }
+
+    [Test]
+    public async Task ServerStreamingCall_FlushHeaders_MultipleCalls_ServerAbort_PickLeastUsed()
+    {
+        // Ignore errors
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        SyncPoint? syncPoint = null;
+        string? host = null;
+        async Task ServerStreamingMethod(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            await context.WriteResponseHeadersAsync(Metadata.Empty);
+
+            host = context.Host;
+            if (syncPoint != null)
+            {
+                await syncPoint.WaitToContinue();
+                Logger.LogInformation("Server aborting");
+                context.GetHttpContext().Abort();
+                return;
+            }
+
+            await responseStream.WriteAsync(new HelloReply { Message = request.Name });
+        }
+
+        // Arrange
+        using var endpoint1 = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, ServerStreamingMethod, nameof(ServerStreamingMethod));
+        using var endpoint2 = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50052, ServerStreamingMethod, nameof(ServerStreamingMethod));
+
+        var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new LoadBalancingConfig("least_used"), new[] { endpoint1.Address, endpoint2.Address }, connect: true);
+
+        await BalancerWaitHelpers.WaitForSubchannelsToBeReadyAsync(
+            Logger,
+            channel,
+            expectedCount: 2,
+            getPickerSubchannels: picker => (picker as LeastUsedPicker)?._subchannels.ToArray() ?? Array.Empty<Subchannel>()).DefaultTimeout();
+
+        var client = TestClientFactory.Create(channel, endpoint1.Method);
+
+        // Act
+        var sp1 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+        var pendingCall1 = client.ServerStreamingCall(new HelloRequest { Name = "Balancer" });
+        await pendingCall1.ResponseHeadersAsync.DefaultTimeout();
+        // Assert
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.AreEqual("127.0.0.1:50051", host);
+
+        // Act
+        var sp2 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+        var pendingCall2 = client.ServerStreamingCall(new HelloRequest { Name = "Balancer" });
+        await pendingCall2.ResponseHeadersAsync.DefaultTimeout();
+        // Assert
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.AreEqual("127.0.0.1:50052", host);
+
+        var rs = pendingCall2.ResponseStream;
+        _ = rs.MoveNext();
+
+        var picker = (LeastUsedPicker)channel.ConnectionManager._picker!;
+        Assert.True(picker._subchannels[0].Attributes.TryGetValue(LeastUsedPicker.CounterKey, out var counter1));
+        Assert.True(picker._subchannels[1].Attributes.TryGetValue(LeastUsedPicker.CounterKey, out var counter2));
+
+        Assert.AreEqual(1, counter1!.Value);
+        Assert.AreEqual(1, counter2!.Value);
+
+        sp2.Continue();
+
+        Logger.LogInformation("Client waiting for notification");
+        await TestHelpers.AssertIsTrueRetryAsync(() => counter2!.Value == 0, "");
+
+        // Act
+        var sp3 = syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+        var pendingCall3 = client.UnaryCall(new HelloRequest { Name = "Balancer" });
+        // Assert
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.AreEqual("127.0.0.1:50052", host);
 
         sp1.Continue();
         sp2.Continue();


### PR DESCRIPTION
Update on https://github.com/grpc/grpc-dotnet/pull/2139

* Adds unit tests.
* Fixes scenario a streaming call is never used (the response stream isn't read from and the call isn't disposed) and the server aborts the call.

FYI @Khazuar 