### PR TITLE
WriteAsync cancellation throws an error with the calls completed status if possible

### DIFF
--- a/src/Grpc.Net.Client/Internal/Http/PushStreamContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/PushStreamContent.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -72,4 +72,10 @@ internal class PushStreamContent<TRequest, TResponse> : HttpContent
     // Hacky. ReadAsStreamAsync does not complete until SerializeToStreamAsync finishes.
     // WARNING: Will run SerializeToStreamAsync again on .NET Framework.
     internal Task PushComplete => ReadAsStreamAsync();
+
+    // Internal for testing.
+    internal Task SerializeToStreamAsync(Stream stream)
+    {
+        return SerializeToStreamAsync(stream, context: null);
+    }
 }

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -367,7 +367,7 @@ internal static partial class StreamExtensions
         // In this situation, report the call's completed status.
         //
         // Replace exception with the status error if:
-        // 1. The exception type is thrown Stream.WriteAsync if the call was completed during a write, and
+        // 1. The original exception is one Stream.WriteAsync throws if the call was completed during a write, and
         // 2. The call has already been successfully completed.
         if (originalException is OperationCanceledException or ObjectDisposedException &&
             call.CallTask.IsCompletedSuccessfully())

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //

--- a/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcCallSerializationContextTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -318,6 +318,7 @@ public class GrpcCallSerializationContextTests
         public override Type RequestType { get; } = typeof(int);
         public override Type ResponseType { get; } = typeof(string);
         public override CancellationToken CancellationToken { get; }
+        public override Task<Status> CallTask => Task.FromResult(Status.DefaultCancelled);
     }
 
     private GrpcCallSerializationContext CreateSerializationContext(string? requestGrpcEncoding = null, int? maxSendMessageSize = null)

--- a/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/StreamSerializationHelper.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -65,5 +65,6 @@ internal static class StreamSerializationHelper
         public override Type RequestType => _type;
         public override Type ResponseType => _type;
         public override CancellationToken CancellationToken { get; }
+        public override Task<Status> CallTask => Task.FromResult(Status.DefaultCancelled);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2122

If a call is completed during `Stream.WriteAsync`, the cancellation error was thrown. This has been changed to throw the call's completed status if available.