### PR TITLE
Revert "update 2.55 branch to 2.55-pre1"

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,13 +2,13 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.55.0-pre1</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.54.0-dev</GrpcDotnetVersion>
     
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>
 
     <!-- file version of all grpc-dotnet -->
-    <GrpcDotnetAssemblyFileVersion>2.55.0.0</GrpcDotnetAssemblyFileVersion>
+    <GrpcDotnetAssemblyFileVersion>2.54.0.0</GrpcDotnetAssemblyFileVersion>
 
   </PropertyGroup>
 </Project>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -36,10 +36,10 @@ public static class VersionInfo
     /// <summary>
     /// Current <c>AssemblyFileVersion</c> of gRPC C# assemblies
     /// </summary>
-    public const string CurrentAssemblyFileVersion = "2.55.0.0";
+    public const string CurrentAssemblyFileVersion = "2.54.0.0";
 
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.55.0-pre1";
+    public const string CurrentVersion = "2.54.0-dev";
 }


### PR DESCRIPTION
This reverts commit 266be407f6d191f9626db189e9abe4b99185b631.

I accidentally merged this into master instead of v2.55.x