### PR TITLE
Socket transport: Don't close socket on available data

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -161,7 +161,8 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                     _initialSocket = socket;
                     _initialSocketAddress = currentAddress;
 
-                    // Schedule ping. Don't set a periodic interval to avoid any change of overlapping execution.
+                    // Schedule ping. Don't set a periodic interval to avoid any chance of timer running the logic multiple
+                    // times because of execution delays (e.g. hitting a debugger breakpoint).
                     _socketConnectedTimer.Change(_socketPingInterval, Timeout.InfiniteTimeSpan);
                 }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -266,7 +266,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                                 var serverDataAvailable = CalculateInitialSocketDataLength(_initialSocketData) + available;
                                 if (serverDataAvailable > MaximumInitialSocketDataLength)
                                 {
-                                    throw new InvalidOperationException($"The server sent {serverDataAvailable} bytes to the client before a connection was established. This exceeds maximum data allow.");
+                                    throw new InvalidOperationException($"The server sent {serverDataAvailable} bytes to the client before a connection was established. Maximum allowed data exceeded.");
                                 }
 
                                 SocketConnectivitySubchannelTransportLog.SocketReceivingAvailable(_logger, _subchannel.Id, socketAddress, available);

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -339,8 +339,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
         {
             if (_initialSocketDirtyBytesReadCount > 0 || IsSocketInBadState(socket, address, allowAvailableReadBytes: false))
             {
-                var readBytesAvailableCount = _initialSocketDirtyBytesReadCount += socket.Available;
-                SocketConnectivitySubchannelTransportLog.SocketPollBadState(_logger, _subchannel.Id, address, readBytesAvailableCount);
+                SocketConnectivitySubchannelTransportLog.ClosingUnusableSocket(_logger, _subchannel.Id, address);
 
                 socket.Dispose();
                 socket = null;
@@ -504,6 +503,9 @@ internal static class SocketConnectivitySubchannelTransportLog
     private static readonly Action<ILogger, int, BalancerAddress, int, Exception?> _socketReceivingAvailable =
         LoggerMessage.Define<int, BalancerAddress, int>(LogLevel.Trace, new EventId(15, "SocketReceivingAvailable"), "Subchannel id '{SubchannelId}' socket {Address} is receiving {ReadBytesAvailableCount} available bytes.");
 
+    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _closingUnusableSocket =
+        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(16, "ClosingUnusableSocket"), "Subchannel id '{SubchannelId}' socket {Address} is being closed because it can't be used. The socket either can't receive data or it has received unexpected data.");
+
     public static void ConnectingSocket(ILogger logger, int subchannelId, BalancerAddress address)
     {
         _connectingSocket(logger, subchannelId, address, null);
@@ -578,6 +580,13 @@ internal static class SocketConnectivitySubchannelTransportLog
     {
         _socketReceivingAvailable(logger, subchannelId, address, readBytesAvailableCount, null);
     }
+
+    public static void ClosingUnusableSocket(ILogger logger, int subchannelId, BalancerAddress address)
+    {
+        _closingUnusableSocket(logger, subchannelId, address, null);
+    }
+
+    // 
 }
 #endif
 #endif

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -163,8 +163,9 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                     _initialSocketAddress = currentAddress;
                     _initialSocketData = null;
 
-                    // Schedule ping. Don't set a periodic interval to avoid any chance of timer running the logic multiple
-                    // times because of execution delays (e.g. hitting a debugger breakpoint).
+                    // Schedule ping. Don't set a periodic interval to avoid any chance of timer causing the target method to run multiple times in paralle.
+                    // This could happen because of execution delays (e.g. hitting a debugger breakpoint).
+                    // Instead, the socket timer target method reschedules the next run after it has finished.
                     _socketConnectedTimer.Change(_socketPingInterval, Timeout.InfiniteTimeSpan);
                 }
 
@@ -353,6 +354,8 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                     socket.Dispose();
                     socket = null;
                 }
+
+                _socketConnectedTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/src/Grpc.Net.Client/Balancer/Internal/StreamWrapper.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/StreamWrapper.cs
@@ -74,15 +74,12 @@ internal sealed class StreamWrapper : Stream
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
         _inner.WriteAsync(buffer, offset, count, cancellationToken);
 
-#if !NETSTANDARD2_0
     public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
         _inner.WriteAsync(buffer, cancellationToken);
-#endif
 
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
         ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
 
-#if !NETSTANDARD2_0
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
         if (_initialSocketData != null && _initialSocketData.Count > 0)
@@ -104,7 +101,6 @@ internal sealed class StreamWrapper : Stream
 
         return await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
     }
-#endif
 
     public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
         _inner.CopyToAsync(destination, bufferSize, cancellationToken);

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -182,8 +182,8 @@ public sealed class Subchannel : IDisposable
                     var currentAddress = CurrentAddress;
                     if (currentAddress != null && !_addresses.Contains(currentAddress))
                     {
-                        requireReconnect = true;
                         SubchannelLog.ConnectedAddressNotInUpdatedAddresses(_logger, Id, currentAddress);
+                        requireReconnect = true;
                     }
                     break;
                 case ConnectivityState.Shutdown:

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -831,7 +831,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
             {
                 return new SocketConnectivitySubchannelTransport(
                     subchannel,
-                    TimeSpan.FromSeconds(5),
+                    SocketConnectivitySubchannelTransport.SocketPingInterval,
                     _channel.ConnectTimeout,
                     _channel.LoggerFactory,
                     socketConnect: null);

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -554,7 +554,7 @@ public class ConnectionTests : FunctionalTestBase
             () => Logs.Count(l => l.EventId.Name == "CheckingSocket") >= RequiredCheckLogCount,
             "Wait for multiple checking socket logs.").DefaultTimeout();
 
-        Assert.True(Logs.Any(l => l.EventId.Name == "ErrorCheckingSocket" && l.Exception?.Message == "The server sent 65536 bytes to the client before a connection was established. This exceeds maximum data allow."), "Socket was unexpectedly disconnected with a bad state.");
+        Assert.True(Logs.Any(l => l.EventId.Name == "ErrorCheckingSocket" && l.Exception is { } ex && ex.Message.Contains("Maximum allowed data exceeded.")), "Socket was disconnected because of large data.");
     }
 
     private static bool HasState<T>(LogRecord l, string key, T expectedValue)

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -585,7 +585,7 @@ public class ConnectionTests : FunctionalTestBase
     }
 
     [Test]
-    public async Task DisconnectSocket_NoCallsMade_ServerSentData_ChannelStateUpdated()
+    public async Task DisconnectSocket_NoCallsMade_ServerSentData_SocketClosed_ChannelStateUpdated()
     {
         using var httpEventSource = new SocketsEventSourceListener(LoggerFactory);
 
@@ -629,6 +629,8 @@ public class ConnectionTests : FunctionalTestBase
 
         // Assert
         await waitForConnectingTask.DefaultTimeout();
+
+        Assert.IsTrue(Logs.Any(l => l.EventId.Name == "SocketReceivingAvailable"), "Socket should have read available data.");
     }
 }
 #endif

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -502,8 +502,8 @@ public class ConnectionTests : FunctionalTestBase
 
         // Assert 2
         await TestHelpers.AssertIsTrueRetryAsync(
-            () => Logs.Any(l => l.EventId.Name == "SocketPollBadState"),
-            "Wait for bad poll.").DefaultTimeout();
+            () => Logs.Any(l => l.EventId.Name == "ClosingUnusableSocket"),
+            "Wait for socket to be closed because it's unusable.").DefaultTimeout();
         cts.Cancel();
     }
 

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -502,7 +502,7 @@ public class ConnectionTests : FunctionalTestBase
 
         // Assert 2
         await TestHelpers.AssertIsTrueRetryAsync(
-            () => Logs.Any(l => l.EventId.Name == "ClosingUnusableSocketOnStreamCreate"),
+            () => Logs.Any(l => l.EventId.Name == "ClosingUnusableSocketOnCreateStream"),
             "Wait for socket to be closed because it's unusable.").DefaultTimeout();
         cts.Cancel();
     }

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -502,7 +502,7 @@ public class ConnectionTests : FunctionalTestBase
 
         // Assert 2
         await TestHelpers.AssertIsTrueRetryAsync(
-            () => Logs.Any(l => l.EventId.Name == "ClosingUnusableSocket"),
+            () => Logs.Any(l => l.EventId.Name == "ClosingUnusableSocketOnStreamCreate"),
             "Wait for socket to be closed because it's unusable.").DefaultTimeout();
         cts.Cancel();
     }

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -23,10 +23,11 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Greet;
@@ -51,7 +52,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer;
 [TestFixture]
 public class ConnectionTests : FunctionalTestBase
 {
-#if NET5_0_OR_GREATER
     [Test]
     public async Task Active_UnaryCall_ConnectTimeout_ErrorThrownWhenTimeoutExceeded()
     {
@@ -446,6 +446,189 @@ public class ConnectionTests : FunctionalTestBase
             return base.SendAsync(request, cancellationToken);
         }
     }
-#endif
+
+    [Test]
+    public async Task SocketSendsBytes_BeforeCall_StaysConnected()
+    {
+        // Arrange
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(int.MaxValue);
+
+        var acceptSocketTask = Task.Run(async () =>
+        {
+            var socket = await listener.AcceptAsync();
+            socket.NoDelay = true;
+            return socket;
+        });
+
+        // Ignore errors
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        var url = $"http://localhost:{((IPEndPoint?)listener.LocalEndPoint!).Port}";
+
+        var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), new[] { new Uri(url) });
+
+        Logger.LogInformation("Client starting connect.");
+        var connectTask = channel.ConnectAsync().DefaultTimeout();
+
+        Logger.LogInformation("Server accepting socket.");
+        var socket = await acceptSocketTask.DefaultTimeout();
+
+        Logger.LogInformation("Client waiting for connect complete.");
+        await connectTask.DefaultTimeout();
+
+        var subchannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+
+        // Act 1
+        Logger.LogInformation("Server sending data.");
+        socket.Send(Encoding.UTF8.GetBytes("Hello world"));
+
+        // Assert 1
+        const int RequiredCheckLogCount = 2;
+        await TestHelpers.AssertIsTrueRetryAsync(
+            () => Logs.Count(l => l.EventId.Name == "CheckingSocket") >= RequiredCheckLogCount,
+            "Wait for multiple checking socket logs.").DefaultTimeout();
+
+        Assert.False(Logs.Any(l => l.EventId.Name == "SocketPollBadState"), "Socket was unexpectedly disconnected with a bad state.");
+
+        // Act 2
+        var cts = new CancellationTokenSource();
+        var client = new Greeter.GreeterClient(channel);
+        _ = client.SayHelloAsync(new HelloRequest(), new CallOptions(cancellationToken: cts.Token));
+
+        // Assert 2
+        await TestHelpers.AssertIsTrueRetryAsync(
+            () => Logs.Any(l => l.EventId.Name == "SocketPollBadState"),
+            "Wait for bad poll.").DefaultTimeout();
+        cts.Cancel();
+    }
+
+    [Test]
+    public async Task Connect_Idle_PingServer()
+    {
+        // Ignore errors
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = request.Name });
+        }
+
+        // Arrange
+        using var endpoint = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod));
+
+        var channel = await BalancerHelpers.CreateChannel(
+            LoggerFactory,
+            new PickFirstConfig(),
+            new[] { endpoint.Address }).DefaultTimeout();
+
+        // Act
+        await channel.ConnectAsync().DefaultTimeout();
+
+        // Assert
+        const int RequiredCheckLogCount = 4;
+        await TestHelpers.AssertIsTrueRetryAsync(
+            () => Logs.Count(l => l.EventId.Name == "CheckingSocket") >= RequiredCheckLogCount,
+            "Wait for multiple checking socket logs.").DefaultTimeout();
+    }
+
+    [Test]
+    public async Task DisconnectSocket_NoCallsMade_ChannelStateUpdated()
+    {
+        // Arrange
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(int.MaxValue);
+
+        var acceptSocketTask = Task.Run(async () =>
+        {
+            var socket = await listener.AcceptAsync();
+            socket.NoDelay = true;
+            return socket;
+        });
+
+        // Ignore errors
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        var url = $"http://localhost:{((IPEndPoint?)listener.LocalEndPoint!).Port}";
+
+        var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), new[] { new Uri(url) });
+
+        var connectTask = channel.ConnectAsync().DefaultTimeout();
+
+        var socket = await acceptSocketTask.DefaultTimeout();
+
+        await connectTask.DefaultTimeout();
+
+        var subchannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+
+        var waitForConnectingTask = BalancerWaitHelpers.WaitForChannelStatesAsync(Logger, channel, new[] { ConnectivityState.Connecting }).DefaultTimeout();
+
+        // Act
+        socket.Shutdown(SocketShutdown.Both);
+        socket.Dispose();
+        listener.Dispose();
+
+        // Assert
+        await waitForConnectingTask.DefaultTimeout();
+    }
+
+    [Test]
+    public async Task DisconnectSocket_NoCallsMade_ServerSentData_ChannelStateUpdated()
+    {
+        using var httpEventSource = new SocketsEventSourceListener(LoggerFactory);
+
+        // Arrange
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(int.MaxValue);
+
+        var acceptSocketTask = Task.Run(async () =>
+        {
+            var socket = await listener.AcceptAsync();
+            socket.NoDelay = true;
+            return socket;
+        });
+
+        // Ignore errors
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        var url = $"http://localhost:{((IPEndPoint?)listener.LocalEndPoint!).Port}";
+
+        var channel = await BalancerHelpers.CreateChannel(LoggerFactory, new RoundRobinConfig(), new[] { new Uri(url) });
+
+        var connectTask = channel.ConnectAsync().DefaultTimeout();
+
+        var socket = await acceptSocketTask.DefaultTimeout();
+        socket.Send(Encoding.UTF8.GetBytes("Hello world"));
+
+        await connectTask.DefaultTimeout();
+
+        var subchannel = await BalancerWaitHelpers.WaitForSubchannelToBeReadyAsync(Logger, channel).DefaultTimeout();
+
+        var waitForConnectingTask = BalancerWaitHelpers.WaitForChannelStatesAsync(Logger, channel, new[] { ConnectivityState.Connecting }).DefaultTimeout();
+
+        // Act
+        socket.Shutdown(SocketShutdown.Both);
+        socket.Dispose();
+        listener.Dispose();
+
+        // Assert
+        await waitForConnectingTask.DefaultTimeout();
+    }
 }
 #endif

--- a/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
@@ -445,8 +445,10 @@ public class PickFirstBalancerTests : FunctionalTestBase
         }
 
         // Arrange
+        Logger.LogInformation("Starting server");
         using var endpoint = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod));
 
+        Logger.LogInformation("Creating clients");
         var socketsHttpHandler = new SocketsHttpHandler();
         var channel1 = await BalancerHelpers.CreateChannel(LoggerFactory, new PickFirstConfig(), new[] { endpoint.Address }, socketsHttpHandler).DefaultTimeout();
         var channel2 = await BalancerHelpers.CreateChannel(LoggerFactory, new PickFirstConfig(), new[] { endpoint.Address }, socketsHttpHandler).DefaultTimeout();
@@ -455,10 +457,12 @@ public class PickFirstBalancerTests : FunctionalTestBase
         var client2 = TestClientFactory.Create(channel2, endpoint.Method);
 
         // Act
+        Logger.LogInformation("Starting calls");
         var reply1Task = client1.UnaryCall(new HelloRequest { Name = "Balancer" }).ResponseAsync.DefaultTimeout();
         var reply2Task = client2.UnaryCall(new HelloRequest { Name = "Balancer" }).ResponseAsync.DefaultTimeout();
 
         // Assert
+        Logger.LogInformation("Client waiting for replies");
         Assert.AreEqual("Balancer", (await reply1Task).Message);
         Assert.AreEqual("Balancer", (await reply2Task).Message);
         Assert.AreEqual("127.0.0.1:50051", host);

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -579,7 +579,6 @@ public class StreamingTests : FunctionalTestBase
             {
                 return true;
             }
-
 
             return false;
         });

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -20,7 +20,6 @@ using System.Net.Sockets;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.FunctionalTests.Infrastructure;
 
@@ -34,8 +33,6 @@ public class GrpcTestFixture<TStartup> : IDisposable where TStartup : class
         Action<KestrelServerOptions, IDictionary<TestServerEndpointName, string>>? configureKestrel = null,
         TestServerEndpointName? defaultClientEndpointName = null)
     {
-        LoggerFactory = new LoggerFactory();
-
         Action<IServiceCollection> configureServices = services =>
         {
             // Registers a service for tests to add new methods
@@ -131,7 +128,6 @@ public class GrpcTestFixture<TStartup> : IDisposable where TStartup : class
         (Client, Handler) = CreateHttpCore(defaultClientEndpointName);
     }
 
-    public ILoggerFactory LoggerFactory { get; }
     public DynamicGrpcServiceRegistry DynamicGrpc { get; }
 
     public HttpMessageHandler Handler { get; }

--- a/test/Grpc.Net.Client.Tests/Balancer/StreamWrapperTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/StreamWrapperTests.cs
@@ -1,0 +1,90 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if SUPPORT_LOAD_BALANCING
+using Grpc.Net.Client.Balancer.Internal;
+using NUnit.Framework;
+
+namespace Grpc.Net.Client.Tests.Balancer;
+
+[TestFixture]
+public class StreamWrapperTests
+{
+    [Test]
+    public async Task ReadAsync_MultipleInitialData_ReadInOrder()
+    {
+        // Arrange
+        var ms = new MemoryStream(new byte[] { 4 });
+        var data = new List<ReadOnlyMemory<byte>>
+        {
+            new byte[] { 1 },
+            new byte[] { 2 },
+            new byte[] { 3 },
+        };
+        var streamWrapper = new StreamWrapper(ms, s => { }, data);
+        var buffer = new byte[1024];
+
+        // Act & Assert
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(1, buffer[0]);
+
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(2, buffer[0]);
+
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(3, buffer[0]);
+
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(4, buffer[0]);
+
+        Assert.AreEqual(0, await streamWrapper.ReadAsync(buffer));
+    }
+
+    [Test]
+    public async Task ReadAsync_BufferSmallerThanInitialData_ReadInOrder()
+    {
+        // Arrange
+        var ms = new MemoryStream(new byte[] { 6 });
+        var data = new List<ReadOnlyMemory<byte>>
+        {
+            new byte[] { 1, 2, 3 },
+            new byte[] { 4, 5 }
+        };
+        var streamWrapper = new StreamWrapper(ms, s => { }, data);
+        var buffer = new byte[2];
+
+        // Act & Assert
+        Assert.AreEqual(2, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(1, buffer[0]);
+        Assert.AreEqual(2, buffer[1]);
+
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(3, buffer[0]);
+
+        Assert.AreEqual(2, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(4, buffer[0]);
+        Assert.AreEqual(5, buffer[1]);
+
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(6, buffer[0]);
+
+        Assert.AreEqual(0, await streamWrapper.ReadAsync(buffer));
+    }
+}
+
+#endif

--- a/test/Shared/BalancerWaitHelpers.cs
+++ b/test/Shared/BalancerWaitHelpers.cs
@@ -44,7 +44,7 @@ internal static class BalancerWaitHelpers
         {
             logger.LogInformation($"Channel id {channelId}: Current channel state '{currentState}' doesn't match expected states {statesText}.");
 
-            await channel.WaitForStateChangedAsync(currentState).DefaultTimeout();
+            await channel.WaitForStateChangedAsync(currentState);
             currentState = channel.State;
         }
 

--- a/test/Shared/HttpEventSourceListener.cs
+++ b/test/Shared/HttpEventSourceListener.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -22,14 +22,38 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.Tests.Shared;
 
-public sealed class HttpEventSourceListener : EventListener
+public sealed class HttpEventSourceListener : EventSourceListenerBase
+{
+    public HttpEventSourceListener(ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+    }
+
+    protected override bool IsTargetEventSource(EventSource eventSource)
+    {
+        return eventSource.Name.Contains("System.Net.Quic") || eventSource.Name.Contains("System.Net.Http");
+    }
+}
+
+public sealed class SocketsEventSourceListener : EventSourceListenerBase
+{
+    public SocketsEventSourceListener(ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+    }
+
+    protected override bool IsTargetEventSource(EventSource eventSource)
+    {
+        return eventSource.Name.Contains("System.Net.Sockets");
+    }
+}
+
+public abstract class EventSourceListenerBase : EventListener
 {
     private readonly StringBuilder _messageBuilder = new StringBuilder();
     private readonly ILogger? _logger;
     private readonly object _lock = new object();
     private bool _disposed;
 
-    public HttpEventSourceListener(ILoggerFactory loggerFactory)
+    public EventSourceListenerBase(ILoggerFactory loggerFactory)
     {
         _logger = loggerFactory.CreateLogger(nameof(HttpEventSourceListener));
         _logger.LogDebug($"Starting {nameof(HttpEventSourceListener)}.");
@@ -39,7 +63,7 @@ public sealed class HttpEventSourceListener : EventListener
     {
         base.OnEventSourceCreated(eventSource);
 
-        if (IsHttpEventSource(eventSource))
+        if (IsTargetEventSource(eventSource))
         {
             lock (_lock)
             {
@@ -51,16 +75,13 @@ public sealed class HttpEventSourceListener : EventListener
         }
     }
 
-    private static bool IsHttpEventSource(EventSource eventSource)
-    {
-        return eventSource.Name.Contains("System.Net.Quic") || eventSource.Name.Contains("System.Net.Http");
-    }
+    protected abstract bool IsTargetEventSource(EventSource eventSource);
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
         base.OnEventWritten(eventData);
 
-        if (!IsHttpEventSource(eventData.EventSource))
+        if (!IsTargetEventSource(eventData.EventSource))
         {
             return;
         }


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/2161
Addresses https://github.com/grpc/grpc-dotnet/issues/2146

The socket transports regularly checks that a socket is still alive. This PR changes its logic to not close the socket if there is pending data. ~The socket is now marked that there was unexpected data and left open. When it comes time to use the socket to create a `SocketsHttpHandler` stream, the socket is recreated then.~

Pending data can happen because some servers (C-core, Java) eagerly send the SETTINGS frame to the client.

Pending data is now cached (up to a limit) and then replayed back to the client when the real connection is established. Fixes the problem and avoids the overhead of having to recreate the socket.