### PR TITLE
Remove System.Memory dependency on .NET Standard 2.1 in Grpc.Core.Api.

### DIFF
--- a/src/Grpc.Core.Api/Grpc.Core.Api.csproj
+++ b/src/Grpc.Core.Api/Grpc.Core.Api.csproj
@@ -19,8 +19,8 @@
     <Compile Include="..\Shared\CodeAnalysisAttributes.cs" Link="Internal\CodeAnalysisAttributes.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' != 'netstandard2.1'" Version="$(SystemMemoryPackageVersion)" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/Grpc.Core.Api/Grpc.Core.Api.csproj
+++ b/src/Grpc.Core.Api/Grpc.Core.Api.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
+    <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' != 'netstandard2.1'" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">


### PR DESCRIPTION
It's not needed; the types this package provides are inbox.