### PR TITLE
Improve grpc-dotnet debugging

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -575,11 +575,7 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
         }
     }
 
-    private string DebuggerToString()
-    {
-        var request = HttpContext.Request;
-        return $"{request.Scheme}://{request.Host.Value}{request.PathBase.Value}{request.Path.Value}{request.QueryString.Value}";
-    }
+    private string DebuggerToString() => $"Host = {Host}, Method = {Method}";
 
     private sealed class HttpContextServerCallContextDebugView
     {

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -27,6 +27,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal;
 
+[DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerTypeProxy(typeof(HttpContextServerCallContextDebugView))]
 internal sealed partial class HttpContextServerCallContext : ServerCallContext, IServerCallContextFeature
 {
     private static readonly AuthContext UnauthenticatedContext = new AuthContext(null, new Dictionary<string, List<AuthProperty>>());
@@ -571,5 +573,35 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
         {
             GrpcServerLog.EncodingNotInAcceptEncoding(Logger, resolvedResponseGrpcEncoding);
         }
+    }
+
+    private string DebuggerToString()
+    {
+        var request = HttpContext.Request;
+        return $"{request.Scheme}://{request.Host.Value}{request.PathBase.Value}{request.Path.Value}{request.QueryString.Value}";
+    }
+
+    private sealed class HttpContextServerCallContextDebugView
+    {
+        private readonly HttpContextServerCallContext _context;
+
+        public HttpContextServerCallContextDebugView(HttpContextServerCallContext context)
+        {
+            _context = context;
+        }
+
+        public AuthContext AuthContext => _context.AuthContext;
+        public CancellationToken CancellationToken => _context.CancellationToken;
+        public DateTime Deadline => _context.Deadline;
+        public string Host => _context.Host;
+        public string Method => _context.Method;
+        public string Peer => _context.Peer;
+        public Metadata RequestHeaders => _context.RequestHeaders;
+        public Metadata ResponseTrailers => _context.ResponseTrailers;
+        public Status Status => _context.Status;
+        public IDictionary<object, object> UserState => _context.UserState;
+        public WriteOptions? WriteOptions => _context.WriteOptions;
+
+        public HttpContext HttpContext => _context.HttpContext;
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
@@ -101,5 +101,6 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
 
         public bool ReaderCompleted => _reader._completed;
         public long ReadCount => _reader._readCount;
+        public TRequest Current => _reader.Current;
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
@@ -28,8 +28,7 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
 {
     private readonly HttpContextServerCallContext _serverCallContext;
     private readonly Func<DeserializationContext, TRequest> _deserializer;
-
-    internal bool _completed { get; private set; }
+    private bool _completed;
     private long _readCount;
 
     public HttpContextStreamReader(HttpContextServerCallContext serverCallContext, Func<DeserializationContext, TRequest> deserializer)

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -137,5 +137,6 @@ internal class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TRespons
         public bool WriterCompleted => _writer._completed;
         public bool IsWriteInProgress => _writer.IsWriteInProgressUnsynchronized;
         public long WriteCount => _writer._writeCount;
+        public WriteOptions? WriteOptions => _writer.WriteOptions;
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -30,8 +30,7 @@ internal class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TRespons
     private readonly Action<TResponse, SerializationContext> _serializer;
     private readonly object _writeLock;
     private Task? _writeTask;
-
-    internal bool _completed { get; private set; }
+    private bool _completed;
     private long _writeCount;
 
     public HttpContextStreamWriter(HttpContextServerCallContext context, Action<TResponse, SerializationContext> serializer)

--- a/src/Grpc.Core.Api/AsyncCallState.cs
+++ b/src/Grpc.Core.Api/AsyncCallState.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-
 using System;
 using System.Threading.Tasks;
 

--- a/src/Grpc.Core.Api/AsyncDuplexStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncDuplexStreamingCall.cs
@@ -159,7 +159,7 @@ public sealed class AsyncDuplexStreamingCall<TRequest, TResponse> : IDisposable
 
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
-        public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.GetAwaiter().GetResult() : null;
+        public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;
         public Metadata? Trailers => CallDebuggerHelpers.GetTrailers(_call.callState);
         public IAsyncStreamReader<TResponse> ResponseStream => _call.ResponseStream;
         public IClientStreamWriter<TRequest> RequestStream => _call.RequestStream;

--- a/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
@@ -140,7 +140,7 @@ public sealed class AsyncServerStreamingCall<TResponse> : IDisposable
 
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
-        public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.GetAwaiter().GetResult() : null;
+        public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;
         public Metadata? Trailers => CallDebuggerHelpers.GetTrailers(_call.callState);
         public IAsyncStreamReader<TResponse> ResponseStream => _call.ResponseStream;
     }

--- a/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
@@ -17,7 +17,9 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
+using Grpc.Core.Internal;
 
 namespace Grpc.Core;
 
@@ -25,6 +27,8 @@ namespace Grpc.Core;
 /// Return type for server streaming calls.
 /// </summary>
 /// <typeparam name="TResponse">Response message type for this call.</typeparam>
+[DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerTypeProxy(typeof(AsyncServerStreamingCall<>.AsyncServerStreamingCallDebugView))]
 public sealed class AsyncServerStreamingCall<TResponse> : IDisposable
 {
     readonly IAsyncStreamReader<TResponse> responseStream;
@@ -121,5 +125,23 @@ public sealed class AsyncServerStreamingCall<TResponse> : IDisposable
     public void Dispose()
     {
         callState.Dispose();
+    }
+
+    private string DebuggerToString() => CallDebuggerHelpers.DebuggerToString(callState);
+
+    private sealed class AsyncServerStreamingCallDebugView
+    {
+        private readonly AsyncServerStreamingCall<TResponse> _call;
+
+        public AsyncServerStreamingCallDebugView(AsyncServerStreamingCall<TResponse> call)
+        {
+            _call = call;
+        }
+
+        public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
+        public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
+        public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.GetAwaiter().GetResult() : null;
+        public Metadata? Trailers => CallDebuggerHelpers.GetTrailers(_call.callState);
+        public IAsyncStreamReader<TResponse> ResponseStream => _call.ResponseStream;
     }
 }

--- a/src/Grpc.Core.Api/AuthContext.cs
+++ b/src/Grpc.Core.Api/AuthContext.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Grpc.Core.Utils;
 
@@ -28,6 +29,7 @@ namespace Grpc.Core;
 /// Using any other call/context properties for authentication purposes is wrong and inherently unsafe.
 /// Note: experimental API that can change or be removed without any prior notice.
 /// </summary>
+[DebuggerDisplay("IsPeerAuthenticated = {IsPeerAuthenticated}")]
 public class AuthContext
 {
     private readonly string? peerIdentityPropertyName;

--- a/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
+++ b/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
@@ -35,6 +35,8 @@ internal static class CallDebuggerHelpers
 
     public static Status? GetStatus(AsyncCallState callState)
     {
+        // This is the only public API to get this value and there is no way to check if it's available.
+        // The overhead of throwing an error in the background is acceptable because this is only called while debugging.
         try
         {
             return callState.GetStatus();
@@ -47,6 +49,8 @@ internal static class CallDebuggerHelpers
 
     public static Metadata? GetTrailers(AsyncCallState callState)
     {
+        // This is the only public API to get this value and there is no way to check if it's available.
+        // The overhead of throwing an error in the background is acceptable because this is only called while debugging.
         try
         {
             return callState.GetTrailers();

--- a/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
+++ b/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
@@ -1,0 +1,59 @@
+#region Copyright notice and license
+
+// Copyright 2015-2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+
+namespace Grpc.Core.Internal;
+
+internal static class CallDebuggerHelpers
+{
+    public static string DebuggerToString(AsyncCallState callState)
+    {
+        var status = GetStatus(callState);
+        var debugText = $"IsComplete = {((status != null) ? "true" : "false")}";
+        if (status != null)
+        {
+            debugText += $", Status = {status}";
+        }
+        return debugText;
+    }
+
+    public static Status? GetStatus(AsyncCallState callState)
+    {
+        try
+        {
+            return callState.GetStatus();
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    public static Metadata? GetTrailers(AsyncCallState callState)
+    {
+        try
+        {
+            return callState.GetTrailers();
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Grpc.Core.Api/Metadata.cs
+++ b/src/Grpc.Core.Api/Metadata.cs
@@ -17,11 +17,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using Grpc.Core.Api.Utils;
-
 using Grpc.Core.Utils;
 
 namespace Grpc.Core;
@@ -35,6 +38,8 @@ namespace Grpc.Core;
 /// <item><term>Response trailers</term><description>are sent by the server at the end of a remote call along with resulting call status.</description></item>
 /// </list>
 /// </summary>
+[DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerTypeProxy(typeof(MetadataDebugView))]
 public sealed class Metadata : IList<Metadata.Entry>
 {
     /// <summary>
@@ -498,5 +503,28 @@ public sealed class Metadata : IList<Metadata.Entry>
             }
             return false;
         }
+    }
+
+    private string DebuggerToString()
+    {
+        var debugText = $"Count = {Count}";
+        if (IsReadOnly)
+        {
+            debugText += $", IsReadOnly = true";
+        }
+        return debugText;
+    }
+
+    private sealed class MetadataDebugView
+    {
+        private readonly Metadata _metadata;
+
+        public MetadataDebugView(Metadata metadata)
+        {
+            _metadata = metadata;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public Entry[] Items => _metadata.ToArray();
     }
 }

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Grpc.Core;
 #if SUPPORT_LOAD_BALANCING
 using Grpc.Net.Client.Balancer;
@@ -93,6 +94,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
     internal ISystemClock Clock = SystemClock.Instance;
     internal IOperatingSystem OperatingSystem;
     internal IRandomGenerator RandomGenerator;
+    internal IDebugger Debugger;
     internal bool DisableClientDeadline;
     internal long MaxTimerDueTime = uint.MaxValue - 1; // Max System.Threading.Timer due time
 
@@ -113,6 +115,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         LoggerFactory = channelOptions.LoggerFactory ?? channelOptions.ResolveService<ILoggerFactory>(NullLoggerFactory.Instance);
         OperatingSystem = channelOptions.ResolveService<IOperatingSystem>(Internal.OperatingSystem.Instance);
         RandomGenerator = channelOptions.ResolveService<IRandomGenerator>(new RandomGenerator());
+        Debugger = channelOptions.ResolveService<IDebugger>(new CachedDebugger());
         Logger = LoggerFactory.CreateLogger<GrpcChannel>();
 
 #if SUPPORT_LOAD_BALANCING

--- a/src/Grpc.Net.Client/Internal/CachedDebugger.cs
+++ b/src/Grpc.Net.Client/Internal/CachedDebugger.cs
@@ -16,11 +16,17 @@
 
 #endregion
 
+using System.Diagnostics;
+
 namespace Grpc.Net.Client.Internal;
 
-internal sealed class SystemClock : ISystemClock
+internal sealed class CachedDebugger : IDebugger
 {
-    public static readonly SystemClock Instance = new SystemClock();
+    public bool IsAttached { get; }
 
-    public DateTime UtcNow => DateTime.UtcNow;
+    public CachedDebugger()
+    {
+        // Don't want to check Debugger.IsAttached with every call. Cache the result when the channel is created.
+        IsAttached = Debugger.IsAttached;
+    }
 }

--- a/src/Grpc.Net.Client/Internal/ClientStreamWriterBase.cs
+++ b/src/Grpc.Net.Client/Internal/ClientStreamWriterBase.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -16,7 +16,6 @@
 
 #endregion
 
-using System.Diagnostics;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Log = Grpc.Net.Client.Internal.ClientStreamWriterBaseLog;
@@ -71,8 +70,6 @@ internal abstract class ClientStreamWriterBase<TRequest> : IClientStreamWriter<T
     {
         get
         {
-            Debug.Assert(Monitor.IsEntered(WriteLock));
-
             var writeTask = WriteTask;
             return writeTask != null && !writeTask.IsCompleted;
         }

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Grpc.Core;
 using Grpc.Net.Client.Internal.Retry;
 
@@ -42,6 +44,8 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         var call = CreateRootGrpcCall<TRequest, TResponse>(Channel, method, options);
         call.StartClientStreaming();
 
+        PrepareForDebugging(call);
+
         return new AsyncClientStreamingCall<TRequest, TResponse>(
             requestStream: call.ClientStreamWriter!,
             responseAsync: call.GetResponseAsync(),
@@ -62,6 +66,8 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         var call = CreateRootGrpcCall<TRequest, TResponse>(Channel, method, options);
         call.StartDuplexStreaming();
 
+        PrepareForDebugging(call);
+
         return new AsyncDuplexStreamingCall<TRequest, TResponse>(
             requestStream: call.ClientStreamWriter!,
             responseStream: call.ClientStreamReader!,
@@ -81,6 +87,8 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         var call = CreateRootGrpcCall<TRequest, TResponse>(Channel, method, options);
         call.StartServerStreaming(request);
 
+        PrepareForDebugging(call);
+
         return new AsyncServerStreamingCall<TResponse>(
             responseStream: call.ClientStreamReader!,
             responseHeadersAsync: Callbacks<TRequest, TResponse>.GetResponseHeadersAsync,
@@ -97,6 +105,8 @@ internal sealed class HttpClientCallInvoker : CallInvoker
     {
         var call = CreateRootGrpcCall<TRequest, TResponse>(Channel, method, options);
         call.StartUnary(request);
+
+        PrepareForDebugging(call);
 
         return new AsyncUnaryCall<TResponse>(
             responseAsync: call.GetResponseAsync(),
@@ -139,6 +149,21 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         {
             // No retry/hedge policy configured. Fast path!
             return CreateGrpcCall<TRequest, TResponse>(channel, method, options, attempt: 1);
+        }
+    }
+
+    private void PrepareForDebugging<TRequest, TResponse>(IGrpcCall<TRequest, TResponse> call)
+        where TRequest : class
+        where TResponse : class
+    {
+        // The ResponseHeadersAsync task is lazy and is only started if accessed.
+        // By default, the debugger can't access a property that runs across threads.
+        // See https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debugger.notifyofcrossthreaddependency
+        //
+        // If the debugger is attached then start the task outside of debugging to make the response headers available.
+        if (Channel.Debugger.IsAttached)
+        {
+            _ = call.GetResponseHeadersAsync();
         }
     }
 

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using Grpc.Core;
 using Grpc.Shared;
@@ -24,6 +25,8 @@ using Log = Grpc.Net.Client.Internal.HttpContentClientStreamReaderLog;
 
 namespace Grpc.Net.Client.Internal;
 
+[DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerTypeProxy(typeof(HttpContentClientStreamReader<,>.HttpContentClientStreamReaderDebugView))]
 internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStreamReader<TResponse>
     where TRequest : class
     where TResponse : class
@@ -41,6 +44,7 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
     private string? _grpcEncoding;
     private Stream? _responseStream;
     private Task<bool>? _moveNextTask;
+    private long _readCount;
 
     public HttpContentClientStreamReader(GrpcCall<TRequest, TResponse> call)
     {
@@ -178,6 +182,7 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
                 GrpcEventSource.Log.MessageReceived();
             }
             Current = readMessage!;
+            Interlocked.Increment(ref _readCount);
             return true;
         }
         catch (OperationCanceledException ex)
@@ -248,6 +253,22 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
             var moveNextTask = _moveNextTask;
             return moveNextTask != null && !moveNextTask.IsCompleted;
         }
+    }
+
+    private string DebuggerToString() => $"ReadCount = {_readCount}, CallCompleted = {(_call.CallTask.IsCompletedSuccessfully() ? "true" : "false")}";
+
+    private sealed class HttpContentClientStreamReaderDebugView
+    {
+        private readonly HttpContentClientStreamReader<TRequest, TResponse> _reader;
+
+        public HttpContentClientStreamReaderDebugView(HttpContentClientStreamReader<TRequest, TResponse> reader)
+        {
+            _reader = reader;
+        }
+
+        public bool CallCompleted => _reader._call.CallTask.IsCompletedSuccessfully();
+        public long ReadCount => _reader._readCount;
+        public bool IsMoveNextInProgress => _reader.IsMoveNextInProgressUnsynchronized;
     }
 }
 

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -269,6 +269,7 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
         public bool CallCompleted => _reader._call.CallTask.IsCompletedSuccessfully();
         public long ReadCount => _reader._readCount;
         public bool IsMoveNextInProgress => _reader.IsMoveNextInProgressUnsynchronized;
+        public TResponse Current => _reader.Current;
     }
 }
 

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -210,5 +210,6 @@ internal class HttpContentClientStreamWriter<TRequest, TResponse> : ClientStream
         public bool WriterCompleted => _writer._completeCalled;
         public bool IsWriteInProgress => _writer.IsWriteInProgressUnsynchronized;
         public long WriteCount => _writer._writeCount;
+        public WriteOptions? WriteOptions => _writer.WriteOptions;
     }
 }

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -41,7 +41,6 @@ internal class HttpContentClientStreamWriter<TRequest, TResponse> : ClientStream
     private bool _completeCalled;
     private long _writeCount;
 
-    public bool IsCompleted => _completeCalled;
     public TaskCompletionSource<Stream> WriteStreamTcs { get; }
     public TaskCompletionSource<bool> CompleteTcs { get; }
 
@@ -208,7 +207,7 @@ internal class HttpContentClientStreamWriter<TRequest, TResponse> : ClientStream
         }
 
         public bool CallCompleted => _writer._call.CallTask.IsCompletedSuccessfully();
-        public bool WriterCompleted => _writer.IsCompleted;
+        public bool WriterCompleted => _writer._completeCalled;
         public bool IsWriteInProgress => _writer.IsWriteInProgressUnsynchronized;
         public long WriteCount => _writer._writeCount;
     }

--- a/src/Grpc.Net.Client/Internal/IDebugger.cs
+++ b/src/Grpc.Net.Client/Internal/IDebugger.cs
@@ -18,9 +18,7 @@
 
 namespace Grpc.Net.Client.Internal;
 
-internal sealed class SystemClock : ISystemClock
+internal interface IDebugger
 {
-    public static readonly SystemClock Instance = new SystemClock();
-
-    public DateTime UtcNow => DateTime.UtcNow;
+    bool IsAttached { get; }
 }

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -445,8 +445,6 @@ public class StreamingTests : FunctionalTestBase
         }
 
         // Arrange
-        System.Diagnostics.Debugger.Launch();
-
         var method = Fixture.DynamicGrpc.AddDuplexStreamingMethod<DataMessage, DataMessage>(UnaryDeadlineExceeded);
 
         var channel = CreateChannel();

--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -445,6 +445,8 @@ public class StreamingTests : FunctionalTestBase
         }
 
         // Arrange
+        System.Diagnostics.Debugger.Launch();
+
         var method = Fixture.DynamicGrpc.AddDuplexStreamingMethod<DataMessage, DataMessage>(UnaryDeadlineExceeded);
 
         var channel = CreateChannel();
@@ -579,7 +581,6 @@ public class StreamingTests : FunctionalTestBase
             {
                 return true;
             }
-
 
             return false;
         });
@@ -726,7 +727,6 @@ public class StreamingTests : FunctionalTestBase
             {
                 return true;
             }
-
 
             return false;
         });


### PR DESCRIPTION
This PR significantly improves the debugging experience of gRPC calls. Changes have been applied in many places. There are before and after screenshots of each.

## ServerCallContext

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/19d831f5-5cfa-4f1a-bdca-4c3b4da59674)


After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/78454788-607d-4316-85ae-dbd61e07363d)

## Server StreamReader

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/67961a67-e4c3-4dc7-a86d-fda99017e827)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/021c5977-26cd-46c3-8bca-a912e91a3546)

## Server StreamWriter

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/8a315675-87b3-4992-85f1-d6dcfacb45f4)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/03b2aeef-16af-436e-9db9-453059d32824)

## Client call

Before:

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/24615961-5258-4037-9eec-d653f5f8bf3b)

## Client StreamReader

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/4ac51a8c-1beb-4fb7-9819-1cdade0a340e)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/7c2cd897-7476-40ba-b5b6-18d56988957a)

## Client StreamWriter

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/2f96fdc2-ae57-4cf8-9cea-c01d39bfe39c)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/101f79b9-93a7-42c2-acf7-aa54af8ed8de)

## Metadata

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/3c6644c2-e5b6-4956-bdb3-1083797aa45b)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/5607fea3-8b4a-49d0-b8e3-30dab8f84a60)
