### PR TITLE
Even better gRPC debugging

### DIFF
--- a/src/Grpc.AspNetCore.Server.ClientFactory/ContextPropagationInterceptor.cs
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/ContextPropagationInterceptor.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -575,7 +575,7 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
         }
     }
 
-    private string DebuggerToString() => $"Host = {Host}, Method = {Method}";
+    private string DebuggerToString() => $"Method = {Method}";
 
     private sealed class HttpContextServerCallContextDebugView
     {

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
@@ -102,7 +102,6 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
         }
 
         public ServerCallContext ServerCallContext => _reader._serverCallContext;
-        public bool ReaderCompleted => _reader._completed;
         public long ReadCount => _reader._readCount;
         public TRequest Current => _reader.Current;
         public bool EndOfStream => _reader._endOfStream;

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
@@ -30,6 +30,7 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
     private readonly Func<DeserializationContext, TRequest> _deserializer;
     private bool _completed;
     private long _readCount;
+    private bool _endOfStream;
 
     public HttpContextStreamReader(HttpContextServerCallContext serverCallContext, Func<DeserializationContext, TRequest> deserializer)
     {
@@ -74,6 +75,7 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
         // Stream is complete
         if (request == null)
         {
+            _endOfStream = true;
             Current = null!;
             return false;
         }
@@ -88,7 +90,7 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
         _completed = true;
     }
 
-    private string DebuggerToString() => $"ReadCount = {_readCount}, CallCompleted = {(_completed ? "true" : "false")}";
+    private string DebuggerToString() => $"ReadCount = {_readCount}, EndOfStream = {(_endOfStream ? "true" : "false")}";
 
     private sealed class HttpContextStreamReaderDebugView
     {
@@ -99,8 +101,10 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
             _reader = reader;
         }
 
+        public ServerCallContext ServerCallContext => _reader._serverCallContext;
         public bool ReaderCompleted => _reader._completed;
         public long ReadCount => _reader._readCount;
         public TRequest Current => _reader.Current;
+        public bool EndOfStream => _reader._endOfStream;
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -123,7 +123,7 @@ internal class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TRespons
         }
     }
 
-    private string DebuggerToString() => $"WriteCount = {_writeCount}, CallCompleted = {(_completed ? "true" : "false")}";
+    private string DebuggerToString() => $"WriteCount = {_writeCount}, WriterCompleted = {(_completed ? "true" : "false")}";
 
     private sealed class HttpContextStreamWriterDebugView
     {
@@ -134,8 +134,8 @@ internal class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TRespons
             _writer = writer;
         }
 
+        public ServerCallContext ServerCallContext => _writer._context;
         public bool WriterCompleted => _writer._completed;
-        public bool IsWriteInProgress => _writer.IsWriteInProgressUnsynchronized;
         public long WriteCount => _writer._writeCount;
         public WriteOptions? WriteOptions => _writer.WriteOptions;
     }

--- a/src/Grpc.Core.Api/AsyncCallState.cs
+++ b/src/Grpc.Core.Api/AsyncCallState.cs
@@ -60,6 +60,8 @@ internal struct AsyncCallState
         this.callbackState = null;
     }
 
+    internal object? State => callbackState;
+
     internal Task<Metadata> ResponseHeadersAsync()
     {
         var withState = responseHeadersAsync as Func<object, Task<Metadata>>;

--- a/src/Grpc.Core.Api/AsyncCallState.cs
+++ b/src/Grpc.Core.Api/AsyncCallState.cs
@@ -60,6 +60,7 @@ internal struct AsyncCallState
         this.callbackState = null;
     }
 
+    // Debugging uses the state property to attempt to discover the method of the gRPC call.
     internal object? State => callbackState;
 
     internal Task<Metadata> ResponseHeadersAsync()

--- a/src/Grpc.Core.Api/AsyncClientStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncClientStreamingCall.cs
@@ -180,6 +180,7 @@ public sealed class AsyncClientStreamingCall<TRequest, TResponse> : IDisposable
             _call = call;
         }
 
+        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.GetAwaiter().GetResult() : null;

--- a/src/Grpc.Core.Api/AsyncDuplexStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncDuplexStreamingCall.cs
@@ -157,6 +157,7 @@ public sealed class AsyncDuplexStreamingCall<TRequest, TResponse> : IDisposable
             _call = call;
         }
 
+        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;

--- a/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
@@ -138,6 +138,7 @@ public sealed class AsyncServerStreamingCall<TResponse> : IDisposable
             _call = call;
         }
 
+        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;

--- a/src/Grpc.Core.Api/AsyncUnaryCall.cs
+++ b/src/Grpc.Core.Api/AsyncUnaryCall.cs
@@ -161,6 +161,7 @@ public sealed class AsyncUnaryCall<TResponse> : IDisposable
             _call = call;
         }
 
+        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;

--- a/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
+++ b/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 
 namespace Grpc.Core.Internal;
 
@@ -24,8 +25,14 @@ internal static class CallDebuggerHelpers
 {
     public static string DebuggerToString(AsyncCallState callState)
     {
+        string debugText = string.Empty;
+        if (callState.State is IMethod method)
+        {
+            debugText = $"Method = {method.FullName}, ";
+        }
+
         var status = GetStatus(callState);
-        var debugText = $"IsComplete = {((status != null) ? "true" : "false")}";
+        debugText += $"IsComplete = {((status != null) ? "true" : "false")}";
         if (status != null)
         {
             debugText += $", Status = {status}";
@@ -60,4 +67,20 @@ internal static class CallDebuggerHelpers
             return null;
         }
     }
+}
+
+[DebuggerDisplay("{FullName,nq}")]
+internal sealed class CallDebuggerMethodDebugView
+{
+    private readonly IMethod _method;
+
+    public CallDebuggerMethodDebugView(IMethod method)
+    {
+        _method = method;
+    }
+
+    public MethodType Type => _method.Type;
+    public string ServiceName => _method.ServiceName;
+    public string Name => _method.Name;
+    public string FullName => _method.FullName;
 }

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -59,6 +59,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
     private TaskCompletionSource<TResponse>? _responseTcs;
 
     public int MessagesWritten { get; private set; }
+    public int MessagesRead { get; private set; }
     public HttpContentClientStreamWriter<TRequest, TResponse>? ClientStreamWriter { get; private set; }
     public HttpContentClientStreamReader<TRequest, TResponse>? ClientStreamReader { get; private set; }
 
@@ -1116,21 +1117,27 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
     }
 
 #if !NETSTANDARD2_0
-    internal ValueTask<TResponse?> ReadMessageAsync(
+    internal async ValueTask<TResponse?> ReadMessageAsync(
 #else
-    internal Task<TResponse?> ReadMessageAsync(
+    internal async Task<TResponse?> ReadMessageAsync(
 #endif
         Stream responseStream,
         string grpcEncoding,
         bool singleMessage,
         CancellationToken cancellationToken)
     {
-        return responseStream.ReadMessageAsync(
+        var message = await responseStream.ReadMessageAsync(
             this,
             Method.ResponseMarshaller.ContextualDeserializer,
             grpcEncoding,
             singleMessage,
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
+        if (message == null)
+        {
+            return null;
+        }
+        MessagesRead++;
+        return message;
     }
 
     public Task WriteClientStreamAsync<TState>(Func<GrpcCall<TRequest, TResponse>, Stream, CallOptions, TState, ValueTask> writeFunc, TState state, CancellationToken cancellationToken)

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -100,6 +100,13 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
     IClientStreamWriter<TRequest>? IGrpcCall<TRequest, TResponse>.ClientStreamWriter => ClientStreamWriter;
     IAsyncStreamReader<TResponse>? IGrpcCall<TRequest, TResponse>.ClientStreamReader => ClientStreamReader;
 
+    public object? CallWrapper { get; set; }
+
+    MethodType IMethod.Type => Method.Type;
+    string IMethod.ServiceName => Method.ServiceName;
+    string IMethod.Name => Method.Name;
+    string IMethod.FullName => Method.FullName;
+
     public void StartUnary(TRequest request) => StartUnaryCore(CreatePushUnaryContent(request));
 
     public void StartClientStreaming()

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -177,10 +177,11 @@ internal sealed class HttpClientCallInvoker : CallInvoker
             // Instead, start the ResponseHeadersAsync task with the call. This is in regular app execution so there is no problem
             // doing it here. Now the response headers are automatically available when debugging.
             //
-            // Start the ResponseHeadersAsync task. Response isn't important here.
+            // Start the ResponseHeadersAsync task.
             _ = call.GetResponseHeadersAsync();
         }
 
+        // CallWrapper is set as a property because there is a circular relationship between the underlying call and the call wrapper.
         call.CallWrapper = callWrapper;
     }
 

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -255,7 +255,7 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
         }
     }
 
-    private string DebuggerToString() => $"ReadCount = {_readCount}, CallCompleted = {(_call.CallTask.IsCompletedSuccessfully() ? "true" : "false")}";
+    private string DebuggerToString() => $"ReadCount = {_readCount}, EndOfStream = {(_call.ResponseFinished ? "true" : "false")}";
 
     private sealed class HttpContentClientStreamReaderDebugView
     {
@@ -266,10 +266,10 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
             _reader = reader;
         }
 
-        public bool CallCompleted => _reader._call.CallTask.IsCompletedSuccessfully();
+        public object? Call => _reader._call.CallWrapper;
         public long ReadCount => _reader._readCount;
-        public bool IsMoveNextInProgress => _reader.IsMoveNextInProgressUnsynchronized;
         public TResponse Current => _reader.Current;
+        public bool EndOfStream => _reader._call.ResponseFinished;
     }
 }
 

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -44,7 +44,6 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
     private string? _grpcEncoding;
     private Stream? _responseStream;
     private Task<bool>? _moveNextTask;
-    private long _readCount;
 
     public HttpContentClientStreamReader(GrpcCall<TRequest, TResponse> call)
     {
@@ -182,7 +181,6 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
                 GrpcEventSource.Log.MessageReceived();
             }
             Current = readMessage!;
-            Interlocked.Increment(ref _readCount);
             return true;
         }
         catch (OperationCanceledException ex)
@@ -255,7 +253,7 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
         }
     }
 
-    private string DebuggerToString() => $"ReadCount = {_readCount}, EndOfStream = {(_call.ResponseFinished ? "true" : "false")}";
+    private string DebuggerToString() => $"ReadCount = {_call.MessagesRead}, EndOfStream = {(_call.ResponseFinished ? "true" : "false")}";
 
     private sealed class HttpContentClientStreamReaderDebugView
     {
@@ -267,7 +265,7 @@ internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStream
         }
 
         public object? Call => _reader._call.CallWrapper;
-        public long ReadCount => _reader._readCount;
+        public long ReadCount => _reader._call.MessagesRead;
         public TResponse Current => _reader.Current;
         public bool EndOfStream => _reader._call.ResponseFinished;
     }

--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -56,4 +56,5 @@ internal interface IGrpcCall<TRequest, TResponse> : IDisposable, IMethod
     object? CallWrapper { get; set; }
     bool Disposed { get; }
     bool ResponseFinished { get; }
+    int MessagesRead { get; }
 }

--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -25,7 +25,7 @@ using ValueTask = System.Threading.Tasks.Task;
 
 namespace Grpc.Net.Client.Internal;
 
-internal interface IGrpcCall<TRequest, TResponse> : IDisposable
+internal interface IGrpcCall<TRequest, TResponse> : IDisposable, IMethod
     where TRequest : class
     where TResponse : class
 {
@@ -53,5 +53,7 @@ internal interface IGrpcCall<TRequest, TResponse> : IDisposable
         CancellationToken cancellationToken,
         [NotNullWhen(true)] out CancellationTokenRegistration? cancellationTokenRegistration);
 
+    object? CallWrapper { get; set; }
     bool Disposed { get; }
+    bool ResponseFinished { get; }
 }

--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -75,7 +75,7 @@ internal sealed partial class HedgingCall<TRequest, TResponse> : RetryCallBase<T
 
                 OnStartingAttempt();
 
-                call = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount);
+                call = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount, CallWrapper);
                 _activeCalls.Add(call);
 
                 startCallFunc(call);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -109,7 +109,7 @@ internal sealed class RetryCall<TRequest, TResponse> : RetryCallBase<TRequest, T
                     // Start new call.
                     OnStartingAttempt();
 
-                    currentCall = _activeCall = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount);
+                    currentCall = _activeCall = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount, CallWrapper);
                     startCallFunc(currentCall);
 
                     SetNewActiveCallUnsynchronized(currentCall);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -59,6 +59,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
     public bool Disposed { get; private set; }
     public object? CallWrapper { get; set; }
     public bool ResponseFinished => CommitedCallTask.IsCompletedSuccessfully() ? CommitedCallTask.Result.ResponseFinished : false;
+    public int MessagesRead => CommitedCallTask.IsCompletedSuccessfully() ? CommitedCallTask.Result.MessagesRead : 0;
 
     protected int AttemptCount { get; private set; }
     protected List<ReadOnlyMemory<byte>> BufferedMessages { get; }
@@ -493,7 +494,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
 
     protected StatusGrpcCall<TRequest, TResponse> CreateStatusCall(Status status)
     {
-        var call = new StatusGrpcCall<TRequest, TResponse>(status, Channel, Method);
+        var call = new StatusGrpcCall<TRequest, TResponse>(status, Channel, Method, MessagesRead);
         call.CallWrapper = CallWrapper;
         return call;
     }

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -55,12 +55,20 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
     public IClientStreamWriter<TRequest>? ClientStreamWriter => _retryBaseClientStreamWriter ??= new RetryCallBaseClientStreamWriter<TRequest, TResponse>(this);
     public WriteOptions? ClientStreamWriteOptions { get; internal set; }
     public bool ClientStreamComplete { get; set; }
+    public int MessagesWritten { get; private set; }
     public bool Disposed { get; private set; }
+    public object? CallWrapper { get; set; }
+    public bool ResponseFinished => CommitedCallTask.IsCompletedSuccessfully() ? CommitedCallTask.Result.ResponseFinished : false;
 
     protected int AttemptCount { get; private set; }
     protected List<ReadOnlyMemory<byte>> BufferedMessages { get; }
     protected long CurrentCallBufferSize { get; set; }
     protected bool BufferedCurrentMessage { get; set; }
+
+    MethodType IMethod.Type => Method.Type;
+    string IMethod.ServiceName => Method.ServiceName;
+    string IMethod.Name => Method.Name;
+    string IMethod.FullName => Method.FullName;
 
     protected RetryCallBase(GrpcChannel channel, Method<TRequest, TResponse> method, CallOptions options, string loggerName, int retryAttempts)
     {
@@ -340,6 +348,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
         }
 
         await call.WriteMessageAsync(writeStream, messageData, callOptions.CancellationToken).ConfigureAwait(false);
+        MessagesWritten++;
     }
 
     protected void CommitCall(IGrpcCall<TRequest, TResponse> call, CommitReason commitReason)
@@ -484,7 +493,9 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
 
     protected StatusGrpcCall<TRequest, TResponse> CreateStatusCall(Status status)
     {
-        return new StatusGrpcCall<TRequest, TResponse>(status, Channel);
+        var call = new StatusGrpcCall<TRequest, TResponse>(status, Channel, Method);
+        call.CallWrapper = CallWrapper;
+        return call;
     }
 
     protected void HandleUnexpectedError(Exception ex)

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamReader.cs
@@ -29,7 +29,6 @@ internal class RetryCallBaseClientStreamReader<TRequest, TResponse> : IAsyncStre
     where TResponse : class
 {
     private readonly RetryCallBase<TRequest, TResponse> _retryCallBase;
-    private int _readCount;
 
     public RetryCallBaseClientStreamReader(RetryCallBase<TRequest, TResponse> retryCallBase)
     {
@@ -42,21 +41,13 @@ internal class RetryCallBaseClientStreamReader<TRequest, TResponse> : IAsyncStre
 
     public async Task<bool> MoveNext(CancellationToken cancellationToken)
     {
-        _readCount++;
-
         var call = await _retryCallBase.CommitedCallTask.ConfigureAwait(false);
         return await call.ClientStreamReader!.MoveNext(cancellationToken).ConfigureAwait(false);
     }
 
     private string DebuggerToString()
     {
-        //IGrpcCall<TRequest, TResponse>? commitedCall = null;
-        //if (_retryCallBase.CommitedCallTask.IsCompletedSuccessfully())
-        //{
-        //    commitedCall = _retryCallBase.CommitedCallTask.Result;
-        //}
-
-        return $"ReadCount = {_readCount}, EndOfStream = {(_retryCallBase.ResponseFinished ? "true" : "false")}";
+        return $"ReadCount = {_retryCallBase.MessagesRead}, EndOfStream = {(_retryCallBase.ResponseFinished ? "true" : "false")}";
     }
 
     private sealed class RetryCallBaseClientStreamReaderDebugView
@@ -69,7 +60,7 @@ internal class RetryCallBaseClientStreamReader<TRequest, TResponse> : IAsyncStre
         }
 
         public object? Call => _reader._retryCallBase.CallWrapper;
-        public long ReadCount => _reader._readCount;
+        public long ReadCount => _reader._retryCallBase.MessagesRead;
         public TResponse Current => _reader.Current;
         public bool EndOfStream => _reader._retryCallBase.ResponseFinished;
     }

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamWriter.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -16,11 +16,14 @@
 
 #endregion
 
+using System.Diagnostics;
 using Grpc.Core;
 using Log = Grpc.Net.Client.Internal.ClientStreamWriterBaseLog;
 
 namespace Grpc.Net.Client.Internal.Retry;
 
+[DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerTypeProxy(typeof(RetryCallBaseClientStreamWriter<,>.RetryCallBaseClientStreamWriterDebugView))]
 internal class RetryCallBaseClientStreamWriter<TRequest, TResponse> : ClientStreamWriterBase<TRequest>
     where TRequest : class
     where TResponse : class
@@ -80,5 +83,22 @@ internal class RetryCallBaseClientStreamWriter<TRequest, TResponse> : ClientStre
         }
 
         return WriteTask;
+    }
+
+    private string DebuggerToString() => $"WriteCount = {_retryCallBase.MessagesWritten}, WriterCompleted = {(_retryCallBase.ClientStreamComplete ? "true" : "false")}";
+
+    private sealed class RetryCallBaseClientStreamWriterDebugView
+    {
+        private readonly RetryCallBaseClientStreamWriter<TRequest, TResponse> _writer;
+
+        public RetryCallBaseClientStreamWriterDebugView(RetryCallBaseClientStreamWriter<TRequest, TResponse> writer)
+        {
+            _writer = writer;
+        }
+
+        public object? Call => _writer._retryCallBase.CallWrapper;
+        public bool WriterCompleted => _writer._retryCallBase.ClientStreamComplete;
+        public long WriteCount => _writer._retryCallBase.MessagesWritten;
+        public WriteOptions? WriteOptions => _writer.WriteOptions;
     }
 }

--- a/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
@@ -39,6 +39,7 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
     public IAsyncStreamReader<TResponse>? ClientStreamReader => _clientStreamReader ??= new StatusStreamReader(_status);
     public bool Disposed => true;
     public bool ResponseFinished => true;
+    public int MessagesRead { get; }
 
     public object? CallWrapper { get; set; }
 
@@ -47,11 +48,12 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
     string IMethod.Name => _method.Name;
     string IMethod.FullName => _method.FullName;
 
-    public StatusGrpcCall(Status status, GrpcChannel channel, Method<TRequest, TResponse> method)
+    public StatusGrpcCall(Status status, GrpcChannel channel, Method<TRequest, TResponse> method, int messagesRead)
     {
         _status = status;
         _channel = channel;
         _method = method;
+        MessagesRead = messagesRead;
     }
 
     public void Dispose()

--- a/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -31,17 +31,27 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
 {
     private readonly Status _status;
     private readonly GrpcChannel _channel;
+    private readonly Method<TRequest, TResponse> _method;
     private IClientStreamWriter<TRequest>? _clientStreamWriter;
     private IAsyncStreamReader<TResponse>? _clientStreamReader;
 
     public IClientStreamWriter<TRequest>? ClientStreamWriter => _clientStreamWriter ??= new StatusClientStreamWriter(_status);
     public IAsyncStreamReader<TResponse>? ClientStreamReader => _clientStreamReader ??= new StatusStreamReader(_status);
     public bool Disposed => true;
+    public bool ResponseFinished => true;
 
-    public StatusGrpcCall(Status status, GrpcChannel channel)
+    public object? CallWrapper { get; set; }
+
+    MethodType IMethod.Type => _method.Type;
+    string IMethod.ServiceName => _method.ServiceName;
+    string IMethod.Name => _method.Name;
+    string IMethod.FullName => _method.FullName;
+
+    public StatusGrpcCall(Status status, GrpcChannel channel, Method<TRequest, TResponse> method)
     {
         _status = status;
         _channel = channel;
+        _method = method;
     }
 
     public void Dispose()


### PR DESCRIPTION
* Client request stream
  * Add debugging enhancements to retry request stream
  * Remove in-progress property
  * Display whether the request stream has been completed
  * Replace `CallCompleted` property with `Call` property linking back to the stream's call
* Client response stream
  * Add debugging enhancements to retry response stream
  * Remove in-progress property
  * Display whether it has reached the end of stream
  * Replace `CallCompleted` property with `Call` property linking back to the stream's call
* Server request stream
  * Display whether it has reached the end of stream
  * Add `ServerCallContext` property linking back to the stream's context
* Server response stream
  * Remove in-progress property
  * Display whether it has reached the end of stream
  * Add `ServerCallContext` property linking back to the stream's context
* Add method information to client call

## Client call

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/303058c9-b185-4ed6-ad7d-429ed38f98d2)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/084099e9-48de-4cef-b57c-4d792a8bc651)

## Client request stream

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/73666f6c-4e98-4ecf-ad07-5d3ae374bf30)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/81b8b21c-3084-44fa-87a7-8024b931e8fe)

## Client response stream

Before:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/f8adce1e-d20d-430b-ac5a-86c090937fff)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/3aee5ab0-ffdf-42f1-838f-b332abc64f37)
