### PR TITLE
Add a recursive parameter to the dotnet-grpc add-files CLI command

### DIFF
--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -41,6 +41,7 @@ internal class AddFileCommand : CommandBase
         var serviceOption = CommonOptions.ServiceOption();
         var additionalImportDirsOption = CommonOptions.AdditionalImportDirsOption();
         var accessOption = CommonOptions.AccessOption();
+        var recursiveOption = CommonOptions.RecursiveOption();
         var filesArgument = new Argument<string[]>
         {
             Name = "files",
@@ -52,6 +53,7 @@ internal class AddFileCommand : CommandBase
         command.AddOption(serviceOption);
         command.AddOption(accessOption);
         command.AddOption(additionalImportDirsOption);
+        command.AddOption(recursiveOption);
         command.AddArgument(filesArgument);
 
         command.SetHandler(
@@ -61,12 +63,13 @@ internal class AddFileCommand : CommandBase
                 var services = context.ParseResult.GetValueForOption(serviceOption);
                 var access = context.ParseResult.GetValueForOption(accessOption);
                 var additionalImportDirs = context.ParseResult.GetValueForOption(additionalImportDirsOption);
+                var searchOption = context.ParseResult.GetValueForOption(recursiveOption) ? SearchOption.TopDirectoryOnly : SearchOption.TopDirectoryOnly;
                 var files = context.ParseResult.GetValueForArgument(filesArgument);
 
                 try
                 {
                     var command = new AddFileCommand(context.Console, project, httpClient);
-                    await command.AddFileAsync(services, access, additionalImportDirs, files);
+                    await command.AddFileAsync(services, access, additionalImportDirs, files, searchOption);
 
                     context.ExitCode = 0;
                 }
@@ -81,11 +84,11 @@ internal class AddFileCommand : CommandBase
         return command;
     }
 
-    public async Task AddFileAsync(Services services, Access access, string? additionalImportDirs, string[] files)
+    public async Task AddFileAsync(Services services, Access access, string? additionalImportDirs, string[] files, SearchOption searchOption)
     {
         var resolvedServices = ResolveServices(services);
         await EnsureNugetPackagesAsync(resolvedServices);
-        files = GlobReferences(files);
+        files = GlobReferences(files, searchOption);
 
         foreach (var file in files)
         {

--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -63,7 +63,7 @@ internal class AddFileCommand : CommandBase
                 var services = context.ParseResult.GetValueForOption(serviceOption);
                 var access = context.ParseResult.GetValueForOption(accessOption);
                 var additionalImportDirs = context.ParseResult.GetValueForOption(additionalImportDirsOption);
-                var searchOption = context.ParseResult.GetValueForOption(recursiveOption) ? SearchOption.TopDirectoryOnly : SearchOption.TopDirectoryOnly;
+                var searchOption = context.ParseResult.HasOption(recursiveOption) ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
                 var files = context.ParseResult.GetValueForArgument(filesArgument);
 
                 try

--- a/src/dotnet-grpc/Commands/CommandBase.cs
+++ b/src/dotnet-grpc/Commands/CommandBase.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -174,7 +174,7 @@ internal class CommandBase
         }
 
         var normalizedFile = NormalizePath(file);
-        
+
         var normalizedAdditionalImportDirs = string.Empty;
 
         if (!string.IsNullOrWhiteSpace(additionalImportDirs))
@@ -298,7 +298,7 @@ internal class CommandBase
         return resolvedReferences;
     }
 
-    internal string[] GlobReferences(string[] references)
+    internal string[] GlobReferences(string[] references, SearchOption searchOption = SearchOption.TopDirectoryOnly)
     {
         var expandedReferences = new List<string>();
 
@@ -315,7 +315,7 @@ internal class CommandBase
                 var directoryToSearch = Path.GetPathRoot(reference)!;
                 var searchPattern = reference.Substring(directoryToSearch.Length);
 
-                var resolvedFiles = Directory.GetFiles(directoryToSearch, searchPattern);
+                var resolvedFiles = Directory.GetFiles(directoryToSearch, searchPattern, searchOption);
 
                 if (resolvedFiles.Length == 0)
                 {
@@ -328,7 +328,7 @@ internal class CommandBase
 
             if (Directory.Exists(Path.Combine(Project.DirectoryPath, Path.GetDirectoryName(reference)!)))
             {
-                var resolvedFiles = Directory.GetFiles(Project.DirectoryPath, reference);
+                var resolvedFiles = Directory.GetFiles(Project.DirectoryPath, reference, searchOption);
 
                 if (resolvedFiles.Length == 0)
                 {

--- a/src/dotnet-grpc/Options/CommonOptions.cs
+++ b/src/dotnet-grpc/Options/CommonOptions.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -52,6 +52,15 @@ internal static class CommonOptions
         var o = new Option<string>(
             aliases: new[] { "-i", "--additional-import-dirs" },
             description: CoreStrings.AdditionalImportDirsOption);
+        return o;
+    }
+
+    public static Option<bool> RecursiveOption()
+    {
+        var o = new Option<bool>(
+            aliases: new[] { "-r", "--recursive" },
+            description: CoreStrings.RecursiveOptionDescription
+            );
         return o;
     }
 }

--- a/src/dotnet-grpc/Properties/CoreStrings.Designer.cs
+++ b/src/dotnet-grpc/Properties/CoreStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Grpc.Dotnet.Cli.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CoreStrings {
@@ -309,6 +309,15 @@ namespace Grpc.Dotnet.Cli.Properties {
         internal static string ProjectOptionDescription {
             get {
                 return ResourceManager.GetString("ProjectOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Whether to add the protobuf file references recursively. Default value is false..
+        /// </summary>
+        internal static string RecursiveOptionDescription {
+            get {
+                return ResourceManager.GetString("RecursiveOptionDescription", resourceCulture);
             }
         }
         

--- a/src/dotnet-grpc/Properties/CoreStrings.resx
+++ b/src/dotnet-grpc/Properties/CoreStrings.resx
@@ -231,4 +231,7 @@
   <data name="LogNoReferences" xml:space="preserve">
     <value>No protobuf references in the gRPC project.</value>
   </data>
+  <data name="RecursiveOptionDescription" xml:space="preserve">
+    <value>Whether to add the protobuf file references recursively. Default value is false.</value>
+  </data>
 </root>

--- a/test/dotnet-grpc.Tests/AddFileCommandTests.cs
+++ b/test/dotnet-grpc.Tests/AddFileCommandTests.cs
@@ -41,7 +41,7 @@ public class AddFileCommandTests : TestBase
         var parser = Program.BuildParser(CreateClient());
 
         // Act
-        var result = await parser.InvokeAsync($"add-file -p {tempDir} -s Server --access Internal -i ImportDir {Path.Combine("Proto", "*.proto")}", testConsole);
+        var result = await parser.InvokeAsync($"add-file -p {tempDir} -s Server --access Internal -r -i ImportDir {Path.Combine("Proto", "*.proto")}", testConsole);
 
         // Assert
         Assert.AreEqual(0, result, testConsole.Error.ToString());
@@ -55,9 +55,10 @@ public class AddFileCommandTests : TestBase
 
 
         var protoRefs = project.GetItems(CommandBase.ProtobufElement);
-        Assert.AreEqual(2, protoRefs.Count);
+        Assert.AreEqual(3, protoRefs.Count);
         Assert.NotNull(protoRefs.SingleOrDefault(r => r.UnevaluatedInclude == "Proto\\a.proto"));
         Assert.NotNull(protoRefs.SingleOrDefault(r => r.UnevaluatedInclude == "Proto\\b.proto"));
+        Assert.NotNull(protoRefs.SingleOrDefault(r => r.UnevaluatedInclude == "Proto\\Subfolder\\c.proto"));
         foreach (var protoRef in protoRefs)
         {
             Assert.AreEqual("Server", protoRef.GetMetadataValue(CommandBase.GrpcServicesElement));

--- a/test/dotnet-grpc.Tests/dotnet-grpc.Tests.csproj
+++ b/test/dotnet-grpc.Tests/dotnet-grpc.Tests.csproj
@@ -59,5 +59,8 @@
     </AssemblyAttribute>
 
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="TestAssets\EmptyProject\Proto\Subfolder\" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add a recursive parameter to the dotnet-grpc add-files CLI command. 

The new parameter will search the files in the requested folder recursively which enables adding proto references to projects inside multiple sub-folders. 

A unit test which verifies the functionality has been added and previous non recursive unit tests were changed.