### PR TITLE
Fix gRPC client retry deadlock

### DIFF
--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -365,10 +365,10 @@ internal sealed partial class HedgingCall<TRequest, TResponse> : RetryCallBase<T
 
     protected override void Dispose(bool disposing)
     {
+        base.Dispose(disposing);
+
         lock (Lock)
         {
-            base.Dispose(disposing);
-
             CleanUpUnsynchronized();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2206

I believe the problem is caused by a [call's TCS being created without `RunContinuationsAsynchronously`](https://github.com/grpc/grpc-dotnet/blob/8ca08ebf05b0c81c15cb68baf5196ffe5ed7b5a3/src/Grpc.Net.Client/Internal/GrpcCall.cs#L74). The simple fix would be to add that setting. Unfortunately, `RunContinuationsAsynchronously` is not used here on purpose because it breaks `Activity`.

When the call is disposed under a lock, the TCS is completed, and continuations are run on the same thread, still holding the lock. That includes logic after the [await here in RetryCall](https://github.com/grpc/grpc-dotnet/blob/8ca08ebf05b0c81c15cb68baf5196ffe5ed7b5a3/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs#L255).

I moved disposing the active call outside of the lock. I think this fixes the deadlock, but I don't have repro to confirm.

Another idea I had, which isn't in this PR, is to place a `Task.Yield()` after the await in RetryCall. It forces the call's TCS to stop executing synchronously, `_callTcs.TrySetResult(...)` returns, the call's dispose finishes, and exits the lock.

cc @andrewhickman