### PR TITLE
Support idle connection timeout with pending sockets

### DIFF
--- a/test/Grpc.Net.Client.Tests/Balancer/StreamWrapperTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/StreamWrapperTests.cs
@@ -26,6 +26,54 @@ namespace Grpc.Net.Client.Tests.Balancer;
 public class StreamWrapperTests
 {
     [Test]
+    public async Task ReadAsync_ExactSize_Read()
+    {
+        // Arrange
+        var ms = new MemoryStream(new byte[] { 4 });
+        var data = new List<ReadOnlyMemory<byte>>
+        {
+            new byte[] { 1, 2, 3 }
+        };
+        var streamWrapper = new StreamWrapper(ms, s => { }, data);
+        var buffer = new byte[3];
+
+        // Act & Assert
+        Assert.AreEqual(3, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(1, buffer[0]);
+        Assert.AreEqual(2, buffer[1]);
+        Assert.AreEqual(3, buffer[2]);
+
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(4, buffer[0]);
+
+        Assert.AreEqual(0, await streamWrapper.ReadAsync(buffer));
+    }
+
+    [Test]
+    public async Task ReadAsync_BiggerThanNeeded_Read()
+    {
+        // Arrange
+        var ms = new MemoryStream(new byte[] { 4 });
+        var data = new List<ReadOnlyMemory<byte>>
+        {
+            new byte[] { 1, 2, 3 }
+        };
+        var streamWrapper = new StreamWrapper(ms, s => { }, data);
+        var buffer = new byte[4];
+
+        // Act & Assert
+        Assert.AreEqual(3, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(1, buffer[0]);
+        Assert.AreEqual(2, buffer[1]);
+        Assert.AreEqual(3, buffer[2]);
+
+        Assert.AreEqual(1, await streamWrapper.ReadAsync(buffer));
+        Assert.AreEqual(4, buffer[0]);
+
+        Assert.AreEqual(0, await streamWrapper.ReadAsync(buffer));
+    }
+
+    [Test]
     public async Task ReadAsync_MultipleInitialData_ReadInOrder()
     {
         // Arrange

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -208,6 +208,34 @@ public class GrpcChannelTests
         Assert.AreEqual("Channel is configured with insecure channel credentials and can't use a HttpClient with a 'https' scheme.", ex.Message);
     }
 
+#if !NET472
+    [Test]
+    public void Build_ConnectTimeout_ReadFromSocketsHttpHandler()
+    {
+        // Arrange & Act
+        var channel = GrpcChannel.ForAddress("https://localhost", CreateGrpcChannelOptions(o => o.HttpHandler = new SocketsHttpHandler
+        {
+            ConnectTimeout = TimeSpan.FromSeconds(1)
+        }));
+
+        // Assert
+        Assert.AreEqual(TimeSpan.FromSeconds(1), channel.ConnectTimeout);
+    }
+
+    [Test]
+    public void Build_ConnectionIdleTimeout_ReadFromSocketsHttpHandler()
+    {
+        // Arrange & Act
+        var channel = GrpcChannel.ForAddress("https://localhost", CreateGrpcChannelOptions(o => o.HttpHandler = new SocketsHttpHandler
+        {
+            PooledConnectionIdleTimeout = TimeSpan.FromSeconds(1)
+        }));
+
+        // Assert
+        Assert.AreEqual(TimeSpan.FromSeconds(1), channel.ConnectionIdleTimeout);
+    }
+#endif
+
     [Test]
     public void Build_HttpClientAndHttpHandler_ThrowsError()
     {

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -208,7 +208,7 @@ public class GrpcChannelTests
         Assert.AreEqual("Channel is configured with insecure channel credentials and can't use a HttpClient with a 'https' scheme.", ex.Message);
     }
 
-#if !NET472
+#if SUPPORT_LOAD_BALANCING
     [Test]
     public void Build_ConnectTimeout_ReadFromSocketsHttpHandler()
     {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2210

I think the issue is caused by a race when there is a long time interval between a channel connecting and a request being made:

1. When a request is made, the socket is double-checked to be healthy before it's given to SocketsHttpHandler to be turned into a connection.
2. After the health check, the server/proxy closes what it thinks is an idle socket.
3. The handler then uses the closed socket to send a request and fails.

The prospective fix is to close and recreate the socket if it exceeds the idle connection timeout. Default of 1 minute.