### PR TITLE
Correctly check socket on stream creation

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -253,7 +253,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                 {
                     CompatibilityHelpers.Assert(socketAddress != null);
 
-                    closeSocket = CheckSocket(socket, socketAddress, ref _initialSocketData, out checkException);
+                    closeSocket = ShouldCloseSocket(socket, socketAddress, ref _initialSocketData, out checkException);
                 }
             }
 
@@ -288,68 +288,6 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                 // Schedule next ping.
                 _socketConnectedTimer.Change(_socketPingInterval, Timeout.InfiniteTimeSpan);
             }
-        }
-    }
-
-    /// <summary>
-    /// Checks whether the socket is healthy. May read available data into the passed in buffer.
-    /// Returns true if the socket should be closed.
-    /// </summary>
-    private bool CheckSocket(Socket socket, BalancerAddress socketAddress, ref List<ReadOnlyMemory<byte>>? socketData, out Exception? checkException)
-    {
-        checkException = null;
-
-        try
-        {
-            SocketConnectivitySubchannelTransportLog.CheckingSocket(_logger, _subchannel.Id, socketAddress);
-
-            // Poll socket to check if it can be read from. Unfortunatly this requires reading pending data.
-            // The server might send data, such as an HTTP/2 SETTINGS or GOAWAY frame, so we need to read and cache it.
-            //
-            // Available data needs to be read now because the only way to determine whether the connection is closed is to
-            // get the results of polling after available data is received.
-            bool hasReadData;
-            do
-            {
-                if (IsSocketInBadState(socket, socketAddress))
-                {
-                    return true;
-                }
-
-                var available = socket.Available;
-                if (available > 0)
-                {
-                    hasReadData = true;
-                    var serverDataAvailable = CalculateInitialSocketDataLength(socketData) + available;
-                    if (serverDataAvailable > MaximumInitialSocketDataSize)
-                    {
-                        // Data sent to the client before a connection is started shouldn't be large.
-                        // Put a maximum limit on the buffer size to prevent an unexpected scenario from consuming too much memory.
-                        throw new InvalidOperationException($"The server sent {serverDataAvailable} bytes to the client before a connection was established. Maximum allowed data exceeded.");
-                    }
-
-                    SocketConnectivitySubchannelTransportLog.SocketReceivingAvailable(_logger, _subchannel.Id, socketAddress, available);
-
-                    // Data is already available so this won't block.
-                    var buffer = new byte[available];
-                    var readCount = socket.Receive(buffer);
-
-                    socketData ??= new List<ReadOnlyMemory<byte>>();
-                    socketData.Add(buffer.AsMemory(0, readCount));
-                }
-                else
-                {
-                    hasReadData = false;
-                }
-            }
-            while (hasReadData);
-            return false;
-        }
-        catch (Exception ex)
-        {
-            checkException = ex;
-            SocketConnectivitySubchannelTransportLog.ErrorCheckingSocket(_logger, _subchannel.Id, socketAddress, ex);
-            return true;
         }
     }
 
@@ -399,7 +337,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                 SocketConnectivitySubchannelTransportLog.ClosingSocketFromIdleTimeoutOnCreateStream(_logger, _subchannel.Id, address, _socketIdleTimeout);
                 closeSocket = true;
             }
-            else if (CheckSocket(socket, address, ref socketData, out _))
+            else if (ShouldCloseSocket(socket, address, ref socketData, out _))
             {
                 SocketConnectivitySubchannelTransportLog.ClosingUnusableSocketOnCreateStream(_logger, _subchannel.Id, address);
                 closeSocket = true;
@@ -435,7 +373,75 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
         return stream;
     }
 
-    private bool IsSocketInBadState(Socket socket, BalancerAddress address)
+    /// <summary>
+    /// Checks whether the socket is healthy. May read available data into the passed in buffer.
+    /// Returns true if the socket should be closed.
+    /// </summary>
+    private bool ShouldCloseSocket(Socket socket, BalancerAddress socketAddress, ref List<ReadOnlyMemory<byte>>? socketData, out Exception? checkException)
+    {
+        checkException = null;
+
+        try
+        {
+            SocketConnectivitySubchannelTransportLog.CheckingSocket(_logger, _subchannel.Id, socketAddress);
+
+            // Poll socket to check if it can be read from. Unfortunately this requires reading pending data.
+            // The server might send data, e.g. HTTP/2 SETTINGS frame, so we need to read and cache it.
+            //
+            // Available data needs to be read now because the only way to determine whether the connection is
+            // closed is to get the results of polling after available data is received.
+            // For example, the server may have sent an HTTP/2 SETTINGS or GOAWAY frame.
+            // We need to cache whatever we read so it isn't dropped.
+            do
+            {
+                if (PollSocket(socket, socketAddress))
+                {
+                    // Polling socket reported an unhealthy state.
+                    return true;
+                }
+
+                var available = socket.Available;
+                if (available > 0)
+                {
+                    var serverDataAvailable = CalculateInitialSocketDataLength(socketData) + available;
+                    if (serverDataAvailable > MaximumInitialSocketDataSize)
+                    {
+                        // Data sent to the client before a connection is started shouldn't be large.
+                        // Put a maximum limit on the buffer size to prevent an unexpected scenario from consuming too much memory.
+                        throw new InvalidOperationException($"The server sent {serverDataAvailable} bytes to the client before a connection was established. Maximum allowed data exceeded.");
+                    }
+
+                    SocketConnectivitySubchannelTransportLog.SocketReceivingAvailable(_logger, _subchannel.Id, socketAddress, available);
+
+                    // Data is already available so this won't block.
+                    var buffer = new byte[available];
+                    var readCount = socket.Receive(buffer);
+
+                    socketData ??= new List<ReadOnlyMemory<byte>>();
+                    socketData.Add(buffer.AsMemory(0, readCount));
+                }
+                else
+                {
+                    // There is no more available data to read and the socket is healthy.
+                    return false;
+                }
+            }
+            while (true);
+        }
+        catch (Exception ex)
+        {
+            checkException = ex;
+            SocketConnectivitySubchannelTransportLog.ErrorCheckingSocket(_logger, _subchannel.Id, socketAddress, ex);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Poll the socket to check for health and available data.
+    /// Shouldn't be used by itself as data needs to be consumed to accurately report the socket health.
+    /// <see cref="ShouldCloseSocket"/> handles consuming data and getting the socket health.
+    /// </summary>
+    private bool PollSocket(Socket socket, BalancerAddress address)
     {
         // From https://github.com/dotnet/runtime/blob/3195fbbd82fdb7f132d6698591ba6489ad6dd8cf/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L158-L168
         try

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -304,7 +304,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
             SocketConnectivitySubchannelTransportLog.CheckingSocket(_logger, _subchannel.Id, socketAddress);
 
             // Poll socket to check if it can be read from. Unfortunatly this requires reading pending data.
-            // The server might send data, e.g. HTTP/2 SETTINGS frame, so we need to read and cache it.
+            // The server might send data, such as an HTTP/2 SETTINGS or GOAWAY frame, so we need to read and cache it.
             //
             // Available data needs to be read now because the only way to determine whether the connection is closed is to
             // get the results of polling after available data is received.

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -219,7 +219,7 @@ public class ConnectionTests : FunctionalTestBase
         // Fails when this test is run with debugging. Kestrel doesn't trigger keepalive timeout if debugging is enabled.
         await TestHelpers.AssertIsTrueRetryAsync(() =>
         {
-            return Logs.Any(l => l.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Connections" && l.EventId.Name == "ConnectionStop");
+            return Logs.Any(l => l.LoggerName.StartsWith("Microsoft.AspNetCore.Server.Kestrel") && l.EventId.Name == "ConnectionStop");
         }, "Wait for server to close connection.");
 
         var client = TestClientFactory.Create(channel, endpoint.Method);

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -156,7 +156,7 @@ public class ConnectionTests : FunctionalTestBase
         }
 
         // Arrange
-        using var endpoint = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod));
+        using var endpoint = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod), loggerFactory: LoggerFactory);
 
         var connectionIdleTimeout = TimeSpan.FromSeconds(1);
         var channel = await BalancerHelpers.CreateChannel(
@@ -178,6 +178,55 @@ public class ConnectionTests : FunctionalTestBase
 
         AssertHasLog(LogLevel.Debug, "ClosingSocketFromIdleTimeoutOnCreateStream", "Subchannel id '1' socket 127.0.0.1:50051 is being closed because it exceeds the idle timeout of 00:00:01.");
         AssertHasLog(LogLevel.Trace, "ConnectingOnCreateStream", "Subchannel id '1' doesn't have a connected socket available. Connecting new stream socket for 127.0.0.1:50051.");
+    }
+
+    [Test]
+    public async Task Active_UnaryCall_ServerCloseOnKeepAlive_SocketRecreatedOnRequest()
+    {
+        // Ignore errors
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = request.Name });
+        }
+
+        // In this test the client connects to the server, and the server then closes it after keep-alive is triggered.
+        // The client then starts a gRPC call to the server. The client should discard the closed socket and create a new one.
+
+        // Arrange
+        using var endpoint = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(
+            50051,
+            UnaryMethod,
+            nameof(UnaryMethod),
+            loggerFactory: LoggerFactory,
+            configureServer: o => o.Limits.KeepAliveTimeout = TimeSpan.FromSeconds(1));
+
+        // Don't timeout the socket or ping it from the client.
+        var channel = await BalancerHelpers.CreateChannel(
+            LoggerFactory,
+            new RoundRobinConfig(),
+            new[] { endpoint.Address },
+            connectionIdleTimeout: TimeSpan.FromMinutes(30),
+            socketPingInterval: TimeSpan.FromMinutes(30)).DefaultTimeout();
+
+        Logger.LogInformation("Connecting channel.");
+        await channel.ConnectAsync();
+
+        // Fails when this test is run with debugging. Kestrel doesn't trigger keepalive timeout if debugging is enabled.
+        await TestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            return Logs.Any(l => l.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Connections" && l.EventId.Name == "ConnectionStop");
+        }, "Wait for server to close connection.");
+
+        var client = TestClientFactory.Create(channel, endpoint.Method);
+        var response = await client.UnaryCall(new HelloRequest { Name = "Test!" }).ResponseAsync.DefaultTimeout();
+
+        // Assert
+        Assert.AreEqual("Test!", response.Message);
     }
 
     [Test]


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2210

I recreated the error from https://github.com/grpc/grpc-dotnet/issues/2210. The previous fix (socket timeout) will address this issue for the vast majority of people. However, some servers may have configured a timeout of less than 60 seconds. They could still run into problems.

Previously if a server had written data to the socket (e.g. HTTP/2 GOAWAY frame) and closed it, then it would incorrectly be seen as healthy. This PR updates the stream creation method to correctly check that a socket is still healthy before using it. This involves reusing the check logic from the ping that reads available data. When available data is read, the client will see the socket is closed and create a new one for the connection.