### PR TITLE
Upgrade Newtonsoft.Json package version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -21,7 +21,7 @@
     <MicrosoftSourceLinkGitHubPackageVersion>1.0.0</MicrosoftSourceLinkGitHubPackageVersion>
     <MicrosoftWin32RegistryLinePackageVersion>4.6.0</MicrosoftWin32RegistryLinePackageVersion>
     <MoqPackageVersion>4.16.1</MoqPackageVersion>
-    <NewtonsoftJsonPackageVersion>12.0.3</NewtonsoftJsonPackageVersion>
+    <NewtonsoftJsonPackageVersion>13.0.3</NewtonsoftJsonPackageVersion>
     <NunitPackageVersion>3.13.1</NunitPackageVersion>
     <Nunit3TestAdapterPackageVersion>3.16.1</Nunit3TestAdapterPackageVersion>
     <OpenTelemetryPackageVersion>1.3.0</OpenTelemetryPackageVersion>


### PR DESCRIPTION
ASP.NET benchmarks don't compile anymore with the current version due to public vulnerability warnings.