### PR TITLE
Consistently don't log message errors on cancellation

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/PipeExtensions.cs
@@ -71,8 +71,9 @@ internal static partial class PipeExtensions
                 GrpcEventSource.Log.MessageSent();
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            // Don't write error when user cancels write
             GrpcServerLog.ErrorSendingMessage(logger, ex);
             throw;
         }
@@ -121,8 +122,9 @@ internal static partial class PipeExtensions
                 GrpcEventSource.Log.MessageSent();
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            // Don't write error when user cancels write
             GrpcServerLog.ErrorSendingMessage(logger, ex);
             throw;
         }
@@ -275,8 +277,9 @@ internal static partial class PipeExtensions
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            // Don't write error when user cancels read
             GrpcServerLog.ErrorReadingMessage(logger, ex);
             throw;
         }

--- a/src/Grpc.Net.Client/Internal/StreamExtensions.cs
+++ b/src/Grpc.Net.Client/Internal/StreamExtensions.cs
@@ -317,7 +317,11 @@ internal static partial class StreamExtensions
         }
         catch (Exception ex)
         {
-            GrpcCallLog.ErrorSendingMessage(call.Logger, ex);
+            if (!IsCancellationException(ex))
+            {
+                // Don't write error when user cancels write
+                GrpcCallLog.ErrorSendingMessage(call.Logger, ex);
+            }
 
             if (TryCreateCallCompleteException(ex, call, out var statusException))
             {
@@ -350,7 +354,11 @@ internal static partial class StreamExtensions
         }
         catch (Exception ex)
         {
-            GrpcCallLog.ErrorSendingMessage(call.Logger, ex);
+            if (!IsCancellationException(ex))
+            {
+                // Don't write error when user cancels write
+                GrpcCallLog.ErrorSendingMessage(call.Logger, ex);
+            }
 
             if (TryCreateCallCompleteException(ex, call, out var statusException))
             {
@@ -361,6 +369,8 @@ internal static partial class StreamExtensions
         }
     }
 
+    private static bool IsCancellationException(Exception ex) => ex is OperationCanceledException or ObjectDisposedException;
+
     private static bool TryCreateCallCompleteException(Exception originalException, GrpcCall call, [NotNullWhen(true)] out Exception? exception)
     {
         // The call may have been completed while WriteAsync was running and caused WriteAsync to throw.
@@ -369,7 +379,7 @@ internal static partial class StreamExtensions
         // Replace exception with the status error if:
         // 1. The original exception is one Stream.WriteAsync throws if the call was completed during a write, and
         // 2. The call has already been successfully completed.
-        if (originalException is OperationCanceledException or ObjectDisposedException &&
+        if (IsCancellationException(originalException) &&
             call.CallTask.IsCompletedSuccessfully())
         {
             exception = call.CreateFailureStatusException(call.CallTask.Result);


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2218

There were some places that read/write messages that didn't log cancellation errors. This PR updates all locations to skip cancellation errors.