### PR TITLE
Change subchannel BalancerAddress when attributes change

### DIFF
--- a/src/Grpc.Net.Client/Balancer/BalancerAddress.cs
+++ b/src/Grpc.Net.Client/Balancer/BalancerAddress.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -30,7 +30,9 @@ namespace Grpc.Net.Client.Balancer;
 /// </summary>
 public sealed class BalancerAddress
 {
-    private BalancerAttributes? _attributes;
+    // Internal so address attributes can be compared without using the Attributes property.
+    // The property allocates an empty collection if one isn't already present.
+    internal BalancerAttributes? _attributes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BalancerAddress"/> class with the specified <see cref="DnsEndPoint"/>.
@@ -48,7 +50,7 @@ public sealed class BalancerAddress
     /// <param name="host">The host.</param>
     /// <param name="port">The port.</param>
     [DebuggerStepThrough]
-    public BalancerAddress(string host, int port) : this(new DnsEndPoint(host, port))
+    public BalancerAddress(string host, int port) : this(new BalancerEndPoint(host, port))
     {
     }
 
@@ -68,6 +70,22 @@ public sealed class BalancerAddress
     public override string ToString()
     {
         return $"{EndPoint.Host}:{EndPoint.Port}";
+    }
+
+    private sealed class BalancerEndPoint : DnsEndPoint
+    {
+        private string? _cachedToString;
+
+        public BalancerEndPoint(string host, int port) : base(host, port)
+        {
+        }
+
+        public override string ToString()
+        {
+            // Improve ToString performance when logging by caching ToString.
+            // Don't include DnsEndPoint address family.
+            return _cachedToString ??= $"{Host}:{Port}";
+        }
     }
 }
 #endif

--- a/src/Grpc.Net.Client/Balancer/BalancerAttributes.cs
+++ b/src/Grpc.Net.Client/Balancer/BalancerAttributes.cs
@@ -38,20 +38,22 @@ public sealed class BalancerAttributes : IDictionary<string, object?>, IReadOnly
     /// <summary>
     /// Gets a read-only collection of metadata attributes.
     /// </summary>
-    public static readonly BalancerAttributes Empty = new BalancerAttributes(new ReadOnlyDictionary<string, object?>(new Dictionary<string, object?>()));
+    public static readonly BalancerAttributes Empty = new BalancerAttributes(new Dictionary<string, object?>(), readOnly: true);
 
-    private readonly IDictionary<string, object?> _attributes;
+    private readonly Dictionary<string, object?> _attributes;
+    private readonly bool _readOnly;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BalancerAttributes"/> class.
     /// </summary>
-    public BalancerAttributes() : this(new Dictionary<string, object?>())
+    public BalancerAttributes() : this(new Dictionary<string, object?>(), readOnly: false)
     {
     }
 
-    private BalancerAttributes(IDictionary<string, object?> attributes)
+    private BalancerAttributes(Dictionary<string, object?> attributes, bool readOnly)
     {
         _attributes = attributes;
+        _readOnly = readOnly;
     }
 
     object? IDictionary<string, object?>.this[string key]
@@ -62,6 +64,7 @@ public sealed class BalancerAttributes : IDictionary<string, object?>, IReadOnly
         }
         set
         {
+            ValidateReadOnly();
             _attributes[key] = value;
         }
     }
@@ -69,21 +72,41 @@ public sealed class BalancerAttributes : IDictionary<string, object?>, IReadOnly
     ICollection<string> IDictionary<string, object?>.Keys => _attributes.Keys;
     ICollection<object?> IDictionary<string, object?>.Values => _attributes.Values;
     int ICollection<KeyValuePair<string, object?>>.Count => _attributes.Count;
-    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => _attributes.IsReadOnly;
+    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => _readOnly || ((ICollection<KeyValuePair<string, object?>>)_attributes).IsReadOnly;
     IEnumerable<string> IReadOnlyDictionary<string, object?>.Keys => _attributes.Keys;
     IEnumerable<object?> IReadOnlyDictionary<string, object?>.Values => _attributes.Values;
     int IReadOnlyCollection<KeyValuePair<string, object?>>.Count => _attributes.Count;
     object? IReadOnlyDictionary<string, object?>.this[string key] => _attributes[key];
-    void IDictionary<string, object?>.Add(string key, object? value) => _attributes.Add(key, value);
-    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) => _attributes.Add(item);
-    void ICollection<KeyValuePair<string, object?>>.Clear() => _attributes.Clear();
+    void IDictionary<string, object?>.Add(string key, object? value)
+    {
+        ValidateReadOnly();
+        _attributes.Add(key, value);
+    }
+    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item)
+    {
+        ValidateReadOnly();
+        ((ICollection<KeyValuePair<string, object?>>)_attributes).Add(item);
+    }
+    void ICollection<KeyValuePair<string, object?>>.Clear()
+    {
+        ValidateReadOnly();
+        _attributes.Clear();
+    }
     bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) => _attributes.Contains(item);
     bool IDictionary<string, object?>.ContainsKey(string key) => _attributes.ContainsKey(key);
-    void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) => _attributes.CopyTo(array, arrayIndex);
+    void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) => ((ICollection<KeyValuePair<string, object?>>)_attributes).CopyTo(array, arrayIndex);
     IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => _attributes.GetEnumerator();
     IEnumerator System.Collections.IEnumerable.GetEnumerator() => ((System.Collections.IEnumerable)_attributes).GetEnumerator();
-    bool IDictionary<string, object?>.Remove(string key) => _attributes.Remove(key);
-    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => _attributes.Remove(item);
+    bool IDictionary<string, object?>.Remove(string key)
+    {
+        ValidateReadOnly();
+        return _attributes.Remove(key);
+    }
+    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item)
+    {
+        ValidateReadOnly();
+        return ((ICollection<KeyValuePair<string, object?>>)_attributes).Remove(item);
+    }
     bool IDictionary<string, object?>.TryGetValue(string key, out object? value) => _attributes.TryGetValue(key, out value);
     bool IReadOnlyDictionary<string, object?>.ContainsKey(string key) => _attributes.ContainsKey(key);
     bool IReadOnlyDictionary<string, object?>.TryGetValue(string key, out object? value) => _attributes.TryGetValue(key, out value);
@@ -121,6 +144,7 @@ public sealed class BalancerAttributes : IDictionary<string, object?>, IReadOnly
     /// <param name="value">The value.</param>
     public void Set<TValue>(BalancerAttributesKey<TValue> key, TValue value)
     {
+        ValidateReadOnly();
         _attributes[key.Key] = value;
     }
 
@@ -135,10 +159,55 @@ public sealed class BalancerAttributes : IDictionary<string, object?>, IReadOnly
     /// </returns>
     public bool Remove<TValue>(BalancerAttributesKey<TValue> key)
     {
+        ValidateReadOnly();
         return _attributes.Remove(key.Key);
     }
 
-    internal string DebuggerToString()
+    private void ValidateReadOnly()
+    {
+        if (_readOnly)
+        {
+            throw new NotSupportedException("Collection is read-only.");
+        }
+    }
+
+    internal static bool DeepEquals(BalancerAttributes? x, BalancerAttributes? y)
+    {
+        var xValues = x?._attributes;
+        var yValues = y?._attributes;
+
+        if (ReferenceEquals(xValues, yValues))
+        {
+            return true;
+        }
+
+        if (xValues == null || yValues == null)
+        {
+            return false;
+        }
+
+        if (xValues.Count != yValues.Count)
+        {
+            return false;
+        }
+
+        foreach (var kvp in xValues)
+        {
+            if (!yValues.TryGetValue(kvp.Key, out var value))
+            {
+                return false;
+            }
+
+            if (!Equals(kvp.Value, value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private string DebuggerToString()
     {
         return $"Count = {_attributes.Count}";
     }

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerAddressEqualityComparer.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerAddressEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -17,8 +17,6 @@
 #endregion
 
 #if SUPPORT_LOAD_BALANCING
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Grpc.Net.Client.Balancer.Internal;
@@ -44,7 +42,7 @@ internal class BalancerAddressEqualityComparer : IEqualityComparer<BalancerAddre
             return false;
         }
 
-        return true;
+        return BalancerAttributes.DeepEquals(x._attributes, y._attributes);
     }
 
     public int GetHashCode([DisallowNull] BalancerAddress obj)

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
@@ -94,7 +94,7 @@ internal class BalancerHttpHandler : DelegatingHandler
         }
 
         Debug.Assert(context.DnsEndPoint.Equals(currentAddress.EndPoint), "Context endpoint should equal address endpoint.");
-        return await subchannel.Transport.GetStreamAsync(currentAddress, cancellationToken).ConfigureAwait(false);
+        return await subchannel.Transport.GetStreamAsync(currentAddress.EndPoint, cancellationToken).ConfigureAwait(false);
     }
 #endif
 

--- a/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
@@ -17,6 +17,7 @@
 #endregion
 
 #if SUPPORT_LOAD_BALANCING
+using System.Net;
 using Grpc.Shared;
 
 namespace Grpc.Net.Client.Balancer.Internal;
@@ -28,11 +29,11 @@ namespace Grpc.Net.Client.Balancer.Internal;
 /// </summary>
 internal interface ISubchannelTransport : IDisposable
 {
-    BalancerAddress? CurrentAddress { get; }
+    DnsEndPoint? CurrentEndPoint { get; }
     TimeSpan? ConnectTimeout { get; }
     TransportStatus TransportStatus { get; }
 
-    ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken);
+    ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken);
     ValueTask<ConnectResult> TryConnectAsync(ConnectContext context);
 
     void Disconnect();

--- a/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
@@ -35,32 +35,32 @@ namespace Grpc.Net.Client.Balancer.Internal;
 internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
 {
     private readonly Subchannel _subchannel;
-    private BalancerAddress? _currentAddress;
+    private DnsEndPoint? _currentEndPoint;
 
     public PassiveSubchannelTransport(Subchannel subchannel)
     {
         _subchannel = subchannel;
     }
 
-    public BalancerAddress? CurrentAddress => _currentAddress;
+    public DnsEndPoint? CurrentEndPoint => _currentEndPoint;
     public TimeSpan? ConnectTimeout { get; }
     public TransportStatus TransportStatus => TransportStatus.Passive;
 
     public void Disconnect()
     {
-        _currentAddress = null;
+        _currentEndPoint = null;
         _subchannel.UpdateConnectivityState(ConnectivityState.Idle, "Disconnected.");
     }
 
     public ValueTask<ConnectResult> TryConnectAsync(ConnectContext context)
     {
         Debug.Assert(_subchannel._addresses.Count == 1);
-        Debug.Assert(CurrentAddress == null);
+        Debug.Assert(CurrentEndPoint == null);
 
         var currentAddress = _subchannel._addresses[0];
 
         _subchannel.UpdateConnectivityState(ConnectivityState.Connecting, "Passively connecting.");
-        _currentAddress = currentAddress;
+        _currentEndPoint = currentAddress.EndPoint;
         _subchannel.UpdateConnectivityState(ConnectivityState.Ready, "Passively connected.");
 
         return new ValueTask<ConnectResult>(ConnectResult.Success);
@@ -68,10 +68,10 @@ internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
 
     public void Dispose()
     {
-        _currentAddress = null;
+        _currentEndPoint = null;
     }
 
-    public ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken)
+    public ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken)
     {
         throw new NotSupportedException();
     }

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -63,7 +63,21 @@ public sealed class Subchannel : IDisposable
     /// <summary>
     /// Gets the current connected address.
     /// </summary>
-    public BalancerAddress? CurrentAddress => GetAddress(_transport.CurrentEndPoint);
+    public BalancerAddress? CurrentAddress
+    {
+        get
+        {
+            if (_transport.CurrentEndPoint is { } ep)
+            {
+                lock (Lock)
+                {
+                    return GetAddressByEndpoint(_addresses, ep);
+                }
+            }
+
+            return null;
+        }
+    }
 
     /// <summary>
     /// Gets the metadata attributes.
@@ -404,19 +418,6 @@ public sealed class Subchannel : IDisposable
         {
             SubchannelLog.NoStateChangedRegistrations(_logger, Id);
         }
-    }
-
-    internal BalancerAddress? GetAddress(DnsEndPoint? endPoint)
-    {
-        if (endPoint != null)
-        {
-            lock (Lock)
-            {
-                return GetAddressByEndpoint(_addresses, endPoint);
-            }
-        }
-
-        return null;
     }
 
     private static BalancerAddress? GetAddressByEndpoint(List<BalancerAddress> addresses, DnsEndPoint endPoint)

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -140,6 +140,14 @@ public abstract class SubchannelsLoadBalancer : LoadBalancer
                 // remaining in this collection at the end will be disposed.
                 currentSubchannels.RemoveAt(i.Value);
 
+                // Check if address attributes have changed. If they have then update the subchannel address.
+                // The new subchannel address has the same endpoint so the connection isn't impacted.
+                if (!BalancerAddressEqualityComparer.Instance.Equals(address, newOrCurrentSubchannel.Address))
+                {
+                    newOrCurrentSubchannel.Subchannel.UpdateAddresses(new[] { address });
+                    newOrCurrentSubchannel = new AddressSubchannel(newOrCurrentSubchannel.Subchannel, address);
+                }
+
                 SubchannelLog.SubchannelPreserved(_logger, newOrCurrentSubchannel.Subchannel.Id, address);
             }
             else

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -346,7 +346,7 @@ public class ConnectionTests : FunctionalTestBase
         }, "Wait for connections to start.");
         foreach (var t in activeStreams)
         {
-            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), t.Address.EndPoint);
+            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), t.EndPoint);
         }
 
         // Act
@@ -367,7 +367,7 @@ public class ConnectionTests : FunctionalTestBase
             activeStreams = transport.GetActiveStreams();
             return activeStreams.Count == 11;
         }, "Wait for connections to start.");
-        Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams[activeStreams.Count - 1].Address.EndPoint);
+        Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), activeStreams[activeStreams.Count - 1].EndPoint);
 
         tcs.SetResult(null);
 
@@ -407,7 +407,7 @@ public class ConnectionTests : FunctionalTestBase
 
         activeStreams = transport.GetActiveStreams();
         Assert.AreEqual(1, activeStreams.Count);
-        Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].Address.EndPoint);
+        Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].EndPoint);
     }
 
 #if NET7_0_OR_GREATER

--- a/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
@@ -371,7 +371,7 @@ public class PickFirstBalancerTests : FunctionalTestBase
         Assert.GreaterOrEqual(activeStreams.Count, 2);
         foreach (var stream in activeStreams)
         {
-            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), stream.Address.EndPoint);
+            Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50051), stream.EndPoint);
         }
 
         tcs.SetResult(null);
@@ -385,7 +385,7 @@ public class PickFirstBalancerTests : FunctionalTestBase
         await TestHelpers.AssertIsTrueRetryAsync(() =>
         {
             activeStreams = transport.GetActiveStreams();
-            Logger.LogInformation($"Current active stream addresses: {string.Join(", ", activeStreams.Select(s => s.Address))}");
+            Logger.LogInformation($"Current active stream addresses: {string.Join(", ", activeStreams.Select(s => s.EndPoint))}");
             return activeStreams.Count == 0;
         }, "Active streams removed.", Logger).DefaultTimeout();
 
@@ -395,7 +395,7 @@ public class PickFirstBalancerTests : FunctionalTestBase
 
         activeStreams = transport.GetActiveStreams();
         Assert.AreEqual(1, activeStreams.Count);
-        Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].Address.EndPoint);
+        Assert.AreEqual(new DnsEndPoint("127.0.0.1", 50052), activeStreams[0].EndPoint);
     }
 
     [Test]

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
@@ -38,7 +38,7 @@ internal class TestSubchannelTransport : ISubchannelTransport
 
     public Subchannel Subchannel { get; }
 
-    public BalancerAddress? CurrentAddress { get; private set; }
+    public DnsEndPoint? CurrentEndPoint { get; private set; }
     public TimeSpan? ConnectTimeout => _factory.ConnectTimeout;
     public TransportStatus TransportStatus => TransportStatus.Passive;
 
@@ -62,14 +62,14 @@ internal class TestSubchannelTransport : ISubchannelTransport
     {
     }
 
-    public ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken)
+    public ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken)
     {
         return new ValueTask<Stream>(new MemoryStream());
     }
 
     public void Disconnect()
     {
-        CurrentAddress = null;
+        CurrentEndPoint = null;
         Subchannel.UpdateConnectivityState(ConnectivityState.Idle, "Disconnected.");
     }
 
@@ -83,7 +83,7 @@ internal class TestSubchannelTransport : ISubchannelTransport
     {
         var (newState, connectResult) = await (_onTryConnect?.Invoke(context.CancellationToken) ?? Task.FromResult(new TryConnectResult(ConnectivityState.Ready)));
 
-        CurrentAddress = Subchannel._addresses[0];
+        CurrentEndPoint = Subchannel._addresses[0].EndPoint;
         var newStatus = newState == ConnectivityState.TransientFailure ? new Status(StatusCode.Internal, "") : Status.DefaultSuccess;
         Subchannel.UpdateConnectivityState(newState, newStatus);
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2225

This PR:
* Updates how `BalancerAttributes` are stored to always use `Dictionary<string, object>`. This is to improve comparison performance.
* Adds an equals comparison on subchannels that includes `BalancerAttributes`.
* Changes subchannel transport to just store the `DnsEndPoint`. The endpoint is then used to look up the balancer attributes to use in the subchannel.
* Changes subchannel transport to use `DnsEndPoint` instead of `BalancerAttributes` in all logs.
* A `BalancerAddress` with different attributes replaces the address on the subchannel. If the subchannel has an open connection, it stays open.

cc @kalduzov