### PR TITLE
Support infinite idle connection timeout values

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -332,7 +332,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
 
             var closeSocket = false;
 
-            if (DateTime.UtcNow > socketCreatedTime.Value.Add(_socketIdleTimeout))
+            if (_socketIdleTimeout != Timeout.InfiniteTimeSpan && DateTime.UtcNow > socketCreatedTime.Value.Add(_socketIdleTimeout))
             {
                 SocketConnectivitySubchannelTransportLog.ClosingSocketFromIdleTimeoutOnCreateStream(_logger, _subchannel.Id, address, _socketIdleTimeout);
                 closeSocket = true;

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -267,7 +267,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
 
             type = HttpHandlerType.SocketsHttpHandler;
             connectTimeout = socketsHttpHandler.ConnectTimeout;
-            connectionIdleTimeout = socketsHttpHandler.PooledConnectionIdleTimeout;
+            connectionIdleTimeout = GetConnectionIdleTimeout(socketsHttpHandler);
 
             // Check if the SocketsHttpHandler is being shared by channels.
             // It has already been setup by another channel (i.e. ConnectCallback is set) then
@@ -312,6 +312,27 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         }
 
         return new HttpHandlerContext(HttpHandlerType.Custom);
+
+#if NET5_0_OR_GREATER
+        static TimeSpan? GetConnectionIdleTimeout(SocketsHttpHandler socketsHttpHandler)
+        {
+            // Check if either TimeSpan is InfiniteTimeSpan, and return the other one.
+            if (socketsHttpHandler.PooledConnectionIdleTimeout == Timeout.InfiniteTimeSpan)
+            {
+                return socketsHttpHandler.PooledConnectionLifetime;
+            }
+
+            if (socketsHttpHandler.PooledConnectionLifetime == Timeout.InfiniteTimeSpan)
+            {
+                return socketsHttpHandler.PooledConnectionIdleTimeout;
+            }
+
+            // Return the bigger TimeSpan.
+            return socketsHttpHandler.PooledConnectionIdleTimeout > socketsHttpHandler.PooledConnectionLifetime
+                ? socketsHttpHandler.PooledConnectionIdleTimeout
+                : socketsHttpHandler.PooledConnectionLifetime;
+        }
+#endif
     }
 
 #if NET5_0_OR_GREATER

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -141,8 +141,9 @@ public class ConnectionTests : FunctionalTestBase
         await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => connectTask).DefaultTimeout();
     }
 
-    [Test]
-    public async Task Active_UnaryCall_ConnectionIdleTimeout_SocketRecreated()
+    [TestCase(0)] // TimeSpan.Zero
+    [TestCase(1000)] // 1 second
+    public async Task Active_UnaryCall_ConnectionIdleTimeout_SocketRecreated(int milliseconds)
     {
         // Ignore errors
         SetExpectedErrorsFilter(writeContext =>
@@ -158,7 +159,7 @@ public class ConnectionTests : FunctionalTestBase
         // Arrange
         using var endpoint = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod), loggerFactory: LoggerFactory);
 
-        var connectionIdleTimeout = TimeSpan.FromSeconds(1);
+        var connectionIdleTimeout = TimeSpan.FromMilliseconds(milliseconds);
         var channel = await BalancerHelpers.CreateChannel(
             LoggerFactory,
             new PickFirstConfig(),
@@ -176,8 +177,41 @@ public class ConnectionTests : FunctionalTestBase
         // Assert
         Assert.AreEqual("Test!", response.Message);
 
-        AssertHasLog(LogLevel.Debug, "ClosingSocketFromIdleTimeoutOnCreateStream", "Subchannel id '1' socket 127.0.0.1:50051 is being closed because it exceeds the idle timeout of 00:00:01.");
+        AssertHasLog(LogLevel.Debug, "ClosingSocketFromIdleTimeoutOnCreateStream");
         AssertHasLog(LogLevel.Trace, "ConnectingOnCreateStream", "Subchannel id '1' doesn't have a connected socket available. Connecting new stream socket for 127.0.0.1:50051.");
+    }
+
+    public async Task Active_UnaryCall_InfiniteConnectionIdleTimeout_SocketNotClosed()
+    {
+        SetExpectedErrorsFilter(writeContext =>
+        {
+            return true;
+        });
+
+        Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = request.Name });
+        }
+
+        // Arrange
+        using var endpoint = BalancerHelpers.CreateGrpcEndpoint<HelloRequest, HelloReply>(50051, UnaryMethod, nameof(UnaryMethod), loggerFactory: LoggerFactory);
+
+        var channel = await BalancerHelpers.CreateChannel(
+            LoggerFactory,
+            new PickFirstConfig(),
+            new[] { endpoint.Address },
+            connectionIdleTimeout: Timeout.InfiniteTimeSpan).DefaultTimeout();
+
+        Logger.LogInformation("Connecting channel.");
+        await channel.ConnectAsync();
+
+        var client = TestClientFactory.Create(channel, endpoint.Method);
+        var response = await client.UnaryCall(new HelloRequest { Name = "Test!" }).ResponseAsync.DefaultTimeout();
+
+        // Assert
+        Assert.AreEqual("Test!", response.Message);
+
+        Assert.IsFalse(Logs.Any(l => l.EventId.Name == "ClosingSocketFromIdleTimeoutOnCreateStream"), "Shouldn't have a ClosingSocketFromIdleTimeoutOnCreateStream log.");
     }
 
     [Test]

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -169,7 +169,8 @@ public class ConnectionTests : FunctionalTestBase
         Logger.LogInformation("Connecting channel.");
         await channel.ConnectAsync();
 
-        await Task.Delay(connectionIdleTimeout);
+        // Wait for timeout plus a little extra to avoid issues from imprecise timers.
+        await Task.Delay(connectionIdleTimeout + TimeSpan.FromMilliseconds(50));
 
         var client = TestClientFactory.Create(channel, endpoint.Method);
         var response = await client.UnaryCall(new HelloRequest { Name = "Test!" }).ResponseAsync.DefaultTimeout();

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -119,21 +119,21 @@ public class FunctionalTestBase
         AssertHasLog(LogLevel.Information, "RpcConnectionError", $"Error status code '{statusCode}' with detail '{detail}' raised.");
     }
 
-    protected void AssertHasLog(LogLevel logLevel, string name, string message, Func<Exception, bool>? exceptionMatch = null)
+    protected void AssertHasLog(LogLevel logLevel, string name, string? message = null, Func<Exception, bool>? exceptionMatch = null)
     {
         if (HasLog(logLevel, name, message, exceptionMatch))
         {
             return;
         }
 
-        Assert.Fail($"No match. Log level = {logLevel}, name = {name}, message = '{message}'.");
+        Assert.Fail($"No match. Log level = {logLevel}, name = {name}, message = '{message ?? "(null)"}'.");
     }
 
-    protected bool HasLog(LogLevel logLevel, string name, string message, Func<Exception, bool>? exceptionMatch = null)
+    protected bool HasLog(LogLevel logLevel, string name, string? message = null, Func<Exception, bool>? exceptionMatch = null)
     {
         return Logs.Any(r =>
         {
-            var match = r.LogLevel == logLevel && r.EventId.Name == name && r.Message == message;
+            var match = r.LogLevel == logLevel && r.EventId.Name == name && (r.Message == message || message == null);
             if (exceptionMatch != null)
             {
                 match = match && r.Exception != null && exceptionMatch(r.Exception);


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2230

Two changes:

* `Timeout.InfiniteTimeSpan` is correctly tested for to never close the connection.
* The socket timeout is now the smaller value of `PooledConnectionIdleTimeout` and `PooledConnectionLifetime`.