### PR TITLE
[2.56.x] Support infinite idle connection timeout values

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -332,7 +332,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
 
             var closeSocket = false;
 
-            if (DateTime.UtcNow > socketCreatedTime.Value.Add(_socketIdleTimeout))
+            if (_socketIdleTimeout != Timeout.InfiniteTimeSpan && DateTime.UtcNow > socketCreatedTime.Value.Add(_socketIdleTimeout))
             {
                 SocketConnectivitySubchannelTransportLog.ClosingSocketFromIdleTimeoutOnCreateStream(_logger, _subchannel.Id, address, _socketIdleTimeout);
                 closeSocket = true;

--- a/test/FunctionalTests/FunctionalTestBase.cs
+++ b/test/FunctionalTests/FunctionalTestBase.cs
@@ -119,21 +119,21 @@ public class FunctionalTestBase
         AssertHasLog(LogLevel.Information, "RpcConnectionError", $"Error status code '{statusCode}' with detail '{detail}' raised.");
     }
 
-    protected void AssertHasLog(LogLevel logLevel, string name, string message, Func<Exception, bool>? exceptionMatch = null)
+    protected void AssertHasLog(LogLevel logLevel, string name, string? message = null, Func<Exception, bool>? exceptionMatch = null)
     {
         if (HasLog(logLevel, name, message, exceptionMatch))
         {
             return;
         }
 
-        Assert.Fail($"No match. Log level = {logLevel}, name = {name}, message = '{message}'.");
+        Assert.Fail($"No match. Log level = {logLevel}, name = {name}, message = '{message ?? "(null)"}'.");
     }
 
-    protected bool HasLog(LogLevel logLevel, string name, string message, Func<Exception, bool>? exceptionMatch = null)
+    protected bool HasLog(LogLevel logLevel, string name, string? message = null, Func<Exception, bool>? exceptionMatch = null)
     {
         return Logs.Any(r =>
         {
-            var match = r.LogLevel == logLevel && r.EventId.Name == name && r.Message == message;
+            var match = r.LogLevel == logLevel && r.EventId.Name == name && (r.Message == message || message == null);
             if (exceptionMatch != null)
             {
                 match = match && r.Exception != null && exceptionMatch(r.Exception);


### PR DESCRIPTION
Backport https://github.com/grpc/grpc-dotnet/pull/2231

Fixes a bug when the timeout is set to infinite. Instead of never closing the connection, the connection is always closed. Reported by a 2.56.0-pre1 user.