### PR TITLE
Update OS version detection to get version directly from Windows

### DIFF
--- a/src/Grpc.Net.Client/Internal/NtDll.cs
+++ b/src/Grpc.Net.Client/Internal/NtDll.cs
@@ -1,0 +1,69 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if !NET5_0_OR_GREATER
+
+using System.Runtime.InteropServices;
+
+namespace Grpc.Net.Client.Internal;
+
+internal static class NtDll
+{
+    [DllImport("ntdll.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    internal static extern NTSTATUS RtlGetVersion(ref OSVERSIONINFOEX versionInfo);
+
+    internal static Version DetectWindowsVersion()
+    {
+        var osVersionInfo = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+        if (RtlGetVersion(ref osVersionInfo) != NTSTATUS.STATUS_SUCCESS)
+        {
+            throw new InvalidOperationException($"Failed to call internal {nameof(RtlGetVersion)}.");
+        }
+
+        return new Version(osVersionInfo.MajorVersion, osVersionInfo.MinorVersion, osVersionInfo.BuildNumber, 0);
+    }
+
+    internal enum NTSTATUS : uint
+    {
+        /// <summary>
+        /// The operation completed successfully. 
+        /// </summary>
+        STATUS_SUCCESS = 0x00000000
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct OSVERSIONINFOEX
+    {
+        // The OSVersionInfoSize field must be set to Marshal.SizeOf(typeof(OSVERSIONINFOEX))
+        public int OSVersionInfoSize;
+        public int MajorVersion;
+        public int MinorVersion;
+        public int BuildNumber;
+        public int PlatformId;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string CSDVersion;
+        public ushort ServicePackMajor;
+        public ushort ServicePackMinor;
+        public short SuiteMask;
+        public byte ProductType;
+        public byte Reserved;
+    }
+}
+
+#endif

--- a/src/Grpc.Net.Client/Internal/NtDll.cs
+++ b/src/Grpc.Net.Client/Internal/NtDll.cs
@@ -22,6 +22,9 @@ using System.Runtime.InteropServices;
 
 namespace Grpc.Net.Client.Internal;
 
+/// <summary>
+/// Types for calling RtlGetVersion. See https://www.pinvoke.net/default.aspx/ntdll/RtlGetVersion.html
+/// </summary>
 internal static class NtDll
 {
     [DllImport("ntdll.dll", SetLastError = true, CharSet = CharSet.Unicode)]

--- a/src/Grpc.Net.Client/Internal/OperatingSystem.cs
+++ b/src/Grpc.Net.Client/Internal/OperatingSystem.cs
@@ -39,13 +39,23 @@ internal sealed class OperatingSystem : IOperatingSystem
 
     private OperatingSystem()
     {
-        IsBrowser = RuntimeInformation.IsOSPlatform(OSPlatform.Create("browser"));
 #if NET5_0_OR_GREATER
         IsAndroid = System.OperatingSystem.IsAndroid();
+        IsWindows = System.OperatingSystem.IsWindows();
+        IsBrowser = System.OperatingSystem.IsBrowser();
+        OSVersion = Environment.OSVersion.Version;
 #else
         IsAndroid = false;
-#endif
         IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        OSVersion = Environment.OSVersion.Version;
+        IsBrowser = RuntimeInformation.IsOSPlatform(OSPlatform.Create("browser"));
+
+        // Older versions of .NET report an OSVersion.Version based on Windows compatibility settings.
+        // For example, if an app running on Windows 11 is configured to be "compatible" with Windows 10
+        // then the version returned is always Windows 10.
+        //
+        // Get correct Windows version directly from Windows by calling RtlGetVersion.
+        // https://www.pinvoke.net/default.aspx/ntdll/RtlGetVersion.html
+        OSVersion = IsWindows ? NtDll.DetectWindowsVersion() : Environment.OSVersion.Version;
+#endif
     }
 }

--- a/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
+++ b/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-using System.Runtime.InteropServices;
 using Grpc.Net.Client.Internal;
 using NUnit.Framework;
 using OperatingSystem = Grpc.Net.Client.Internal.OperatingSystem;
@@ -27,14 +26,11 @@ public class OperatingSystemTests
 {
 #if !NET5_0_OR_GREATER
     [Test]
+    [Platform("Windows", Reason = "Only runs on Windows where ntdll.dll is present.")]
     public void DetectWindowsVersion_Windows_MatchesEnvironment()
     {
-        // Test only works on Windows where ntdll.dll is present.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibilty setting.
-            Assert.AreEqual(Environment.OSVersion.Version, NtDll.DetectWindowsVersion());
-        }
+        // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibilty setting.
+        Assert.AreEqual(Environment.OSVersion.Version, NtDll.DetectWindowsVersion());
     }
 #endif
 

--- a/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
+++ b/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
@@ -1,0 +1,34 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using NUnit.Framework;
+using OperatingSystem = Grpc.Net.Client.Internal.OperatingSystem;
+
+namespace Grpc.Net.Client.Tests;
+
+public class OperatingSystemTests
+{
+#if NET5_0_OR_GREATER
+    [Test]
+    public void OSVersion_ModernDotNet_MatchesEnvironment()
+    {
+        // Environment.OSVersion and OperatingSystem.OSVersion should match in .NET 5 and greater.
+        Assert.AreEqual(Environment.OSVersion.Version, OperatingSystem.Instance.OSVersion);
+    }
+#endif
+}

--- a/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
+++ b/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
@@ -26,7 +26,7 @@ public class OperatingSystemTests
 {
 #if !NET5_0_OR_GREATER
     [Test]
-    [Platform("Windows", Reason = "Only runs on Windows where ntdll.dll is present.")]
+    [Platform("Win", Reason = "Only runs on Windows where ntdll.dll is present.")]
     public void DetectWindowsVersion_Windows_MatchesEnvironment()
     {
         // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibilty setting.

--- a/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
+++ b/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
@@ -29,19 +29,19 @@ public class OperatingSystemTests
     [Test]
     public void DetectWindowsVersion_Windows_MatchesEnvironment()
     {
+        // Test only works on Windows where ntdll.dll is present.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
+            // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibilty setting.
             Assert.AreEqual(Environment.OSVersion.Version, NtDll.DetectWindowsVersion());
         }
     }
 #endif
 
-#if NET5_0_OR_GREATER
     [Test]
     public void OSVersion_ModernDotNet_MatchesEnvironment()
     {
-        // Environment.OSVersion and OperatingSystem.OSVersion should match in .NET 5 and greater.
+        // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibilty setting.
         Assert.AreEqual(Environment.OSVersion.Version, OperatingSystem.Instance.OSVersion);
     }
-#endif
 }

--- a/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
+++ b/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+using System.Runtime.InteropServices;
+using Grpc.Net.Client.Internal;
 using NUnit.Framework;
 using OperatingSystem = Grpc.Net.Client.Internal.OperatingSystem;
 
@@ -23,6 +25,17 @@ namespace Grpc.Net.Client.Tests;
 
 public class OperatingSystemTests
 {
+#if !NET5_0_OR_GREATER
+    [Test]
+    public void DetectWindowsVersion_Windows_MatchesEnvironment()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.AreEqual(Environment.OSVersion.Version, NtDll.DetectWindowsVersion());
+        }
+    }
+#endif
+
 #if NET5_0_OR_GREATER
     [Test]
     public void OSVersion_ModernDotNet_MatchesEnvironment()


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/pull/2229/files#r1288695799

`Environment.OSVersion.Version` is a problem on older versions of .NET. It reports the OS based on the compatibility settings of an app, not the real version. This isn't a problem in our unit tests because there isn't a compatibility setting, but will be a problem when Grpc.Net.Client is used in a real-world client app.

For example, an app is installed on Windows 11 but is configured to be compatible with Windows 10. The version reported is Windows 10.

Fix this by getting the correct version directly from Windows. There are two options for doing this: PInvoke Windows API or read from the registry. Using PInvoke as it's simpler.

This issue is fixed in later versions of .NET (5+). Continue to use `Environment.OSVersion.Version` in .NET 6 and later.