### PR TITLE
Force yielding after awaiting CallTask to avoid holding onto locks

### DIFF
--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -129,7 +129,8 @@ internal sealed partial class HedgingCall<TRequest, TResponse> : RetryCallBase<T
 
                 // Wait until the call has finished and then check its status code
                 // to update retry throttling tokens.
-                var status = await call.CallTask.ConfigureAwait(false);
+                // Force yield here to prevent continuation running with any locks.
+                var status = await CompatibilityHelpers.AwaitWithYieldAsync(call.CallTask).ConfigureAwait(false);
                 if (status.StatusCode == StatusCode.OK)
                 {
                     RetryAttemptCallSuccess();
@@ -202,7 +203,8 @@ internal sealed partial class HedgingCall<TRequest, TResponse> : RetryCallBase<T
             if (CommitedCallTask.IsCompletedSuccessfully() && CommitedCallTask.Result == call)
             {
                 // Wait until the commited call is finished and then clean up hedging call.
-                await call.CallTask.ConfigureAwait(false);
+                // Force yield here to prevent continuation running with any locks.
+                await CompatibilityHelpers.AwaitWithYieldAsync(call.CallTask).ConfigureAwait(false);
                 Cleanup();
             }
         }

--- a/src/Shared/CompatibilityHelpers.cs
+++ b/src/Shared/CompatibilityHelpers.cs
@@ -46,7 +46,7 @@ internal static class CompatibilityHelpers
     }
 
 #if !NET6_0_OR_GREATER
-    public async static Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellationToken)
+    public static async Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellationToken)
     {
         var tcs = new TaskCompletionSource<T>();
         using (cancellationToken.Register(static s => ((TaskCompletionSource<T>)s!).TrySetCanceled(), tcs))
@@ -70,7 +70,7 @@ internal static class CompatibilityHelpers
     public static Task<T> AwaitWithYieldAsync<T>(Task<T> callTask)
     {
         // A completed task doesn't need to yield because code after it isn't run in a continuation.
-        if (callTask.IsCompletedSuccessfully())
+        if (callTask.IsCompleted)
         {
             return callTask;
         }


### PR DESCRIPTION
Extra fix for https://github.com/grpc/grpc-dotnet/issues/2206