### PR TITLE
Upgrade QpsWorker to net8

### DIFF
--- a/perf/benchmarkapps/QpsWorker/QpsWorker.csproj
+++ b/perf/benchmarkapps/QpsWorker/QpsWorker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
To unbreak the "dotnet" GKE benchmarks in the grpc/grpc repository.
Followup for https://github.com/grpc/test-infra/pull/379