### PR TITLE
Change subchannel ID to include a channel ID

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ChannelIdProvider.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ChannelIdProvider.cs
@@ -1,0 +1,28 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+#if SUPPORT_LOAD_BALANCING
+namespace Grpc.Net.Client.Balancer.Internal;
+
+internal sealed class ChannelIdProvider
+{
+    private long _currentChannelId;
+
+    public long GetNextChannelId() => Interlocked.Increment(ref _currentChannelId);
+}
+#endif

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -518,138 +518,138 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
 
 internal static class SocketConnectivitySubchannelTransportLog
 {
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _connectingSocket =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Trace, new EventId(1, "ConnectingSocket"), "Subchannel id '{SubchannelId}' connecting socket to {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _connectingSocket =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Trace, new EventId(1, "ConnectingSocket"), "Subchannel id '{SubchannelId}' connecting socket to {Address}.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _connectedSocket =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(2, "ConnectedSocket"), "Subchannel id '{SubchannelId}' connected to socket {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _connectedSocket =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(2, "ConnectedSocket"), "Subchannel id '{SubchannelId}' connected to socket {Address}.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception> _errorConnectingSocket =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(3, "ErrorConnectingSocket"), "Subchannel id '{SubchannelId}' error connecting to socket {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception> _errorConnectingSocket =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(3, "ErrorConnectingSocket"), "Subchannel id '{SubchannelId}' error connecting to socket {Address}.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _checkingSocket =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Trace, new EventId(4, "CheckingSocket"), "Subchannel id '{SubchannelId}' checking socket {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _checkingSocket =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Trace, new EventId(4, "CheckingSocket"), "Subchannel id '{SubchannelId}' checking socket {Address}.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception> _errorCheckingSocket =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(5, "ErrorCheckingSocket"), "Subchannel id '{SubchannelId}' error checking socket {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception> _errorCheckingSocket =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(5, "ErrorCheckingSocket"), "Subchannel id '{SubchannelId}' error checking socket {Address}.");
 
-    private static readonly Action<ILogger, int, Exception> _errorSocketTimer =
-        LoggerMessage.Define<int>(LogLevel.Error, new EventId(6, "ErrorSocketTimer"), "Subchannel id '{SubchannelId}' unexpected error in check socket timer.");
+    private static readonly Action<ILogger, string, Exception> _errorSocketTimer =
+        LoggerMessage.Define<string>(LogLevel.Error, new EventId(6, "ErrorSocketTimer"), "Subchannel id '{SubchannelId}' unexpected error in check socket timer.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _creatingStream =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Trace, new EventId(7, "CreatingStream"), "Subchannel id '{SubchannelId}' creating stream for {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _creatingStream =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Trace, new EventId(7, "CreatingStream"), "Subchannel id '{SubchannelId}' creating stream for {Address}.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, int, Exception?> _disposingStream =
-        LoggerMessage.Define<int, BalancerAddress, int>(LogLevel.Trace, new EventId(8, "DisposingStream"), "Subchannel id '{SubchannelId}' disposing stream for {Address}. Transport has {ActiveStreams} active streams.");
+    private static readonly Action<ILogger, string, BalancerAddress, int, Exception?> _disposingStream =
+        LoggerMessage.Define<string, BalancerAddress, int>(LogLevel.Trace, new EventId(8, "DisposingStream"), "Subchannel id '{SubchannelId}' disposing stream for {Address}. Transport has {ActiveStreams} active streams.");
 
-    private static readonly Action<ILogger, int, Exception?> _disposingTransport =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(9, "DisposingTransport"), "Subchannel id '{SubchannelId}' disposing transport.");
+    private static readonly Action<ILogger, string, Exception?> _disposingTransport =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(9, "DisposingTransport"), "Subchannel id '{SubchannelId}' disposing transport.");
 
-    private static readonly Action<ILogger, int, Exception> _errorOnDisposingStream =
-        LoggerMessage.Define<int>(LogLevel.Error, new EventId(10, "ErrorOnDisposingStream"), "Subchannel id '{SubchannelId}' unexpected error when reacting to transport stream dispose.");
+    private static readonly Action<ILogger, string, Exception> _errorOnDisposingStream =
+        LoggerMessage.Define<string>(LogLevel.Error, new EventId(10, "ErrorOnDisposingStream"), "Subchannel id '{SubchannelId}' unexpected error when reacting to transport stream dispose.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _connectingOnCreateStream =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Trace, new EventId(11, "ConnectingOnCreateStream"), "Subchannel id '{SubchannelId}' doesn't have a connected socket available. Connecting new stream socket for {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _connectingOnCreateStream =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Trace, new EventId(11, "ConnectingOnCreateStream"), "Subchannel id '{SubchannelId}' doesn't have a connected socket available. Connecting new stream socket for {Address}.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, int, int, Exception?> _streamCreated =
-        LoggerMessage.Define<int, BalancerAddress, int, int>(LogLevel.Trace, new EventId(12, "StreamCreated"), "Subchannel id '{SubchannelId}' created stream for {Address} with {BufferedBytes} buffered bytes. Transport has {ActiveStreams} active streams.");
+    private static readonly Action<ILogger, string, BalancerAddress, int, int, Exception?> _streamCreated =
+        LoggerMessage.Define<string, BalancerAddress, int, int>(LogLevel.Trace, new EventId(12, "StreamCreated"), "Subchannel id '{SubchannelId}' created stream for {Address} with {BufferedBytes} buffered bytes. Transport has {ActiveStreams} active streams.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception> _errorPollingSocket =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(13, "ErrorPollingSocket"), "Subchannel id '{SubchannelId}' error checking socket {Address}.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception> _errorPollingSocket =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(13, "ErrorPollingSocket"), "Subchannel id '{SubchannelId}' error checking socket {Address}.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _socketPollBadState =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(14, "SocketPollBadState"), "Subchannel id '{SubchannelId}' socket {Address} is in a bad state and can't be used.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _socketPollBadState =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(14, "SocketPollBadState"), "Subchannel id '{SubchannelId}' socket {Address} is in a bad state and can't be used.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, int, Exception?> _socketReceivingAvailable =
-        LoggerMessage.Define<int, BalancerAddress, int>(LogLevel.Trace, new EventId(15, "SocketReceivingAvailable"), "Subchannel id '{SubchannelId}' socket {Address} is receiving {ReadBytesAvailableCount} available bytes.");
+    private static readonly Action<ILogger, string, BalancerAddress, int, Exception?> _socketReceivingAvailable =
+        LoggerMessage.Define<string, BalancerAddress, int>(LogLevel.Trace, new EventId(15, "SocketReceivingAvailable"), "Subchannel id '{SubchannelId}' socket {Address} is receiving {ReadBytesAvailableCount} available bytes.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _closingUnusableSocketOnCreateStream =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(16, "ClosingUnusableSocketOnCreateStream"), "Subchannel id '{SubchannelId}' socket {Address} is being closed because it can't be used. The socket either can't receive data or it has received unexpected data.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _closingUnusableSocketOnCreateStream =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(16, "ClosingUnusableSocketOnCreateStream"), "Subchannel id '{SubchannelId}' socket {Address} is being closed because it can't be used. The socket either can't receive data or it has received unexpected data.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, TimeSpan, Exception?> _closingSocketFromIdleTimeoutOnCreateStream =
-        LoggerMessage.Define<int, BalancerAddress, TimeSpan>(LogLevel.Debug, new EventId(16, "ClosingSocketFromIdleTimeoutOnCreateStream"), "Subchannel id '{SubchannelId}' socket {Address} is being closed because it exceeds the idle timeout of {SocketIdleTimeout}.");
+    private static readonly Action<ILogger, string, BalancerAddress, TimeSpan, Exception?> _closingSocketFromIdleTimeoutOnCreateStream =
+        LoggerMessage.Define<string, BalancerAddress, TimeSpan>(LogLevel.Debug, new EventId(16, "ClosingSocketFromIdleTimeoutOnCreateStream"), "Subchannel id '{SubchannelId}' socket {Address} is being closed because it exceeds the idle timeout of {SocketIdleTimeout}.");
 
-    public static void ConnectingSocket(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void ConnectingSocket(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _connectingSocket(logger, subchannelId, address, null);
     }
 
-    public static void ConnectedSocket(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void ConnectedSocket(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _connectedSocket(logger, subchannelId, address, null);
     }
 
-    public static void ErrorConnectingSocket(ILogger logger, int subchannelId, BalancerAddress address, Exception ex)
+    public static void ErrorConnectingSocket(ILogger logger, string subchannelId, BalancerAddress address, Exception ex)
     {
         _errorConnectingSocket(logger, subchannelId, address, ex);
     }
 
-    public static void CheckingSocket(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void CheckingSocket(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _checkingSocket(logger, subchannelId, address, null);
     }
 
-    public static void ErrorCheckingSocket(ILogger logger, int subchannelId, BalancerAddress address, Exception ex)
+    public static void ErrorCheckingSocket(ILogger logger, string subchannelId, BalancerAddress address, Exception ex)
     {
         _errorCheckingSocket(logger, subchannelId, address, ex);
     }
 
-    public static void ErrorSocketTimer(ILogger logger, int subchannelId, Exception ex)
+    public static void ErrorSocketTimer(ILogger logger, string subchannelId, Exception ex)
     {
         _errorSocketTimer(logger, subchannelId, ex);
     }
 
-    public static void CreatingStream(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void CreatingStream(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _creatingStream(logger, subchannelId, address, null);
     }
 
-    public static void DisposingStream(ILogger logger, int subchannelId, BalancerAddress address, int activeStreams)
+    public static void DisposingStream(ILogger logger, string subchannelId, BalancerAddress address, int activeStreams)
     {
         _disposingStream(logger, subchannelId, address, activeStreams, null);
     }
 
-    public static void DisposingTransport(ILogger logger, int subchannelId)
+    public static void DisposingTransport(ILogger logger, string subchannelId)
     {
         _disposingTransport(logger, subchannelId, null);
     }
 
-    public static void ErrorOnDisposingStream(ILogger logger, int subchannelId, Exception ex)
+    public static void ErrorOnDisposingStream(ILogger logger, string subchannelId, Exception ex)
     {
         _errorOnDisposingStream(logger, subchannelId, ex);
     }
 
-    public static void ConnectingOnCreateStream(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void ConnectingOnCreateStream(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _connectingOnCreateStream(logger, subchannelId, address, null);
     }
 
-    public static void StreamCreated(ILogger logger, int subchannelId, BalancerAddress address, int bufferedBytes, int activeStreams)
+    public static void StreamCreated(ILogger logger, string subchannelId, BalancerAddress address, int bufferedBytes, int activeStreams)
     {
         _streamCreated(logger, subchannelId, address, bufferedBytes, activeStreams, null);
     }
 
-    public static void ErrorPollingSocket(ILogger logger, int subchannelId, BalancerAddress address, Exception ex)
+    public static void ErrorPollingSocket(ILogger logger, string subchannelId, BalancerAddress address, Exception ex)
     {
         _errorPollingSocket(logger, subchannelId, address, ex);
     }
 
-    public static void SocketPollBadState(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void SocketPollBadState(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _socketPollBadState(logger, subchannelId, address, null);
     }
 
-    public static void SocketReceivingAvailable(ILogger logger, int subchannelId, BalancerAddress address, int readBytesAvailableCount)
+    public static void SocketReceivingAvailable(ILogger logger, string subchannelId, BalancerAddress address, int readBytesAvailableCount)
     {
         _socketReceivingAvailable(logger, subchannelId, address, readBytesAvailableCount, null);
     }
 
-    public static void ClosingUnusableSocketOnCreateStream(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void ClosingUnusableSocketOnCreateStream(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _closingUnusableSocketOnCreateStream(logger, subchannelId, address, null);
     }
 
-    public static void ClosingSocketFromIdleTimeoutOnCreateStream(ILogger logger, int subchannelId, BalancerAddress address, TimeSpan socketIdleTimeout)
+    public static void ClosingSocketFromIdleTimeoutOnCreateStream(ILogger logger, string subchannelId, BalancerAddress address, TimeSpan socketIdleTimeout)
     {
         _closingSocketFromIdleTimeoutOnCreateStream(logger, subchannelId, address, socketIdleTimeout, null);
     }

--- a/src/Grpc.Net.Client/Balancer/PickFirstBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/PickFirstBalancer.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -202,18 +202,18 @@ internal class RequestConnectionPicker : PickFirstPicker
 
 internal static class PickFirstBalancerLog
 {
-    private static readonly Action<ILogger, int, ConnectivityState, string, Exception?> _processingSubchannelStateChanged =
-        LoggerMessage.Define<int, ConnectivityState, string>(LogLevel.Trace, new EventId(1, "ProcessingSubchannelStateChanged"), "Processing subchannel id '{SubchannelId}' state changed to {State}. Detail: '{Detail}'.");
+    private static readonly Action<ILogger, string, ConnectivityState, string, Exception?> _processingSubchannelStateChanged =
+        LoggerMessage.Define<string, ConnectivityState, string>(LogLevel.Trace, new EventId(1, "ProcessingSubchannelStateChanged"), "Processing subchannel id '{SubchannelId}' state changed to {State}. Detail: '{Detail}'.");
 
-    private static readonly Action<ILogger, int, Exception?> _ignoredSubchannelStateChange =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(2, "IgnoredSubchannelStateChange"), "Ignored state change because of unknown subchannel id '{SubchannelId}'.");
+    private static readonly Action<ILogger, string, Exception?> _ignoredSubchannelStateChange =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(2, "IgnoredSubchannelStateChange"), "Ignored state change because of unknown subchannel id '{SubchannelId}'.");
 
-    public static void ProcessingSubchannelStateChanged(ILogger logger, int subchannelId, ConnectivityState state, Status status)
+    public static void ProcessingSubchannelStateChanged(ILogger logger, string subchannelId, ConnectivityState state, Status status)
     {
         _processingSubchannelStateChanged(logger, subchannelId, state, status.Detail, status.DebugException);
     }
 
-    public static void IgnoredSubchannelStateChange(ILogger logger, int subchannelId)
+    public static void IgnoredSubchannelStateChange(ILogger logger, string subchannelId)
     {
         _ignoredSubchannelStateChange(logger, subchannelId, null);
     }

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -40,7 +40,7 @@ public sealed class Subchannel : IDisposable
     internal readonly List<BalancerAddress> _addresses;
     internal readonly object Lock;
     internal ISubchannelTransport Transport => _transport;
-    internal int Id { get; }
+    internal string Id { get; }
 
     /// <summary>
     /// Connectivity state is internal rather than public because it can be updated by multiple threads while
@@ -445,58 +445,58 @@ public sealed class Subchannel : IDisposable
 
 internal static class SubchannelLog
 {
-    private static readonly Action<ILogger, int, string, Exception?> _subchannelCreated =
-        LoggerMessage.Define<int, string>(LogLevel.Debug, new EventId(1, "SubchannelCreated"), "Subchannel id '{SubchannelId}' created with addresses: {Addresses}");
+    private static readonly Action<ILogger, string, string, Exception?> _subchannelCreated =
+        LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(1, "SubchannelCreated"), "Subchannel id '{SubchannelId}' created with addresses: {Addresses}");
 
-    private static readonly Action<ILogger, int, Exception?> _addressesUpdatedWhileConnecting =
-        LoggerMessage.Define<int>(LogLevel.Debug, new EventId(2, "AddressesUpdatedWhileConnecting"), "Subchannel id '{SubchannelId}' is connecting when its addresses are updated. Restarting connect.");
+    private static readonly Action<ILogger, string, Exception?> _addressesUpdatedWhileConnecting =
+        LoggerMessage.Define<string>(LogLevel.Debug, new EventId(2, "AddressesUpdatedWhileConnecting"), "Subchannel id '{SubchannelId}' is connecting when its addresses are updated. Restarting connect.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _connectedAddressNotInUpdatedAddresses =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Debug, new EventId(3, "ConnectedAddressNotInUpdatedAddresses"), "Subchannel id '{SubchannelId}' current address '{CurrentAddress}' is not in the updated addresses.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _connectedAddressNotInUpdatedAddresses =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(3, "ConnectedAddressNotInUpdatedAddresses"), "Subchannel id '{SubchannelId}' current address '{CurrentAddress}' is not in the updated addresses.");
 
-    private static readonly Action<ILogger, int, Exception?> _connectionRequested =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(4, "ConnectionRequested"), "Subchannel id '{SubchannelId}' connection requested.");
+    private static readonly Action<ILogger, string, Exception?> _connectionRequested =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(4, "ConnectionRequested"), "Subchannel id '{SubchannelId}' connection requested.");
 
-    private static readonly Action<ILogger, int, ConnectivityState, Exception?> _connectionRequestedInNonIdleState =
-        LoggerMessage.Define<int, ConnectivityState>(LogLevel.Debug, new EventId(5, "ConnectionRequestedInNonIdleState"), "Subchannel id '{SubchannelId}' connection requested in non-idle state of {State}.");
+    private static readonly Action<ILogger, string, ConnectivityState, Exception?> _connectionRequestedInNonIdleState =
+        LoggerMessage.Define<string, ConnectivityState>(LogLevel.Debug, new EventId(5, "ConnectionRequestedInNonIdleState"), "Subchannel id '{SubchannelId}' connection requested in non-idle state of {State}.");
 
-    private static readonly Action<ILogger, int, Exception?> _connectingTransport =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(6, "ConnectingTransport"), "Subchannel id '{SubchannelId}' connecting to transport.");
+    private static readonly Action<ILogger, string, Exception?> _connectingTransport =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(6, "ConnectingTransport"), "Subchannel id '{SubchannelId}' connecting to transport.");
 
-    private static readonly Action<ILogger, int, TimeSpan, Exception?> _startingConnectBackoff =
-        LoggerMessage.Define<int, TimeSpan>(LogLevel.Trace, new EventId(7, "StartingConnectBackoff"), "Subchannel id '{SubchannelId}' starting connect backoff of {BackoffDuration}.");
+    private static readonly Action<ILogger, string, TimeSpan, Exception?> _startingConnectBackoff =
+        LoggerMessage.Define<string, TimeSpan>(LogLevel.Trace, new EventId(7, "StartingConnectBackoff"), "Subchannel id '{SubchannelId}' starting connect backoff of {BackoffDuration}.");
 
-    private static readonly Action<ILogger, int, Exception?> _connectBackoffInterrupted =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(8, "ConnectBackoffInterrupted"), "Subchannel id '{SubchannelId}' connect backoff interrupted.");
+    private static readonly Action<ILogger, string, Exception?> _connectBackoffInterrupted =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(8, "ConnectBackoffInterrupted"), "Subchannel id '{SubchannelId}' connect backoff interrupted.");
 
-    private static readonly Action<ILogger, int, Exception?> _connectCanceled =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(9, "ConnectCanceled"), "Subchannel id '{SubchannelId}' connect canceled.");
+    private static readonly Action<ILogger, string, Exception?> _connectCanceled =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(9, "ConnectCanceled"), "Subchannel id '{SubchannelId}' connect canceled.");
 
-    private static readonly Action<ILogger, int, Exception?> _connectError =
-        LoggerMessage.Define<int>(LogLevel.Error, new EventId(10, "ConnectError"), "Subchannel id '{SubchannelId}' unexpected error while connecting to transport.");
+    private static readonly Action<ILogger, string, Exception?> _connectError =
+        LoggerMessage.Define<string>(LogLevel.Error, new EventId(10, "ConnectError"), "Subchannel id '{SubchannelId}' unexpected error while connecting to transport.");
 
-    private static readonly Action<ILogger, int, ConnectivityState, string, Exception?> _subchannelStateChanged =
-        LoggerMessage.Define<int, ConnectivityState, string>(LogLevel.Debug, new EventId(11, "SubchannelStateChanged"), "Subchannel id '{SubchannelId}' state changed to {State}. Detail: '{Detail}'.");
+    private static readonly Action<ILogger, string, ConnectivityState, string, Exception?> _subchannelStateChanged =
+        LoggerMessage.Define<string, ConnectivityState, string>(LogLevel.Debug, new EventId(11, "SubchannelStateChanged"), "Subchannel id '{SubchannelId}' state changed to {State}. Detail: '{Detail}'.");
 
-    private static readonly Action<ILogger, int, string, Exception?> _stateChangedRegistrationCreated =
-        LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(12, "StateChangedRegistrationCreated"), "Subchannel id '{SubchannelId}' state changed registration '{RegistrationId}' created.");
+    private static readonly Action<ILogger, string, string, Exception?> _stateChangedRegistrationCreated =
+        LoggerMessage.Define<string, string>(LogLevel.Trace, new EventId(12, "StateChangedRegistrationCreated"), "Subchannel id '{SubchannelId}' state changed registration '{RegistrationId}' created.");
 
-    private static readonly Action<ILogger, int, string, Exception?> _stateChangedRegistrationRemoved =
-        LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(13, "StateChangedRegistrationRemoved"), "Subchannel id '{SubchannelId}' state changed registration '{RegistrationId}' removed.");
+    private static readonly Action<ILogger, string, string, Exception?> _stateChangedRegistrationRemoved =
+        LoggerMessage.Define<string, string>(LogLevel.Trace, new EventId(13, "StateChangedRegistrationRemoved"), "Subchannel id '{SubchannelId}' state changed registration '{RegistrationId}' removed.");
 
-    private static readonly Action<ILogger, int, string, Exception?> _executingStateChangedRegistration =
-        LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(14, "ExecutingStateChangedRegistration"), "Subchannel id '{SubchannelId}' executing state changed registration '{RegistrationId}'.");
+    private static readonly Action<ILogger, string, string, Exception?> _executingStateChangedRegistration =
+        LoggerMessage.Define<string, string>(LogLevel.Trace, new EventId(14, "ExecutingStateChangedRegistration"), "Subchannel id '{SubchannelId}' executing state changed registration '{RegistrationId}'.");
 
-    private static readonly Action<ILogger, int, Exception?> _noStateChangedRegistrations =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(15, "NoStateChangedRegistrations"), "Subchannel id '{SubchannelId}' has no state changed registrations.");
+    private static readonly Action<ILogger, string, Exception?> _noStateChangedRegistrations =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(15, "NoStateChangedRegistrations"), "Subchannel id '{SubchannelId}' has no state changed registrations.");
 
-    private static readonly Action<ILogger, int, BalancerAddress, Exception?> _subchannelPreserved =
-        LoggerMessage.Define<int, BalancerAddress>(LogLevel.Trace, new EventId(16, "SubchannelPreserved"), "Subchannel id '{SubchannelId}' matches address '{Address}' and is preserved.");
+    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _subchannelPreserved =
+        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Trace, new EventId(16, "SubchannelPreserved"), "Subchannel id '{SubchannelId}' matches address '{Address}' and is preserved.");
 
-    private static readonly Action<ILogger, int, Exception?> _cancelingConnect =
-        LoggerMessage.Define<int>(LogLevel.Debug, new EventId(17, "CancelingConnect"), "Subchannel id '{SubchannelId}' canceling connect.");
+    private static readonly Action<ILogger, string, Exception?> _cancelingConnect =
+        LoggerMessage.Define<string>(LogLevel.Debug, new EventId(17, "CancelingConnect"), "Subchannel id '{SubchannelId}' canceling connect.");
 
-    public static void SubchannelCreated(ILogger logger, int subchannelId, IReadOnlyList<BalancerAddress> addresses)
+    public static void SubchannelCreated(ILogger logger, string subchannelId, IReadOnlyList<BalancerAddress> addresses)
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
@@ -505,82 +505,82 @@ internal static class SubchannelLog
         }
     }
 
-    public static void AddressesUpdatedWhileConnecting(ILogger logger, int subchannelId)
+    public static void AddressesUpdatedWhileConnecting(ILogger logger, string subchannelId)
     {
         _addressesUpdatedWhileConnecting(logger, subchannelId, null);
     }
 
-    public static void ConnectedAddressNotInUpdatedAddresses(ILogger logger, int subchannelId, BalancerAddress currentAddress)
+    public static void ConnectedAddressNotInUpdatedAddresses(ILogger logger, string subchannelId, BalancerAddress currentAddress)
     {
         _connectedAddressNotInUpdatedAddresses(logger, subchannelId, currentAddress, null);
     }
 
-    public static void ConnectionRequested(ILogger logger, int subchannelId)
+    public static void ConnectionRequested(ILogger logger, string subchannelId)
     {
         _connectionRequested(logger, subchannelId, null);
     }
 
-    public static void ConnectionRequestedInNonIdleState(ILogger logger, int subchannelId, ConnectivityState state)
+    public static void ConnectionRequestedInNonIdleState(ILogger logger, string subchannelId, ConnectivityState state)
     {
         _connectionRequestedInNonIdleState(logger, subchannelId, state, null);
     }
 
-    public static void ConnectingTransport(ILogger logger, int subchannelId)
+    public static void ConnectingTransport(ILogger logger, string subchannelId)
     {
         _connectingTransport(logger, subchannelId, null);
     }
 
-    public static void StartingConnectBackoff(ILogger logger, int subchannelId, TimeSpan delay)
+    public static void StartingConnectBackoff(ILogger logger, string subchannelId, TimeSpan delay)
     {
         _startingConnectBackoff(logger, subchannelId, delay, null);
     }
 
-    public static void ConnectBackoffInterrupted(ILogger logger, int subchannelId)
+    public static void ConnectBackoffInterrupted(ILogger logger, string subchannelId)
     {
         _connectBackoffInterrupted(logger, subchannelId, null);
     }
 
-    public static void ConnectCanceled(ILogger logger, int subchannelId)
+    public static void ConnectCanceled(ILogger logger, string subchannelId)
     {
         _connectCanceled(logger, subchannelId, null);
     }
 
-    public static void ConnectError(ILogger logger, int subchannelId, Exception ex)
+    public static void ConnectError(ILogger logger, string subchannelId, Exception ex)
     {
         _connectError(logger, subchannelId, ex);
     }
 
-    public static void SubchannelStateChanged(ILogger logger, int subchannelId, ConnectivityState state, Status status)
+    public static void SubchannelStateChanged(ILogger logger, string subchannelId, ConnectivityState state, Status status)
     {
         _subchannelStateChanged(logger, subchannelId, state, status.Detail, status.DebugException);
     }
 
-    public static void ExecutingStateChangedRegistration(ILogger logger, int subchannelId, string registrationId)
+    public static void ExecutingStateChangedRegistration(ILogger logger, string subchannelId, string registrationId)
     {
         _executingStateChangedRegistration(logger, subchannelId, registrationId, null);
     }
 
-    public static void NoStateChangedRegistrations(ILogger logger, int subchannelId)
+    public static void NoStateChangedRegistrations(ILogger logger, string subchannelId)
     {
         _noStateChangedRegistrations(logger, subchannelId, null);
     }
 
-    public static void StateChangedRegistrationCreated(ILogger logger, int subchannelId, string registrationId)
+    public static void StateChangedRegistrationCreated(ILogger logger, string subchannelId, string registrationId)
     {
         _stateChangedRegistrationCreated(logger, subchannelId, registrationId, null);
     }
 
-    public static void StateChangedRegistrationRemoved(ILogger logger, int subchannelId, string registrationId)
+    public static void StateChangedRegistrationRemoved(ILogger logger, string subchannelId, string registrationId)
     {
         _stateChangedRegistrationRemoved(logger, subchannelId, registrationId, null);
     }
 
-    public static void SubchannelPreserved(ILogger logger, int subchannelId, BalancerAddress address)
+    public static void SubchannelPreserved(ILogger logger, string subchannelId, BalancerAddress address)
     {
         _subchannelPreserved(logger, subchannelId, address, null);
     }
 
-    public static void CancelingConnect(ILogger logger, int subchannelId)
+    public static void CancelingConnect(ILogger logger, string subchannelId)
     {
         _cancelingConnect(logger, subchannelId, null);
     }

--- a/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/SubchannelsLoadBalancer.cs
@@ -325,30 +325,30 @@ public abstract class SubchannelsLoadBalancer : LoadBalancer
 
 internal static class SubchannelsLoadBalancerLog
 {
-    private static readonly Action<ILogger, int, ConnectivityState, string, Exception?> _processingSubchannelStateChanged =
-        LoggerMessage.Define<int, ConnectivityState, string>(LogLevel.Trace, new EventId(1, "ProcessingSubchannelStateChanged"), "Processing subchannel id '{SubchannelId}' state changed to {State}. Detail: '{Detail}'.");
+    private static readonly Action<ILogger, string, ConnectivityState, string, Exception?> _processingSubchannelStateChanged =
+        LoggerMessage.Define<string, ConnectivityState, string>(LogLevel.Trace, new EventId(1, "ProcessingSubchannelStateChanged"), "Processing subchannel id '{SubchannelId}' state changed to {State}. Detail: '{Detail}'.");
 
-    private static readonly Action<ILogger, int, Exception?> _ignoredSubchannelStateChange =
-        LoggerMessage.Define<int>(LogLevel.Trace, new EventId(2, "IgnoredSubchannelStateChange"), "Ignored state change because of unknown subchannel id '{SubchannelId}'.");
+    private static readonly Action<ILogger, string, Exception?> _ignoredSubchannelStateChange =
+        LoggerMessage.Define<string>(LogLevel.Trace, new EventId(2, "IgnoredSubchannelStateChange"), "Ignored state change because of unknown subchannel id '{SubchannelId}'.");
 
     private static readonly Action<ILogger, Exception?> _connectionsUnchanged =
         LoggerMessage.Define(LogLevel.Trace, new EventId(3, "ConnectionsUnchanged"), "Connections unchanged.");
 
-    private static readonly Action<ILogger, int, ConnectivityState, Exception?> _refreshingResolverForSubchannel =
-        LoggerMessage.Define<int, ConnectivityState>(LogLevel.Trace, new EventId(4, "RefreshingResolverForSubchannel"), "Refreshing resolver because subchannel id '{SubchannelId}' is in state {State}.");
+    private static readonly Action<ILogger, string, ConnectivityState, Exception?> _refreshingResolverForSubchannel =
+        LoggerMessage.Define<string, ConnectivityState>(LogLevel.Trace, new EventId(4, "RefreshingResolverForSubchannel"), "Refreshing resolver because subchannel id '{SubchannelId}' is in state {State}.");
 
-    private static readonly Action<ILogger, int, ConnectivityState, Exception?> _requestingConnectionForSubchannel =
-        LoggerMessage.Define<int, ConnectivityState>(LogLevel.Trace, new EventId(5, "RequestingConnectionForSubchannel"), "Requesting connection for subchannel id '{SubchannelId}' because it is in state {State}.");
+    private static readonly Action<ILogger, string, ConnectivityState, Exception?> _requestingConnectionForSubchannel =
+        LoggerMessage.Define<string, ConnectivityState>(LogLevel.Trace, new EventId(5, "RequestingConnectionForSubchannel"), "Requesting connection for subchannel id '{SubchannelId}' because it is in state {State}.");
 
     private static readonly Action<ILogger, int, string, Exception?> _creatingReadyPicker =
         LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(6, "CreatingReadyPicker"), "Creating ready picker with {SubchannelCount} subchannels: {Subchannels}");
 
-    public static void ProcessingSubchannelStateChanged(ILogger logger, int subchannelId, ConnectivityState state, Status status)
+    public static void ProcessingSubchannelStateChanged(ILogger logger, string subchannelId, ConnectivityState state, Status status)
     {
         _processingSubchannelStateChanged(logger, subchannelId, state, status.Detail, status.DebugException);
     }
 
-    public static void IgnoredSubchannelStateChange(ILogger logger, int subchannelId)
+    public static void IgnoredSubchannelStateChange(ILogger logger, string subchannelId)
     {
         _ignoredSubchannelStateChange(logger, subchannelId, null);
     }
@@ -358,12 +358,12 @@ internal static class SubchannelsLoadBalancerLog
         _connectionsUnchanged(logger, null);
     }
 
-    public static void RefreshingResolverForSubchannel(ILogger logger, int subchannelId, ConnectivityState state)
+    public static void RefreshingResolverForSubchannel(ILogger logger, string subchannelId, ConnectivityState state)
     {
         _refreshingResolverForSubchannel(logger, subchannelId, state, null);
     }
 
-    public static void RequestingConnectionForSubchannel(ILogger logger, int subchannelId, ConnectivityState state)
+    public static void RequestingConnectionForSubchannel(ILogger logger, string subchannelId, ConnectivityState state)
     {
         _requestingConnectionForSubchannel(logger, subchannelId, state, null);
     }

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -179,7 +179,7 @@ public class ConnectionTests : FunctionalTestBase
         Assert.AreEqual("Test!", response.Message);
 
         AssertHasLog(LogLevel.Debug, "ClosingSocketFromIdleTimeoutOnCreateStream");
-        AssertHasLog(LogLevel.Trace, "ConnectingOnCreateStream", "Subchannel id '1' doesn't have a connected socket available. Connecting new stream socket for 127.0.0.1:50051.");
+        AssertHasLog(LogLevel.Trace, "ConnectingOnCreateStream");
     }
 
     public async Task Active_UnaryCall_InfiniteConnectionIdleTimeout_SocketNotClosed()


### PR DESCRIPTION
Subchannel ID in log messages is there to help understand what is happening to a connection. Each subchannel id is unique to a channel. However, this is a problem if there are multiple channels. All channels will have a subchannel ID of 1, for example. There isn't an easy way to tell them apart in log messages.

This PR changes subchannel ID to combine a static channel ID with the subchannel number.

* Before: `1`, `2`, `1`, `2`
* After: `1-1`, `1-2`, `2-1`, `2-2`

Changing the log value type could break someone. However, it would only impact someone who has written a custom log provider and is accessing the `SubchannelId` value and casting it to an int. The likelihood of anyone accessing this internal/transient ID like this is minimal.