### PR TITLE
Reduce logger allocations by not using generic CreateLogger

### DIFF
--- a/src/Grpc.Net.Client/Balancer/DnsResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/DnsResolver.cs
@@ -59,7 +59,7 @@ internal sealed class DnsResolver : PollingResolver
         _dnsAddress = addressParsed.Host;
         _port = addressParsed.Port == -1 ? defaultPort : addressParsed.Port;
         _refreshInterval = refreshInterval;
-        _logger = loggerFactory.CreateLogger<DnsResolver>();
+        _logger = loggerFactory.CreateLogger(typeof(DnsResolver));
     }
 
     protected override void OnStarted()

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -45,7 +45,7 @@ internal class BalancerHttpHandler : DelegatingHandler
         : base(innerHandler)
     {
         _manager = manager;
-        _logger = manager.LoggerFactory.CreateLogger<BalancerHttpHandler>();
+        _logger = manager.LoggerFactory.CreateLogger(typeof(BalancerHttpHandler));
     }
 
     internal static bool IsSocketsHttpHandlerSetup(SocketsHttpHandler socketsHttpHandler)

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -61,7 +61,7 @@ internal sealed class ConnectionManager : IDisposable, IChannelControlHelper
         _resolverStartedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         _channelId = _channelIdProvider.GetNextChannelId();
 
-        Logger = loggerFactory.CreateLogger<ConnectionManager>();
+        Logger = loggerFactory.CreateLogger(typeof(ConnectionManager));
         LoggerFactory = loggerFactory;
         BackoffPolicyFactory = backoffPolicyFactory;
         _subchannels = new List<Subchannel>();

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -69,7 +69,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
         ILoggerFactory loggerFactory,
         Func<Socket, DnsEndPoint, CancellationToken, ValueTask>? socketConnect)
     {
-        _logger = loggerFactory.CreateLogger<SocketConnectivitySubchannelTransport>();
+        _logger = loggerFactory.CreateLogger(typeof(SocketConnectivitySubchannelTransport));
         _subchannel = subchannel;
         _socketPingInterval = socketPingInterval;
         ConnectTimeout = connectTimeout;

--- a/src/Grpc.Net.Client/Balancer/PickFirstBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/PickFirstBalancer.cs
@@ -49,7 +49,7 @@ internal sealed class PickFirstBalancer : LoadBalancer
     public PickFirstBalancer(IChannelControlHelper controller, ILoggerFactory loggerFactory)
     {
         _controller = controller;
-        _logger = loggerFactory.CreateLogger<PickFirstBalancer>();
+        _logger = loggerFactory.CreateLogger(typeof(PickFirstBalancer));
     }
 
     private void ResolverError(Status status)

--- a/src/Grpc.Net.Client/Balancer/PollingResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/PollingResolver.cs
@@ -72,7 +72,7 @@ public abstract class PollingResolver : Resolver
     {
         ArgumentNullThrowHelper.ThrowIfNull(loggerFactory);
 
-        _logger = loggerFactory.CreateLogger<PollingResolver>();
+        _logger = loggerFactory.CreateLogger(typeof(PollingResolver));
         _backoffPolicyFactory = backoffPolicyFactory;
     }
 

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -118,7 +118,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         OperatingSystem = channelOptions.ResolveService<IOperatingSystem>(Internal.OperatingSystem.Instance);
         RandomGenerator = channelOptions.ResolveService<IRandomGenerator>(new RandomGenerator());
         Debugger = channelOptions.ResolveService<IDebugger>(new CachedDebugger());
-        Logger = LoggerFactory.CreateLogger<GrpcChannel>();
+        Logger = LoggerFactory.CreateLogger(typeof(GrpcChannel));
 
 #if SUPPORT_LOAD_BALANCING
         InitialReconnectBackoff = channelOptions.InitialReconnectBackoff;

--- a/src/Grpc.Net.Client/Internal/Retry/ChannelRetryThrottling.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/ChannelRetryThrottling.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -26,7 +26,7 @@ internal class ChannelRetryThrottling
     private readonly object _lock = new object();
     private readonly double _tokenRatio;
     private readonly int _maxTokens;
-    private readonly ILogger<ChannelRetryThrottling> _logger;
+    private readonly ILogger _logger;
 
     private double _tokenCount;
     private readonly double _tokenThreshold;
@@ -41,7 +41,7 @@ internal class ChannelRetryThrottling
         _maxTokens = maxTokens;
         _tokenCount = maxTokens;
         _tokenThreshold = _tokenCount / 2;
-        _logger = loggerFactory.CreateLogger<ChannelRetryThrottling>();
+        _logger = loggerFactory.CreateLogger(typeof(ChannelRetryThrottling));
     }
 
     public bool IsRetryThrottlingActive()


### PR DESCRIPTION
Non-generic `CreateLogger` caches logger instances on the log name. Meanwhile, `CreateLogger<T>` always creates a new instance: https://github.com/dotnet/runtime/blob/ea2022818b117bead26fc19c8ebb47b455907cab/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerFactoryExtensions.cs#L20-L25

These loggers last the lifetime of a channel, so the cost of the generic create is low. But this saves a few allocations per channel for apps with multiple channels.