### PR TITLE
Update call debugger display to show status code

### DIFF
--- a/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
+++ b/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
@@ -35,7 +35,7 @@ internal static class CallDebuggerHelpers
         debugText += $"IsComplete = {((status != null) ? "true" : "false")}";
         if (status != null)
         {
-            debugText += $", Status = {status}";
+            debugText += $", StatusCode = {status.Value.StatusCode}";
         }
         return debugText;
     }

--- a/test/FunctionalTests/Client/AuthorizationTests.cs
+++ b/test/FunctionalTests/Client/AuthorizationTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -70,7 +70,6 @@ public class AuthorizationTests : FunctionalTestBase
 
         // Act
         await call.ResponseAsync.DefaultTimeout();
-
 
         Assert.AreEqual("Bearer token!", authorization);
     }


### PR DESCRIPTION
The status can include a long description that stretches the debug display of calls. Simplify by just displaying the status code, e.g. `StatusCode = OK`

The status is still easily accessible from the type proxy.