### PR TITLE
Add transport status to subchannel picked log

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -316,7 +316,7 @@ internal sealed class ConnectionManager : IDisposable, IChannelControlHelper
 
                     if (address != null)
                     {
-                        ConnectionManagerLog.PickResultSuccessful(Logger, subchannel.Id, address);
+                        ConnectionManagerLog.PickResultSuccessful(Logger, subchannel.Id, address, subchannel.Transport.TransportStatus);
                         return (subchannel, address, result.SubchannelCallTracker);
                     }
                     else
@@ -478,8 +478,8 @@ internal static class ConnectionManagerLog
     private static readonly Action<ILogger, Exception?> _pickStarted =
         LoggerMessage.Define(LogLevel.Trace, new EventId(5, "PickStarted"), "Pick started.");
 
-    private static readonly Action<ILogger, string, BalancerAddress, Exception?> _pickResultSuccessful =
-        LoggerMessage.Define<string, BalancerAddress>(LogLevel.Debug, new EventId(6, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}.");
+    private static readonly Action<ILogger, string, BalancerAddress, TransportStatus, Exception?> _pickResultSuccessful =
+        LoggerMessage.Define<string, BalancerAddress, TransportStatus>(LogLevel.Debug, new EventId(6, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}. Transport state: {TransportState}");
 
     private static readonly Action<ILogger, string, Exception?> _pickResultSubchannelNoCurrentAddress =
         LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, "PickResultSubchannelNoCurrentAddress"), "Picked subchannel id '{SubchannelId}' doesn't have a current address.");
@@ -528,9 +528,9 @@ internal static class ConnectionManagerLog
         _pickStarted(logger, null);
     }
 
-    public static void PickResultSuccessful(ILogger logger, string subchannelId, BalancerAddress currentAddress)
+    public static void PickResultSuccessful(ILogger logger, string subchannelId, BalancerAddress currentAddress, TransportStatus transportState)
     {
-        _pickResultSuccessful(logger, subchannelId, currentAddress, null);
+        _pickResultSuccessful(logger, subchannelId, currentAddress, transportState, null);
     }
 
     public static void PickResultSubchannelNoCurrentAddress(ILogger logger, string subchannelId)

--- a/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ConnectionManager.cs
@@ -479,7 +479,7 @@ internal static class ConnectionManagerLog
         LoggerMessage.Define(LogLevel.Trace, new EventId(5, "PickStarted"), "Pick started.");
 
     private static readonly Action<ILogger, string, BalancerAddress, TransportStatus, Exception?> _pickResultSuccessful =
-        LoggerMessage.Define<string, BalancerAddress, TransportStatus>(LogLevel.Debug, new EventId(6, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}. Transport state: {TransportState}");
+        LoggerMessage.Define<string, BalancerAddress, TransportStatus>(LogLevel.Debug, new EventId(6, "PickResultSuccessful"), "Successfully picked subchannel id '{SubchannelId}' with address {CurrentAddress}. Transport status: {TransportStatus}");
 
     private static readonly Action<ILogger, string, Exception?> _pickResultSubchannelNoCurrentAddress =
         LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, "PickResultSubchannelNoCurrentAddress"), "Picked subchannel id '{SubchannelId}' doesn't have a current address.");
@@ -528,9 +528,9 @@ internal static class ConnectionManagerLog
         _pickStarted(logger, null);
     }
 
-    public static void PickResultSuccessful(ILogger logger, string subchannelId, BalancerAddress currentAddress, TransportStatus transportState)
+    public static void PickResultSuccessful(ILogger logger, string subchannelId, BalancerAddress currentAddress, TransportStatus transportStatus)
     {
-        _pickResultSuccessful(logger, subchannelId, currentAddress, transportState, null);
+        _pickResultSuccessful(logger, subchannelId, currentAddress, transportStatus, null);
     }
 
     public static void PickResultSubchannelNoCurrentAddress(ILogger logger, string subchannelId)

--- a/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
@@ -40,7 +40,7 @@ internal interface ISubchannelTransport : IDisposable
 
 internal enum TransportStatus
 {
-    Unknown,
+    NotConnected,
     Passive,
     InitialSocket,
     ActiveStream

--- a/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
@@ -30,19 +30,20 @@ internal interface ISubchannelTransport : IDisposable
 {
     BalancerAddress? CurrentAddress { get; }
     TimeSpan? ConnectTimeout { get; }
+    TransportStatus TransportStatus { get; }
 
-#if NET5_0_OR_GREATER
     ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken);
-#endif
-
-#if !NETSTANDARD2_0 && !NET462
-    ValueTask<ConnectResult>
-#else
-    Task<ConnectResult>
-#endif
-        TryConnectAsync(ConnectContext context);
+    ValueTask<ConnectResult> TryConnectAsync(ConnectContext context);
 
     void Disconnect();
+}
+
+internal enum TransportStatus
+{
+    Unknown,
+    Passive,
+    InitialSocket,
+    ActiveStream
 }
 
 internal enum ConnectResult

--- a/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
@@ -44,6 +44,7 @@ internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
 
     public BalancerAddress? CurrentAddress => _currentAddress;
     public TimeSpan? ConnectTimeout { get; }
+    public TransportStatus TransportStatus => TransportStatus.Passive;
 
     public void Disconnect()
     {
@@ -51,13 +52,7 @@ internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
         _subchannel.UpdateConnectivityState(ConnectivityState.Idle, "Disconnected.");
     }
 
-    public
-#if !NETSTANDARD2_0 && !NET462
-        ValueTask<ConnectResult>
-#else
-        Task<ConnectResult>
-#endif
-        TryConnectAsync(ConnectContext context)
+    public ValueTask<ConnectResult> TryConnectAsync(ConnectContext context)
     {
         Debug.Assert(_subchannel._addresses.Count == 1);
         Debug.Assert(CurrentAddress == null);
@@ -68,11 +63,7 @@ internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
         _currentAddress = currentAddress;
         _subchannel.UpdateConnectivityState(ConnectivityState.Ready, "Passively connected.");
 
-#if !NETSTANDARD2_0 && !NET462
         return new ValueTask<ConnectResult>(ConnectResult.Success);
-#else
-        return Task.FromResult(ConnectResult.Success);
-#endif
     }
 
     public void Dispose()
@@ -80,11 +71,9 @@ internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
         _currentAddress = null;
     }
 
-#if NET5_0_OR_GREATER
     public ValueTask<Stream> GetStreamAsync(BalancerAddress address, CancellationToken cancellationToken)
     {
         throw new NotSupportedException();
     }
-#endif
 }
 #endif

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -96,7 +96,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
                 {
                     return TransportStatus.ActiveStream;
                 }
-                return TransportStatus.Unknown;
+                return TransportStatus.NotConnected;
             }
         }
     }

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -82,6 +82,24 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
     private object Lock => _subchannel.Lock;
     public BalancerAddress? CurrentAddress => _currentAddress;
     public TimeSpan? ConnectTimeout { get; }
+    public TransportStatus TransportStatus
+    {
+        get
+        {
+            lock (Lock)
+            {
+                if (_initialSocket != null)
+                {
+                    return TransportStatus.InitialSocket;
+                }
+                if (_activeStreams.Count > 0)
+                {
+                    return TransportStatus.ActiveStream;
+                }
+                return TransportStatus.Unknown;
+            }
+        }
+    }
 
     // For testing. Take a copy under lock for thread-safety.
     internal IReadOnlyList<ActiveStream> GetActiveStreams()

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/TestSubChannelTransport.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -40,6 +40,7 @@ internal class TestSubchannelTransport : ISubchannelTransport
 
     public BalancerAddress? CurrentAddress { get; private set; }
     public TimeSpan? ConnectTimeout => _factory.ConnectTimeout;
+    public TransportStatus TransportStatus => TransportStatus.Passive;
 
     public Task TryConnectTask => _connectTcs.Task;
 


### PR DESCRIPTION
Help debug call issues by reporting information about the subchannel transport status when a subchannel is picked.