### PR TITLE
proposal: Build changelog based on previous stable version

### DIFF
--- a/doc/release_process.md
+++ b/doc/release_process.md
@@ -40,7 +40,7 @@ release that the new release depends on.
 - Build the signed nuget packages and push them to nuget.org (internal process). **These are the stable grpc-dotnet packages.**
 
 - Create a new release and tag in https://github.com/grpc/grpc-dotnet/releases (by creating the tag from the current release branch).
-  This is the stable release. Fill in the release notes and list changes since the last previous _stable_ version.
+  This is the stable release. Fill in the release notes and list changes since the previous _stable_ version.
 
 ### After the release
 

--- a/doc/release_process.md
+++ b/doc/release_process.md
@@ -40,7 +40,7 @@ release that the new release depends on.
 - Build the signed nuget packages and push them to nuget.org (internal process). **These are the stable grpc-dotnet packages.**
 
 - Create a new release and tag in https://github.com/grpc/grpc-dotnet/releases (by creating the tag from the current release branch).
-  This is the stable release. Fill in the release notes.
+  This is the stable release. Fill in the release notes and list changes since the last previous _stable_ version.
 
 ### After the release
 


### PR DESCRIPTION
Build changelog based on previous stable version to ensure end-users have a good overview what changed instead of having to go through every single preview version to compile a list.

Relates to https://github.com/grpc/grpc-dotnet/pull/2251#issuecomment-1697640346