### PR TITLE
Update ServiceBinderBase.AddMethod annotations to allow null handler

### DIFF
--- a/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -39,7 +39,7 @@ internal class ProviderServiceBinder<
         _declaringType = declaringType;
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse>? handler)
     {
         var (invoker, metadata) = CreateModelCore<ClientStreamingServerMethod<TService, TRequest, TResponse>>(
             method.Name,
@@ -48,7 +48,7 @@ internal class ProviderServiceBinder<
         _context.AddClientStreamingMethod<TRequest, TResponse>(method, metadata, invoker);
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse>? handler)
     {
         var (invoker, metadata) = CreateModelCore<DuplexStreamingServerMethod<TService, TRequest, TResponse>>(
             method.Name,
@@ -57,7 +57,7 @@ internal class ProviderServiceBinder<
         _context.AddDuplexStreamingMethod<TRequest, TResponse>(method, metadata, invoker);
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse>? handler)
     {
         var (invoker, metadata) = CreateModelCore<ServerStreamingServerMethod<TService, TRequest, TResponse>>(
             method.Name,
@@ -66,7 +66,7 @@ internal class ProviderServiceBinder<
         _context.AddServerStreamingMethod<TRequest, TResponse>(method, metadata, invoker);
     }
 
-    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse>? handler)
     {
         var (invoker, metadata) = CreateModelCore<UnaryServerMethod<TService, TRequest, TResponse>>(
             method.Name,

--- a/src/Grpc.Core.Api/ServiceBinderBase.cs
+++ b/src/Grpc.Core.Api/ServiceBinderBase.cs
@@ -40,7 +40,7 @@ public class ServiceBinderBase
     /// <param name="handler">The method handler.</param>
     public virtual void AddMethod<TRequest, TResponse>(
         Method<TRequest, TResponse> method,
-        UnaryServerMethod<TRequest, TResponse> handler)
+        UnaryServerMethod<TRequest, TResponse>? handler)
             where TRequest : class
             where TResponse : class
     {
@@ -56,7 +56,7 @@ public class ServiceBinderBase
     /// <param name="handler">The method handler.</param>
     public virtual void AddMethod<TRequest, TResponse>(
         Method<TRequest, TResponse> method,
-        ClientStreamingServerMethod<TRequest, TResponse> handler)
+        ClientStreamingServerMethod<TRequest, TResponse>? handler)
             where TRequest : class
             where TResponse : class
     {
@@ -72,7 +72,7 @@ public class ServiceBinderBase
     /// <param name="handler">The method handler.</param>
     public virtual void AddMethod<TRequest, TResponse>(
         Method<TRequest, TResponse> method,
-        ServerStreamingServerMethod<TRequest, TResponse> handler)
+        ServerStreamingServerMethod<TRequest, TResponse>? handler)
             where TRequest : class
             where TResponse : class
     {
@@ -88,7 +88,7 @@ public class ServiceBinderBase
     /// <param name="handler">The method handler.</param>
     public virtual void AddMethod<TRequest, TResponse>(
         Method<TRequest, TResponse> method,
-        DuplexStreamingServerMethod<TRequest, TResponse> handler)
+        DuplexStreamingServerMethod<TRequest, TResponse>? handler)
             where TRequest : class
             where TResponse : class
     {


### PR DESCRIPTION
See https://github.com/grpc/grpc/pull/33878#discussion_r1315241617

Generated code can pass in a null handler. Update Grpc.Core.Api annotations to match reality.

This isn't a breaking change. If a library inherits from ServiceBinderBase and has nullable annotations enabled, it will get a warning to prompt the developer to update the overloads to include `?`. This is standard behavior when changing nullable annotations. There is no impact on runtime behavior.