### PR TITLE
Add request and channel to call debugging

### DIFF
--- a/src/Grpc.Core.Api/AsyncClientStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncClientStreamingCall.cs
@@ -180,12 +180,13 @@ public sealed class AsyncClientStreamingCall<TRequest, TResponse> : IDisposable
             _call = call;
         }
 
-        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.GetAwaiter().GetResult() : null;
         public Metadata? Trailers => CallDebuggerHelpers.GetTrailers(_call.callState);
         public IClientStreamWriter<TRequest> RequestStream => _call.RequestStream;
         public TResponse? Response => _call.ResponseAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseAsync.Result : default;
+        public CallDebuggerMethodDebugView? Method => CallDebuggerHelpers.GetDebugValue<IMethod>(_call.callState, CallDebuggerHelpers.MethodKey) is { } method ? new CallDebuggerMethodDebugView(method) : null;
+        public ChannelBase? Channel => CallDebuggerHelpers.GetDebugValue<ChannelBase>(_call.callState, CallDebuggerHelpers.ChannelKey);
     }
 }

--- a/src/Grpc.Core.Api/AsyncDuplexStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncDuplexStreamingCall.cs
@@ -157,12 +157,13 @@ public sealed class AsyncDuplexStreamingCall<TRequest, TResponse> : IDisposable
             _call = call;
         }
 
-        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;
         public Metadata? Trailers => CallDebuggerHelpers.GetTrailers(_call.callState);
         public IAsyncStreamReader<TResponse> ResponseStream => _call.ResponseStream;
         public IClientStreamWriter<TRequest> RequestStream => _call.RequestStream;
+        public CallDebuggerMethodDebugView? Method => CallDebuggerHelpers.GetDebugValue<IMethod>(_call.callState, CallDebuggerHelpers.MethodKey) is { } method ? new CallDebuggerMethodDebugView(method) : null;
+        public ChannelBase? Channel => CallDebuggerHelpers.GetDebugValue<ChannelBase>(_call.callState, CallDebuggerHelpers.ChannelKey);
     }
 }

--- a/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
+++ b/src/Grpc.Core.Api/AsyncServerStreamingCall.cs
@@ -138,11 +138,13 @@ public sealed class AsyncServerStreamingCall<TResponse> : IDisposable
             _call = call;
         }
 
-        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;
         public Metadata? Trailers => CallDebuggerHelpers.GetTrailers(_call.callState);
         public IAsyncStreamReader<TResponse> ResponseStream => _call.ResponseStream;
+        public CallDebuggerMethodDebugView? Method => CallDebuggerHelpers.GetDebugValue<IMethod>(_call.callState, CallDebuggerHelpers.MethodKey) is { } method ? new CallDebuggerMethodDebugView(method) : null;
+        public ChannelBase? Channel => CallDebuggerHelpers.GetDebugValue<ChannelBase>(_call.callState, CallDebuggerHelpers.ChannelKey);
+        public object? Request => CallDebuggerHelpers.GetDebugValue<object>(_call.callState, CallDebuggerHelpers.RequestKey);
     }
 }

--- a/src/Grpc.Core.Api/AsyncUnaryCall.cs
+++ b/src/Grpc.Core.Api/AsyncUnaryCall.cs
@@ -161,11 +161,13 @@ public sealed class AsyncUnaryCall<TResponse> : IDisposable
             _call = call;
         }
 
-        public CallDebuggerMethodDebugView? Method => _call.callState.State is IMethod method ? new CallDebuggerMethodDebugView(method) : null;
         public bool IsComplete => CallDebuggerHelpers.GetStatus(_call.callState) != null;
         public Status? Status => CallDebuggerHelpers.GetStatus(_call.callState);
         public Metadata? ResponseHeaders => _call.ResponseHeadersAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseHeadersAsync.Result : null;
         public Metadata? Trailers => CallDebuggerHelpers.GetTrailers(_call.callState);
         public TResponse? Response => _call.ResponseAsync.Status == TaskStatus.RanToCompletion ? _call.ResponseAsync.Result : default;
+        public CallDebuggerMethodDebugView? Method => CallDebuggerHelpers.GetDebugValue<IMethod>(_call.callState, CallDebuggerHelpers.MethodKey) is { } method ? new CallDebuggerMethodDebugView(method) : null;
+        public ChannelBase? Channel => CallDebuggerHelpers.GetDebugValue<ChannelBase>(_call.callState, CallDebuggerHelpers.ChannelKey);
+        public object? Request => CallDebuggerHelpers.GetDebugValue<object>(_call.callState, CallDebuggerHelpers.RequestKey);
     }
 }

--- a/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
+++ b/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Grpc.Core.Internal;
@@ -54,11 +55,11 @@ internal static class CallDebuggerHelpers
         // We want to get information about a call to display during debugging, but Grpc.Core.Api does
         // doesn't have access to the implementation's internal fields.
         // GetDebugValue accesses values by IEnumerable + key from the implementation state.
-        if (callState.State is IEnumerable enumerable)
+        if (callState.State is IEnumerable<KeyValuePair<string, object>> enumerable)
         {
-            foreach (DictionaryEntry entry in enumerable)
+            foreach (var entry in enumerable)
             {
-                if ((string)entry.Key == key)
+                if (entry.Key == key)
                 {
                     return (T)entry.Value;
                 }

--- a/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
+++ b/src/Grpc.Core.Api/Internal/CallDebuggerHelpers.cs
@@ -61,7 +61,12 @@ internal static class CallDebuggerHelpers
             {
                 if (entry.Key == key)
                 {
-                    return (T)entry.Value;
+                    if (entry.Value is T t)
+                    {
+                        return t;
+                    }
+
+                    return null;
                 }
             }
         }

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -53,6 +54,7 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
     // These are set depending on the type of gRPC call
     private TaskCompletionSource<TResponse>? _responseTcs;
+    private TRequest? _request;
 
     public int MessagesWritten { get; private set; }
     public int MessagesRead { get; private set; }
@@ -99,12 +101,11 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
     public object? CallWrapper { get; set; }
 
-    MethodType IMethod.Type => Method.Type;
-    string IMethod.ServiceName => Method.ServiceName;
-    string IMethod.Name => Method.Name;
-    string IMethod.FullName => Method.FullName;
-
-    public void StartUnary(TRequest request) => StartUnaryCore(CreatePushUnaryContent(request));
+    public void StartUnary(TRequest request)
+    {
+        _request = request;
+        StartUnaryCore(CreatePushUnaryContent(request));
+    }
 
     public void StartClientStreaming()
     {
@@ -1161,4 +1162,6 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
     {
         diagnosticSource.Write(name, value);
     }
+
+    public IEnumerator GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(Channel, Method, _request);
 }

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -1163,5 +1163,6 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         diagnosticSource.Write(name, value);
     }
 
-    public IEnumerator GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(Channel, Method, _request);
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(Channel, Method, _request);
 }

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Collections;
 using System.Net.Http.Headers;
 using Grpc.Core;
 using Grpc.Net.Compression;
@@ -81,6 +82,17 @@ internal static class GrpcProtocolConstants
 #else
             string.Join(",", compressionProviders.Select(p => p.Key));
 #endif
+    }
+
+    public const string MethodKey = "Method";
+    public const string ChannelKey = "Channel";
+    public const string RequestKey = "Request";
+
+    public static IEnumerator GetDebugEnumerator(ChannelBase channel, IMethod method, object? request)
+    {
+        yield return new DictionaryEntry(ChannelKey, channel);
+        yield return new DictionaryEntry(MethodKey, method);
+        yield return new DictionaryEntry(RequestKey, request);
     }
 
     static GrpcProtocolConstants()

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -16,7 +16,7 @@
 
 #endregion
 
-using System.Collections;
+using System.Collections.Generic;
 using System.Net.Http.Headers;
 using Grpc.Core;
 using Grpc.Net.Compression;
@@ -88,11 +88,14 @@ internal static class GrpcProtocolConstants
     public const string ChannelKey = "Channel";
     public const string RequestKey = "Request";
 
-    public static IEnumerator GetDebugEnumerator(ChannelBase channel, IMethod method, object? request)
+    public static IEnumerator<KeyValuePair<string, object>> GetDebugEnumerator(ChannelBase channel, IMethod method, object? request)
     {
-        yield return new DictionaryEntry(ChannelKey, channel);
-        yield return new DictionaryEntry(MethodKey, method);
-        yield return new DictionaryEntry(RequestKey, request);
+        yield return new KeyValuePair<string, object>(ChannelKey, channel);
+        yield return new KeyValuePair<string, object>(MethodKey, method);
+        if (request != null)
+        {
+            yield return new KeyValuePair<string, object>(RequestKey, request);
+        }
     }
 
     static GrpcProtocolConstants()

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -84,6 +84,10 @@ internal static class GrpcProtocolConstants
 #endif
     }
 
+    /// <summary>
+    /// Gets key value pairs used by debugging. These are provided as an enumerator instead of a dictionary
+    /// because it's one method to implement an enumerator on gRPC calls compared to a dozen members for a dictionary.
+    /// </summary>
     public static IEnumerator<KeyValuePair<string, object>> GetDebugEnumerator(ChannelBase channel, IMethod method, object? request)
     {
         const string MethodKey = "Method";

--- a/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcProtocolConstants.cs
@@ -84,12 +84,12 @@ internal static class GrpcProtocolConstants
 #endif
     }
 
-    public const string MethodKey = "Method";
-    public const string ChannelKey = "Channel";
-    public const string RequestKey = "Request";
-
     public static IEnumerator<KeyValuePair<string, object>> GetDebugEnumerator(ChannelBase channel, IMethod method, object? request)
     {
+        const string MethodKey = "Method";
+        const string ChannelKey = "Channel";
+        const string RequestKey = "Request";
+
         yield return new KeyValuePair<string, object>(ChannelKey, channel);
         yield return new KeyValuePair<string, object>(MethodKey, method);
         if (request != null)

--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -16,13 +16,12 @@
 
 #endregion
 
-using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
 
 namespace Grpc.Net.Client.Internal;
 
-internal interface IGrpcCall<TRequest, TResponse> : IDisposable, IEnumerable
+internal interface IGrpcCall<TRequest, TResponse> : IDisposable, IEnumerable<KeyValuePair<string, object>>
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/IGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/IGrpcCall.cs
@@ -16,12 +16,13 @@
 
 #endregion
 
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
 
 namespace Grpc.Net.Client.Internal;
 
-internal interface IGrpcCall<TRequest, TResponse> : IDisposable, IMethod
+internal interface IGrpcCall<TRequest, TResponse> : IDisposable, IEnumerable
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -594,5 +594,6 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
         throw new NotSupportedException();
     }
 
-    public IEnumerator GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(Channel, Method, _request);
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(Channel, Method, _request);
 }

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
@@ -35,6 +36,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
     private RetryCallBaseClientStreamWriter<TRequest, TResponse>? _retryBaseClientStreamWriter;
     private Task<TResponse>? _responseTask;
     private Task<Metadata>? _responseHeadersTask;
+    private TRequest? _request;
 
     // Internal for unit testing.
     internal CancellationTokenRegistration? _ctsRegistration;
@@ -63,11 +65,6 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
     protected List<ReadOnlyMemory<byte>> BufferedMessages { get; }
     protected long CurrentCallBufferSize { get; set; }
     protected bool BufferedCurrentMessage { get; set; }
-
-    MethodType IMethod.Type => Method.Type;
-    string IMethod.ServiceName => Method.ServiceName;
-    string IMethod.Name => Method.Name;
-    string IMethod.FullName => Method.FullName;
 
     protected RetryCallBase(GrpcChannel channel, Method<TRequest, TResponse> method, CallOptions options, string loggerName, int retryAttempts)
     {
@@ -170,6 +167,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
 
     public void StartUnary(TRequest request)
     {
+        _request = request;
         StartCore(call => call.StartUnaryCore(CreatePushUnaryContent(request, call)));
     }
 
@@ -520,7 +518,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
 
     protected StatusGrpcCall<TRequest, TResponse> CreateStatusCall(Status status)
     {
-        var call = new StatusGrpcCall<TRequest, TResponse>(status, Channel, Method, MessagesRead);
+        var call = new StatusGrpcCall<TRequest, TResponse>(status, Channel, Method, MessagesRead, _request);
         call.CallWrapper = CallWrapper;
         return call;
     }
@@ -595,4 +593,6 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
     {
         throw new NotSupportedException();
     }
+
+    public IEnumerator GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(Channel, Method, _request);
 }

--- a/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
@@ -122,7 +122,8 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
         }
     }
 
-    public IEnumerator GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(_channel, _method, _request);
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(_channel, _method, _request);
 
     private sealed class StatusClientStreamWriter : IClientStreamWriter<TRequest>
     {

--- a/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/StatusGrpcCall.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Grpc.Core;
 
@@ -28,6 +29,7 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
     private readonly Status _status;
     private readonly GrpcChannel _channel;
     private readonly Method<TRequest, TResponse> _method;
+    private readonly TRequest? _request;
     private IClientStreamWriter<TRequest>? _clientStreamWriter;
     private IAsyncStreamReader<TResponse>? _clientStreamReader;
 
@@ -39,17 +41,13 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
 
     public object? CallWrapper { get; set; }
 
-    MethodType IMethod.Type => _method.Type;
-    string IMethod.ServiceName => _method.ServiceName;
-    string IMethod.Name => _method.Name;
-    string IMethod.FullName => _method.FullName;
-
-    public StatusGrpcCall(Status status, GrpcChannel channel, Method<TRequest, TResponse> method, int messagesRead)
+    public StatusGrpcCall(Status status, GrpcChannel channel, Method<TRequest, TResponse> method, int messagesRead, TRequest? request)
     {
         _status = status;
         _channel = channel;
         _method = method;
         MessagesRead = messagesRead;
+        _request = request;
     }
 
     public void Dispose()
@@ -123,6 +121,8 @@ internal sealed class StatusGrpcCall<TRequest, TResponse> : IGrpcCall<TRequest, 
             return new RpcException(status);
         }
     }
+
+    public IEnumerator GetEnumerator() => GrpcProtocolConstants.GetDebugEnumerator(_channel, _method, _request);
 
     private sealed class StatusClientStreamWriter : IClientStreamWriter<TRequest>
     {


### PR DESCRIPTION
This adds the channel and request (for unary and server streaming calls) to gRPC debugging.

This change is tricky because types are split across projects and don't have access to each other's internal views. The hack workaround is to use `IEnumerable` to return values. Nothing bad is exposed to the user and if another channel implementation doesn't implement enumerable and return values with the expected keys then the debugging information is just missing.

![image](https://github.com/grpc/grpc-dotnet/assets/303201/9ceddddb-f8ad-41f8-b962-57bd74b8c43a)