### PR TITLE
Support disabling load balancing with SocketsHttpHandler.Properties

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -292,6 +292,14 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
                 }
             }
 
+            // Load balancing has been disabled on the SocketsHttpHandler.
+            if (socketsHttpHandler.Properties["__GrpcLoadBalancingDisabled"] is bool value && value)
+            {   
+                type = HttpHandlerType.Custom;
+                connectTimeout = null;
+                connectionIdleTimeout = null;
+            }
+
             // If a proxy is specified then requests could be sent via an SSL tunnel.
             // A CONNECT request is made to the proxy to establish the transport stream and then
             // gRPC calls are sent via stream. This feature isn't supported by load balancer.

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -293,8 +293,9 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
             }
 
             // Load balancing has been disabled on the SocketsHttpHandler.
-            if (socketsHttpHandler.Properties["__GrpcLoadBalancingDisabled"] is bool value && value)
-            {   
+            if (socketsHttpHandler.Properties.TryGetValue("__GrpcLoadBalancingDisabled", out var value)
+                && value is bool loadBalancingDisabled && loadBalancingDisabled)
+            {
                 type = HttpHandlerType.Custom;
                 connectTimeout = null;
                 connectionIdleTimeout = null;


### PR DESCRIPTION
Allows someone to configure `SocketsHttpHandler` without using gRPC load balancing.

The setting uses the object bag `SocketsHttpHandler.Properties`. The UI for configuring this value is ugly but it isn't intended for general use.