### PR TITLE
Add debugger display to Status

### DIFF
--- a/src/Grpc.Core.Api/Status.cs
+++ b/src/Grpc.Core.Api/Status.cs
@@ -15,6 +15,7 @@
 #endregion
 
 using System;
+using System.Diagnostics;
 
 namespace Grpc.Core;
 
@@ -22,6 +23,7 @@ namespace Grpc.Core;
 /// <summary>
 /// Represents RPC result, which consists of <see cref="StatusCode"/> and an optional detail string.
 /// </summary>
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public struct Status
 {
     /// <summary>
@@ -92,5 +94,20 @@ public struct Status
                 $" DebugException=\"{DebugException.GetType()}: {DebugException.Message}\")";
         }
         return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\")";
+    }
+
+    private string DebuggerToString()
+    {
+        var text = $"StatusCode = {StatusCode}";
+        if (!string.IsNullOrEmpty(Detail))
+        {
+            text += $@", Detail = ""{Detail}""";
+        }
+        if (DebugException != null)
+        {
+            text += $@", DebugException = ""{DebugException.GetType()}: {DebugException.Message}""";
+        }
+
+        return text;
     }
 }


### PR DESCRIPTION
Make the display of `Status` more consistent with other .NET types in the debugger.

note: `Status` already overrides `ToString()`. I didn't change `ToString()` because it's used at runtime to build exception messages.

Before (see `Status` property):

![image](https://github.com/grpc/grpc-dotnet/assets/303201/243eaa1f-87a2-48b0-a18f-215828c5be83)

After:

![image](https://github.com/grpc/grpc-dotnet/assets/303201/ea4037d3-1557-4bf6-aa99-90a6399cd951)
