### PR TITLE
Fix HttpContext race condition by copying values to reader and writer

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -233,5 +233,18 @@ internal static class GrpcProtocolHelpers
     internal static bool ShouldSkipHeader(string name)
     {
         return name.StartsWith(':') || GrpcProtocolConstants.FilteredHeaders.Contains(name);
+    }
+
+    internal static IHttpRequestLifetimeFeature GetRequestLifetimeFeature(HttpContext httpContext)
+    {
+        var lifetimeFeature = httpContext.Features.Get<IHttpRequestLifetimeFeature>();
+        if (lifetimeFeature is null)
+        {
+            // This should only run in tests where the HttpContext is manually created.
+            lifetimeFeature = new HttpRequestLifetimeFeature();
+            httpContext.Features.Set(lifetimeFeature);
+        }
+
+        return lifetimeFeature;
     }
 }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
@@ -45,7 +45,7 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
         // This is done to avoid a race condition when reading them from HttpContext later when running in a separate thread.
         _bodyReader = _serverCallContext.HttpContext.Request.BodyReader;
         // Copy lifetime feature because HttpContext.RequestAborted on .NET 6 doesn't return the real cancellation token.
-        _requestLifetimeFeature = _serverCallContext.HttpContext.Features.Get<IHttpRequestLifetimeFeature>()!;
+        _requestLifetimeFeature = GrpcProtocolHelpers.GetRequestLifetimeFeature(_serverCallContext.HttpContext);
     }
 
     public TRequest Current { get; private set; } = default!;

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
@@ -39,6 +39,9 @@ internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> 
     {
         _serverCallContext = serverCallContext;
         _deserializer = deserializer;
+
+        // Copy HttpContext values.
+        // This is done to avoid a race condition when reading them from HttpContext later when running in a separate thread.
         _bodyReader = _serverCallContext.HttpContext.Request.BodyReader;
         _cancellationToken = _serverCallContext.HttpContext.RequestAborted;
     }

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -48,7 +48,7 @@ internal class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TRespons
         // This is done to avoid a race condition when reading them from HttpContext later when running in a separate thread.
         _bodyWriter = context.HttpContext.Response.BodyWriter;
         // Copy lifetime feature because HttpContext.RequestAborted on .NET 6 doesn't return the real cancellation token.
-        _requestLifetimeFeature = context.HttpContext.Features.Get<IHttpRequestLifetimeFeature>()!;
+        _requestLifetimeFeature = GrpcProtocolHelpers.GetRequestLifetimeFeature(context.HttpContext);
     }
 
     public WriteOptions? WriteOptions

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -41,9 +41,12 @@ internal class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TRespons
     {
         _context = context;
         _serializer = serializer;
+        _writeLock = new object();
+
+        // Copy HttpContext values.
+        // This is done to avoid a race condition when reading them from HttpContext later when running in a separate thread.
         _bodyWriter = context.HttpContext.Response.BodyWriter;
         _cancellationToken = context.HttpContext.RequestAborted;
-        _writeLock = new object();
     }
 
     public WriteOptions? WriteOptions

--- a/test/Grpc.AspNetCore.Server.Tests/DuplexStreamingServerCallHandlerTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/DuplexStreamingServerCallHandlerTests.cs
@@ -34,11 +34,9 @@ public class DuplexStreamingServerCallHandlerTests
     private static readonly Marshaller<TestMessage> _marshaller = new Marshaller<TestMessage>((message, context) => { context.Complete(Array.Empty<byte>()); }, context => new TestMessage());
 
     [Test]
-    public async Task Invoke_ReadAndWrite_Success()
+    public async Task HandleCallAsync_ConcurrentReadAndWrite_Success()
     {
         // Arrange
-        var serviceActivator = new TestGrpcServiceActivator<TestService>();
-        var ex = new Exception("Exception!");
         var invoker = new DuplexStreamingServerMethodInvoker<TestService, TestMessage, TestMessage>(
             (service, reader, writer, context) =>
             {
@@ -49,7 +47,7 @@ public class DuplexStreamingServerCallHandlerTests
             },
             new Method<TestMessage, TestMessage>(MethodType.DuplexStreaming, "test", "test", _marshaller, _marshaller),
             HttpContextServerCallContextHelper.CreateMethodOptions(),
-            serviceActivator);
+            new TestGrpcServiceActivator<TestService>());
         var handler = new DuplexStreamingServerCallHandler<TestService, TestMessage, TestMessage>(invoker, NullLoggerFactory.Instance);
 
         // Verify there isn't a race condition when reading/writing on seperate threads.

--- a/test/Grpc.AspNetCore.Server.Tests/DuplexStreamingServerCallHandlerTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/DuplexStreamingServerCallHandlerTests.cs
@@ -1,0 +1,69 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.AspNetCore.Server.Internal.CallHandlers;
+using Grpc.AspNetCore.Server.Tests.TestObjects;
+using Grpc.Core;
+using Grpc.Shared.Server;
+using Grpc.Tests.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Grpc.AspNetCore.Server.Tests;
+
+[TestFixture]
+public class DuplexStreamingServerCallHandlerTests
+{
+    private static readonly Marshaller<TestMessage> _marshaller = new Marshaller<TestMessage>((message, context) => { context.Complete(Array.Empty<byte>()); }, context => new TestMessage());
+
+    [Test]
+    public async Task Invoke_ReadAndWrite_Success()
+    {
+        // Arrange
+        var serviceActivator = new TestGrpcServiceActivator<TestService>();
+        var ex = new Exception("Exception!");
+        var invoker = new DuplexStreamingServerMethodInvoker<TestService, TestMessage, TestMessage>(
+            (service, reader, writer, context) =>
+            {
+                var message = new TestMessage();
+                var readTask = Task.Run(() => reader.MoveNext());
+                var writeTask = Task.Run(() => writer.WriteAsync(message));
+                return Task.WhenAll(readTask, writeTask);
+            },
+            new Method<TestMessage, TestMessage>(MethodType.DuplexStreaming, "test", "test", _marshaller, _marshaller),
+            HttpContextServerCallContextHelper.CreateMethodOptions(),
+            serviceActivator);
+        var handler = new DuplexStreamingServerCallHandler<TestService, TestMessage, TestMessage>(invoker, NullLoggerFactory.Instance);
+
+        // Verify there isn't a race condition when reading/writing on seperate threads.
+        // This test primarily exists to ensure that the stream reader and stream writer aren't accessing non-thread safe APIs on HttpContext.
+        for (var i = 0; i < 10_000; i++)
+        {
+            var httpContext = HttpContextHelpers.CreateContext();
+
+            // Act
+            await handler.HandleCallAsync(httpContext);
+
+            // Assert
+            var trailers = httpContext.Features.Get<IHttpResponseTrailersFeature>()!.Trailers;
+            Assert.AreEqual("0", trailers["grpc-status"].ToString());
+        }
+    }
+}


### PR DESCRIPTION
Potential fix to `HttpContext.RequestAborted` race condition. Fix is to copy fields need from the context when reader and writer are created.