### PR TITLE
Update Grpc.Tools to 2.60.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
 
     <!-- gRPC -->
-    <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.60.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
     <PackageVersion Include="Grpc.Core.Api" Version="$(GrpcDotNetPackageVersion)"/>
     <PackageVersion Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />


### PR DESCRIPTION
Prerequisite for starting 2.60.0 release.

Note: This is the only thing I'll do for 2.60.0 release. I expect someone else will make the usual PR to update the package version numbers.