### PR TITLE
Bump dev version to 2.61.0-dev on master branch

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,13 +2,13 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.58.0-dev</GrpcDotnetVersion>
-    
+    <GrpcDotnetVersion>2.61.0-dev</GrpcDotnetVersion>
+
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>
 
     <!-- file version of all grpc-dotnet -->
-    <GrpcDotnetAssemblyFileVersion>2.58.0.0</GrpcDotnetAssemblyFileVersion>
+    <GrpcDotnetAssemblyFileVersion>2.61.0.0</GrpcDotnetAssemblyFileVersion>
 
   </PropertyGroup>
 </Project>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -36,10 +36,10 @@ public static class VersionInfo
     /// <summary>
     /// Current <c>AssemblyFileVersion</c> of gRPC C# assemblies
     /// </summary>
-    public const string CurrentAssemblyFileVersion = "2.58.0.0";
+    public const string CurrentAssemblyFileVersion = "2.61.0.0";
 
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.58.0-dev";
+    public const string CurrentVersion = "2.61.0-dev";
 }


### PR DESCRIPTION
Similar to #2227

Bumping version string on the `master` branch here. Looks like the version hasn't been updated for a while.

gRPC core has already released version 1.60. So we are catching up, bumping the `master` branch version string to `2.61.0-dev`.