### PR TITLE
Bumping version string to 2.60.0-pre1 in release branch

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,13 +2,13 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.58.0-dev</GrpcDotnetVersion>
-    
+    <GrpcDotnetVersion>2.60.0-pre1</GrpcDotnetVersion>
+
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>
 
     <!-- file version of all grpc-dotnet -->
-    <GrpcDotnetAssemblyFileVersion>2.58.0.0</GrpcDotnetAssemblyFileVersion>
+    <GrpcDotnetAssemblyFileVersion>2.60.0.0</GrpcDotnetAssemblyFileVersion>
 
   </PropertyGroup>
 </Project>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -36,10 +36,10 @@ public static class VersionInfo
     /// <summary>
     /// Current <c>AssemblyFileVersion</c> of gRPC C# assemblies
     /// </summary>
-    public const string CurrentAssemblyFileVersion = "2.58.0.0";
+    public const string CurrentAssemblyFileVersion = "2.60.0.0";
 
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.58.0-dev";
+    public const string CurrentVersion = "2.60.0-pre1";
 }


### PR DESCRIPTION
This is to bump version string to `2.60.0-pre1` in the newly created release branch `v2.60.x`