### PR TITLE
Add key services tests for service and interceptor

### DIFF
--- a/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
@@ -21,7 +21,6 @@ using Grpc.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using NUnit.Framework;
-using static Grpc.AspNetCore.Server.Tests.DefaultGrpcInterceptorActivatorTests;
 
 namespace Grpc.AspNetCore.Server.Tests;
 

--- a/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/DefaultGrpcServiceActivatorTests.cs
@@ -18,8 +18,10 @@
 
 using Grpc.AspNetCore.Server.Internal;
 using Grpc.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using NUnit.Framework;
+using static Grpc.AspNetCore.Server.Tests.DefaultGrpcInterceptorActivatorTests;
 
 namespace Grpc.AspNetCore.Server.Tests;
 
@@ -46,6 +48,22 @@ public class DefaultGrpcServiceActivatorTests
             return default;
         }
     }
+#if NET8_0_OR_GREATER
+    public class GrpcServiceWithKeyedService
+    {
+        public GrpcServiceWithKeyedService([FromKeyedServices("test")] KeyedClass c)
+        {
+            C = c;
+        }
+
+        public KeyedClass C { get; }
+    }
+
+    public class KeyedClass
+    {
+        public required string Key { get; init; }
+    }
+#endif
 
     [Test]
     public void Create_NotResolvedFromServiceProvider_CreatedByActivator()
@@ -60,6 +78,25 @@ public class DefaultGrpcServiceActivatorTests
         Assert.NotNull(handle.Instance);
         Assert.IsTrue(handle.Created);
     }
+
+#if NET8_0_OR_GREATER
+    [Test]
+    public void Create_KeyedService_CreatedByActivator()
+    {
+        // Arrange
+        var activator = new DefaultGrpcServiceActivator<GrpcServiceWithKeyedService>();
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton("test", new KeyedClass { Key = "test" });
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Act
+        var handle = activator.Create(serviceProvider);
+
+        // Assert
+        var interceptor = handle.Instance;
+        Assert.AreEqual("test", interceptor.C.Key);
+    }
+#endif
 
     [Test]
     public void Create_ResolvedFromServiceProvider_NotCreatedByActivator()


### PR DESCRIPTION
Test to ensure services and interceptors can be created with key services. It works without any product changes because `ActivitorUtilites` is used to create objects.