### PR TITLE
Allow GrpcChannel to use WinHttpHandler on Windows Server 2019

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -185,25 +185,41 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
             Log.AddressPathUnused(Logger, Address.OriginalString);
         }
 
-        // Grpc.Net.Client + .NET Framework + WinHttpHandler requires features in WinHTTP, shipped in Windows, to work correctly.
-        // This scenario is supported in these versions of Windows or later:
-        // -Windows Server 2022 has partial support.
-        //    -Unary and server streaming methods are supported.
-        //    -Client and bidi streaming methods aren't supported.
-        // -Windows 11 has full support.
-        //
-        // GrpcChannel validates the Windows version is WinServer2022 or later. Win11 version number is greater than WinServer2022.
-        // Note that this doesn't block using unsupported client and bidi streaming methods on WinServer2022.
-        const int WinServer2022BuildVersion = 20348;
-        if (HttpHandlerType == HttpHandlerType.WinHttpHandler &&
-            OperatingSystem.IsWindows &&
-            OperatingSystem.OSVersion.Build < WinServer2022BuildVersion)
+        if (HttpHandlerType == HttpHandlerType.WinHttpHandler && !OperatingSystemSupportsWinHttpHandler())
         {
             throw new InvalidOperationException("The channel configuration isn't valid on this operating system. " +
                 "The channel is configured to use WinHttpHandler and the current version of Windows " +
                 "doesn't support HTTP/2 features required by gRPC. Windows Server 2022 or Windows 11 or later is required. " +
                 "For more information, see https://aka.ms/aspnet/grpc/netframework.");
         }
+    }
+
+    private bool OperatingSystemSupportsWinHttpHandler()
+    {
+        // Grpc.Net.Client + .NET Framework + WinHttpHandler requires features in WinHTTP, shipped in Windows, to work correctly.
+        // This scenario is supported in these versions of Windows or later:
+        // - Windows Server 2019 and Windows Server 2022 have partial support.
+        //    -Unary and server streaming methods are supported.
+        //    -Client and bidi streaming methods aren't supported.
+        // - Windows 11 has full support.
+        const int WinServer2022BuildVersion = 20348;
+        const int WinServer2019BuildVersion = 17763;
+
+        // Validate the Windows version is WinServer2022 or later. Win11 version number is greater than WinServer2022.
+        // Note that this doesn't block using unsupported client and bidi streaming methods on WinServer2022.
+        if (OperatingSystem.IsWindows && OperatingSystem.OSVersion.Build >= WinServer2022BuildVersion)
+        {
+            return true;
+        }
+
+        // Validate the Windows version is WinServer2019. Its build numbers are mixed with Windows 10, so we must check
+        // the OS version is Windows Server and the build number together to avoid allowing Windows 10.
+        if (OperatingSystem.IsWindowsServer && OperatingSystem.OSVersion.Build >= WinServer2019BuildVersion)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private void ResolveCredentials(GrpcChannelOptions channelOptions, out bool isSecure, out List<CallCredentials>? callCredentials)

--- a/test/Grpc.Net.Client.Tests/GetStatusTests.cs
+++ b/test/Grpc.Net.Client.Tests/GetStatusTests.cs
@@ -215,6 +215,7 @@ public class GetStatusTests
         public bool IsBrowser { get; set; }
         public bool IsAndroid { get; set; }
         public bool IsWindows { get; set; }
+        public bool IsWindowsServer { get; }
         public Version OSVersion { get; set; } = new Version(1, 2, 3, 4);
     }
 

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -614,6 +614,7 @@ public class GrpcChannelTests
         public bool IsBrowser { get; set; }
         public bool IsAndroid { get; set; }
         public bool IsWindows { get; set; }
+        public bool IsWindowsServer { get; }
         public Version OSVersion { get; set; } = new Version(1, 2, 3, 4);
     }
 

--- a/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
+++ b/test/Grpc.Net.Client.Tests/OperatingSystemTests.cs
@@ -29,15 +29,28 @@ public class OperatingSystemTests
     [Platform("Win", Reason = "Only runs on Windows where ntdll.dll is present.")]
     public void DetectWindowsVersion_Windows_MatchesEnvironment()
     {
-        // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibilty setting.
-        Assert.AreEqual(Environment.OSVersion.Version, NtDll.DetectWindowsVersion());
+        NtDll.DetectWindowsVersion(out var version, out _);
+
+        // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibility setting.
+        Assert.AreEqual(Environment.OSVersion.Version, version);
+    }
+
+    [Test]
+    [Platform("Win", Reason = "Only runs on Windows where ntdll.dll is present.")]
+    public void InstanceAndIsWindowsServer_Windows_MatchesEnvironment()
+    {
+        NtDll.DetectWindowsVersion(out var version, out var isWindowsServer);
+
+        Assert.AreEqual(true, OperatingSystem.Instance.IsWindows);
+        Assert.AreEqual(version, OperatingSystem.Instance.OSVersion);
+        Assert.AreEqual(isWindowsServer, OperatingSystem.Instance.IsWindowsServer);
     }
 #endif
 
     [Test]
     public void OSVersion_ModernDotNet_MatchesEnvironment()
     {
-        // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibilty setting.
+        // It is safe to compare Environment.OSVersion.Version on netfx because tests have no compatibility setting.
         Assert.AreEqual(Environment.OSVersion.Version, OperatingSystem.Instance.OSVersion);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2359