### PR TITLE
Add .NET 9 NuGet feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,6 +6,7 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="grpc" value="https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev" />
   </packageSources>
   


### PR DESCRIPTION
Benchmark environment runs with .NET 9. Add .NET 9 feed so it can resolve 9.0 packages.