### PR TITLE
Prevent block inside ResolveAsync from blocking PollingResolver.Refresh

### DIFF
--- a/src/Grpc.Net.Client/Balancer/PollingResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/PollingResolver.cs
@@ -135,7 +135,9 @@ public abstract class PollingResolver : Resolver
 
             if (_resolveTask.IsCompleted)
             {
-                _resolveTask = ResolveNowAsync(_cts.Token);
+                // Run ResolveAsync in a background task.
+                // This is done to prevent a deadlock inside ResolveAsync from blocking future Refresh calls.
+                _resolveTask = Task.Run(() => ResolveNowAsync(_cts.Token), _cts.Token);
                 _resolveTask.ContinueWith(static (t, state) =>
                 {
                     var pollingResolver = (PollingResolver)state!;

--- a/src/Grpc.Net.Client/Balancer/PollingResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/PollingResolver.cs
@@ -136,7 +136,7 @@ public abstract class PollingResolver : Resolver
             if (_resolveTask.IsCompleted)
             {
                 // Run ResolveAsync in a background task.
-                // This is done to prevent a deadlock inside ResolveAsync from blocking future Refresh calls.
+                // This is done to prevent synchronous block inside ResolveAsync from blocking future Refresh calls.
                 _resolveTask = Task.Run(() => ResolveNowAsync(_cts.Token), _cts.Token);
                 _resolveTask.ContinueWith(static (t, state) =>
                 {

--- a/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
@@ -196,6 +196,8 @@ public class PickFirstBalancerTests
         _ = channel.ConnectAsync();
 
         // Assert
+        await resolver.HasResolvedTask.DefaultTimeout();
+
         var subchannels = channel.ConnectionManager.GetSubchannels();
         Assert.AreEqual(1, subchannels.Count);
 

--- a/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
@@ -187,7 +187,10 @@ public class RoundRobinBalancerTests
         _ = channel.ConnectAsync();
 
         // Assert
+        await resolver.HasResolvedTask.DefaultTimeout();
+
         var subchannels = channel.ConnectionManager.GetSubchannels();
+
         Assert.AreEqual(1, subchannels.Count);
 
         Assert.AreEqual(1, subchannels[0]._addresses.Count);

--- a/test/Shared/TestResolver.cs
+++ b/test/Shared/TestResolver.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -34,6 +34,7 @@ internal class TestResolver : PollingResolver
 {
     private readonly Func<Task>? _onRefreshAsync;
     private readonly TaskCompletionSource<object?> _hasResolvedTcs;
+    private readonly ILogger _logger;
     private ResolverResult? _result;
 
     public Task HasResolvedTask => _hasResolvedTcs.Task;
@@ -46,15 +47,18 @@ internal class TestResolver : PollingResolver
     {
         _onRefreshAsync = onRefreshAsync;
         _hasResolvedTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _logger = (ILogger?)loggerFactory?.CreateLogger<TestResolver>() ?? NullLogger.Instance;
     }
 
     public void UpdateAddresses(List<BalancerAddress> addresses, ServiceConfig? serviceConfig = null, Status? serviceConfigStatus = null)
     {
+        _logger.LogInformation("Updating result addresses: {Addresses}", string.Join(", ", addresses));
         UpdateResult(ResolverResult.ForResult(addresses, serviceConfig, serviceConfigStatus));
     }
 
     public void UpdateError(Status status)
     {
+        _logger.LogInformation("Updating result error: {Status}", status);
         UpdateResult(ResolverResult.ForFailure(status));
     }
 


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/2380#issuecomment-1987257515

User code is called inside a lock in the `Refresh` method. If the user code blocks without returning a task then the lock blocks future calls to `Refresh`.

The fix is to ensure user code is async by calling it from `Task.Run`.