### PR TITLE
Update microsoft-support.md

### DIFF
--- a/microsoft-support.md
+++ b/microsoft-support.md
@@ -22,7 +22,7 @@ Support is provided for the following grpc-dotnet packages:
 
 Notes:
 * Applications must be using a [currently supported .NET release](https://dotnet.microsoft.com/platform/support/policy).
-* Minimum supported grpc-dotnet version is currently v2.37.0. The minimum grpc-dotnet version supported is increased when major new .NET versions are released.
+* Minimum supported grpc-dotnet version is currently v2.59.0. The minimum grpc-dotnet version supported is increased when major new .NET versions are released.
 * Minimum supported version is the earliest major and minor release required to obtain assisted support. Please utilize public community channels for assistance or log issues directly on GitHub for releases before the minimum supported version.
 * Assisted support is only available for the official builds released from https://github.com/grpc/grpc-dotnet, and no assisted support option is available for individual forks.
 * Please note that new features and security\bug fixes are provided in the latest released version and are not backported to previous versions. To obtain the latest updates and features, please upgrade to the latest version.


### PR DESCRIPTION
Update the minimum supported version of grpc-dotnet to the version available when .NET 8 was released.