### PR TITLE
Interrupt existing subchannel connect attempt when reconnect is requested

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ISubchannelTransport.cs
@@ -34,7 +34,7 @@ internal interface ISubchannelTransport : IDisposable
     TransportStatus TransportStatus { get; }
 
     ValueTask<Stream> GetStreamAsync(DnsEndPoint endPoint, CancellationToken cancellationToken);
-    ValueTask<ConnectResult> TryConnectAsync(ConnectContext context);
+    ValueTask<ConnectResult> TryConnectAsync(ConnectContext context, int attempt);
 
     void Disconnect();
 }

--- a/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
@@ -52,7 +52,7 @@ internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
         _subchannel.UpdateConnectivityState(ConnectivityState.Idle, "Disconnected.");
     }
 
-    public ValueTask<ConnectResult> TryConnectAsync(ConnectContext context)
+    public ValueTask<ConnectResult> TryConnectAsync(ConnectContext context, int attempt)
     {
         Debug.Assert(_subchannel._addresses.Count == 1);
         Debug.Assert(CurrentEndPoint == null);

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -144,7 +144,7 @@ internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDi
         _currentEndPoint = null;
     }
 
-    public async ValueTask<ConnectResult> TryConnectAsync(ConnectContext context)
+    public async ValueTask<ConnectResult> TryConnectAsync(ConnectContext context, int attempt)
     {
         Debug.Assert(CurrentEndPoint == null);
 

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -165,8 +165,6 @@ public sealed class Subchannel : IDisposable
     /// <param name="addresses"></param>
     public void UpdateAddresses(IReadOnlyList<BalancerAddress> addresses)
     {
-        SubchannelLog.AddressesUpdated(_logger, Id, addresses);
-
         var requireReconnect = false;
         lock (Lock)
         {
@@ -175,6 +173,8 @@ public sealed class Subchannel : IDisposable
                 // Don't do anything if new addresses match existing addresses.
                 return;
             }
+
+            SubchannelLog.AddressesUpdated(_logger, Id, addresses);
 
             // Get a copy of the current address before updating addresses.
             // Updating addresses to not contain this value changes the property to return null.

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -188,7 +188,7 @@ public class ClientChannelTests
             new BalancerAddress("localhost", 80)
         });
 
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             return Task.FromException<TryConnectResult>(new Exception("Test error!"));
         });
@@ -357,7 +357,7 @@ public class ClientChannelTests
 
         var syncPoint = new SyncPoint(runContinuationsAsynchronously: true);
 
-        var transportFactory = new TestSubchannelTransportFactory(async (s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create(async (s, c) =>
         {
             c.Register(state => ((SyncPoint)state!).Continue(), syncPoint);
 
@@ -548,7 +548,7 @@ public class ClientChannelTests
 
         var callbackAsyncLocalValues = new List<object>();
 
-        var transportFactory = new TestSubchannelTransportFactory((subchannel, cancellationToken) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((subchannel, cancellationToken) =>
         {
             callbackAsyncLocalValues.Add(asyncLocal.Value);
             if (callbackAsyncLocalValues.Count >= 2)

--- a/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
@@ -58,7 +58,7 @@ public class PickFirstBalancerTests
         services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
 
         var subChannelConnections = new List<Subchannel>();
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             lock (subChannelConnections)
             {
@@ -176,7 +176,7 @@ public class PickFirstBalancerTests
             new BalancerAddress("localhost", 80)
         });
 
-        var transportFactory = new TestSubchannelTransportFactory((s, c) => Task.FromResult(new TryConnectResult(ConnectivityState.TransientFailure)));
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) => Task.FromResult(new TryConnectResult(ConnectivityState.TransientFailure)));
         services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
         services.AddSingleton<ISubchannelTransportFactory>(transportFactory);
         var serviceProvider = services.BuildServiceProvider();
@@ -234,7 +234,7 @@ public class PickFirstBalancerTests
         var connectivityState = ConnectivityState.TransientFailure;
 
         services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
-        services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory(async (s, c) =>
+        services.AddSingleton<ISubchannelTransportFactory>(TestSubchannelTransportFactory.Create(async (s, c) =>
         {
             await syncPoint.WaitToContinue();
             return new TryConnectResult(connectivityState);
@@ -290,7 +290,7 @@ public class PickFirstBalancerTests
         });
 
         var transportConnectCount = 0;
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             transportConnectCount++;
             return Task.FromResult(new TryConnectResult(ConnectivityState.Ready));
@@ -340,7 +340,7 @@ public class PickFirstBalancerTests
         resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
         var transportConnectCount = 0;
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             transportConnectCount++;
             return Task.FromResult(new TryConnectResult(ConnectivityState.Ready));
@@ -385,7 +385,7 @@ public class PickFirstBalancerTests
         resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
         var transportConnectCount = 0;
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             transportConnectCount++;
             return Task.FromResult(new TryConnectResult(ConnectivityState.Ready));
@@ -448,7 +448,7 @@ public class PickFirstBalancerTests
 
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var transportConnectCount = 0;
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             transportConnectCount++;
 
@@ -510,7 +510,7 @@ public class PickFirstBalancerTests
 
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var transportConnectCount = 0;
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             transportConnectCount++;
 
@@ -576,7 +576,7 @@ public class PickFirstBalancerTests
         var resolver = new TestResolver();
         resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             return Task.FromResult(new TryConnectResult(ConnectivityState.Connecting));
         });
@@ -640,7 +640,7 @@ public class PickFirstBalancerTests
         resolver.UpdateAddresses(new List<BalancerAddress> { new BalancerAddress("localhost", 80) });
 
         var tryConnectTcs = new TaskCompletionSource<TryConnectResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var transportFactory = new TestSubchannelTransportFactory((s, ct) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, ct) =>
         {
             return tryConnectTcs.Task;
         });

--- a/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
@@ -642,7 +642,7 @@ public class ResolverTests
             ServiceProvider = services.BuildServiceProvider(),
         };
 
-        // Act & Assert
+        // Act
         var channel = GrpcChannel.ForAddress("test:///test_addr", channelOptions);
 
         logger.LogInformation("Client connecting.");
@@ -668,6 +668,7 @@ public class ResolverTests
             waitForReady: true,
             CancellationToken.None);
 
+        // Assert
         logger.LogInformation("TryConnectData count: {Count}", tryConnectData.Count);
         foreach (var data in tryConnectData)
         {

--- a/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
@@ -19,6 +19,7 @@
 #if SUPPORT_LOAD_BALANCING
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -298,7 +299,7 @@ public class ResolverTests
         var currentConnectivityState = ConnectivityState.Ready;
 
         services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
-        services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory(async (s, c) =>
+        services.AddSingleton<ISubchannelTransportFactory>(TestSubchannelTransportFactory.Create(async (s, i, c) =>
         {
             await syncPoint.WaitToContinue();
             return new TryConnectResult(currentConnectivityState);
@@ -550,6 +551,134 @@ public class ResolverTests
     {
         var balancer = (ChildHandlerLoadBalancer)channel.ConnectionManager._balancer!;
         return (T?)balancer._current?.LoadBalancer;
+    }
+
+    internal class TestBackoffPolicyFactory : IBackoffPolicyFactory
+    {
+        private readonly TimeSpan _backoff;
+
+        public TestBackoffPolicyFactory() : this(TimeSpan.FromSeconds(20))
+        {
+        }
+
+        public TestBackoffPolicyFactory(TimeSpan backoff)
+        {
+            _backoff = backoff;
+        }
+
+        public IBackoffPolicy Create()
+        {
+            return new TestBackoffPolicy(_backoff);
+        }
+
+        private class TestBackoffPolicy : IBackoffPolicy
+        {
+            private readonly TimeSpan _backoff;
+
+            public TestBackoffPolicy(TimeSpan backoff)
+            {
+                _backoff = backoff;
+            }
+
+            public TimeSpan NextBackoff()
+            {
+                return _backoff;
+            }
+        }
+    }
+
+    [Test]
+    public async Task Resolver_UpdateResultsAfterPreviousConnect_InterruptConnect()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // add logger
+        services.AddNUnitLogger();
+        var loggerFactory = services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<ResolverTests>();
+
+        // add resolver and balancer
+        var resolver = new TestResolver(loggerFactory);
+        var result = ResolverResult.ForResult(new List<BalancerAddress> { new BalancerAddress("localhost", 80) }, serviceConfig: null, serviceConfigStatus: null);
+        resolver.UpdateResult(result);
+
+        services.AddSingleton<ResolverFactory>(new TestResolverFactory(resolver));
+        services.AddSingleton<IBackoffPolicyFactory>(new TestBackoffPolicyFactory(TimeSpan.FromSeconds(0.2)));
+
+        var tryConnectData = new List<(IReadOnlyList<BalancerAddress> BalancerAddresses, int Attempt, bool IsCancellationRequested)>();
+
+        var tryConnectCount = 0;
+        services.AddSingleton<ISubchannelTransportFactory>(
+            TestSubchannelTransportFactory.Create((subchannel, attempt, cancellationToken) =>
+            {
+                var addresses = subchannel.GetAddresses();
+                var isCancellationRequested = cancellationToken.IsCancellationRequested;
+                ConnectivityState state;
+
+                var i = Interlocked.Increment(ref tryConnectCount);
+                if (i == 1)
+                {
+                    state = ConnectivityState.Ready;
+                }
+                else
+                {
+                    state = attempt >= 2 ? ConnectivityState.Ready : ConnectivityState.TransientFailure;
+                }
+
+                logger.LogInformation("TryConnect attempt {Attempt} to addresses {Addresses}. State: {ConnectivityState}, IsCancellationRequested: {IsCancellationRequested}", attempt, string.Join(", ", addresses), state, isCancellationRequested);
+
+                lock (tryConnectData)
+                {
+                    tryConnectData.Add((addresses, attempt, isCancellationRequested));
+                }
+
+                return Task.FromResult(new TryConnectResult(state));
+            }));
+
+        var channelOptions = new GrpcChannelOptions
+        {
+            Credentials = ChannelCredentials.Insecure,
+            ServiceProvider = services.BuildServiceProvider(),
+        };
+
+        // Act & Assert
+        var channel = GrpcChannel.ForAddress("test:///test_addr", channelOptions);
+
+        logger.LogInformation("Client connecting.");
+        await channel.ConnectionManager.ConnectAsync(waitForReady: true, CancellationToken.None);
+
+        logger.LogInformation("Client updating resolver.");
+        result = ResolverResult.ForResult(new List<BalancerAddress> { new BalancerAddress("localhost", 81) }, serviceConfig: null, serviceConfigStatus: null);
+        resolver.UpdateResult(result);
+
+        logger.LogInformation("Client picking.");
+        await ExceptionAssert.ThrowsAsync<RpcException>(async () => await channel.ConnectionManager.PickAsync(
+            new PickContext(),
+            waitForReady: false,
+            CancellationToken.None));
+
+        logger.LogInformation("Client updating Resolver.");
+        result = ResolverResult.ForResult(new List<BalancerAddress> { new BalancerAddress("localhost", 82) }, serviceConfig: null, serviceConfigStatus: null);
+        resolver.UpdateResult(result);
+
+        logger.LogInformation("Client picking and waiting for ready.");
+        await channel.ConnectionManager.PickAsync(
+            new PickContext(),
+            waitForReady: true,
+            CancellationToken.None);
+
+        logger.LogInformation("TryConnectData count: {Count}", tryConnectData.Count);
+        foreach (var data in tryConnectData)
+        {
+            logger.LogInformation("Attempt: {Attempt}, BalancerAddresses: {BalancerAddresses}, IsCancellationRequested: {IsCancellationRequested}", data.Attempt, string.Join(", ", data.BalancerAddresses), data.IsCancellationRequested);
+        }
+
+        var duplicate = tryConnectData.GroupBy(d => new { Address = d.BalancerAddresses.Single(), d.Attempt }).FirstOrDefault(g => g.Count() >= 2);
+        if (duplicate != null)
+        {
+            Assert.Fail($"Duplicate attempts to address. Count: {duplicate.Count()}, Address: {duplicate.Key.Address}");
+        }
     }
 }
 #endif

--- a/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/RoundRobinBalancerTests.cs
@@ -163,7 +163,7 @@ public class RoundRobinBalancerTests
         services.AddNUnitLogger();
         services.AddSingleton<TestResolver>();
         services.AddSingleton<ResolverFactory, TestResolverFactory>();
-        var transportFactory = new TestSubchannelTransportFactory((s, c) => Task.FromResult(new TryConnectResult(ConnectivityState.TransientFailure)));
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) => Task.FromResult(new TryConnectResult(ConnectivityState.TransientFailure)));
         services.AddSingleton<ISubchannelTransportFactory>(transportFactory);
         var serviceProvider = services.BuildServiceProvider();
 
@@ -221,7 +221,7 @@ public class RoundRobinBalancerTests
 
         var connectState = ConnectivityState.Ready;
 
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             logger.LogInformation($"Transport factory returning state: {connectState}");
             return Task.FromResult(new TryConnectResult(connectState));
@@ -304,7 +304,7 @@ public class RoundRobinBalancerTests
         var connectState = ConnectivityState.Ready;
 
         var subChannelConnections = new List<Subchannel>();
-        var transportFactory = new TestSubchannelTransportFactory((s, c) =>
+        var transportFactory = TestSubchannelTransportFactory.Create((s, c) =>
         {
             lock (subChannelConnections)
             {

--- a/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
+++ b/test/Grpc.Net.Client.Tests/GrpcChannelTests.cs
@@ -934,7 +934,7 @@ public class GrpcChannelTests
         var services = new ServiceCollection();
         services.AddNUnitLogger();
         services.AddSingleton<ResolverFactory, ChannelTestResolverFactory>();
-        services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory(async (s, c) =>
+        services.AddSingleton<ISubchannelTransportFactory>(TestSubchannelTransportFactory.Create(async (s, c) =>
         {
             await syncPoint.WaitToContinue();
             return new TryConnectResult(currentConnectivityState);
@@ -998,7 +998,7 @@ public class GrpcChannelTests
         var services = new ServiceCollection();
         services.AddNUnitLogger();
         services.AddSingleton<ResolverFactory, ChannelTestResolverFactory>();
-        services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory(async (s, c) =>
+        services.AddSingleton<ISubchannelTransportFactory>(TestSubchannelTransportFactory.Create(async (s, c) =>
         {
             await syncPoint.WaitToContinue();
             return new TryConnectResult(currentConnectivityState);


### PR DESCRIPTION
A subchannel should only have one concurrent attempt to connect. I noticed a rare scenario there could breifly be multiple:

1. Subchannel starts trying to connect.
2. Subchannel fails to connect and waits for backoff before trying again.
3. Resolver changes all of the subchannel's addresses and requests it to reconnect
4. Previous connection attempt in backoff tries to connect one more time before exiting

Fix is to immediately interrupt previous connect attempt.