### PR TITLE
Fix ObjectDisposedException message

### DIFF
--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -545,7 +545,7 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         {
             // Test the disposed flag inside the lock to ensure there is no chance of a race and adding a call after dispose.
             // Note that a GrpcCall has been created but hasn't been started. The error will prevent it from starting.
-            ObjectDisposedThrowHelper.ThrowIf(Disposed, nameof(GrpcChannel));
+            ObjectDisposedThrowHelper.ThrowIf(Disposed, typeof(GrpcChannel));
 
             _activeCalls.Add(grpcCall);
         }


### PR DESCRIPTION
The call to `ObjectDisposedThrowHelper.ThrowIf` expects an instance or a type. This code was passing a name, which resulted in an error message resembling:

> System.ObjectDisposedException : Cannot access a disposed object.
> Object name: 'System.String'.

It should mention the `GrpcChannel` type, not the string type.