### PR TITLE
Enable multiple connections with WinHttpHandler by default

### DIFF
--- a/src/Shared/HttpHandlerFactory.cs
+++ b/src/Shared/HttpHandlerFactory.cs
@@ -38,7 +38,7 @@ internal static class HttpHandlerFactory
 #endif
 
 #if NET462
-        // Create SocketsHttpHandler with EnableMultipleHttp2Connections set to true. That will
+        // Create WinHttpHandler with EnableMultipleHttp2Connections set to true. That will
         // allow a gRPC channel to create new connections if the maximum allow concurrency is exceeded.
         return new WinHttpHandler
         {

--- a/src/Shared/HttpHandlerFactory.cs
+++ b/src/Shared/HttpHandlerFactory.cs
@@ -38,7 +38,12 @@ internal static class HttpHandlerFactory
 #endif
 
 #if NET462
-        return new WinHttpHandler();
+        // Create SocketsHttpHandler with EnableMultipleHttp2Connections set to true. That will
+        // allow a gRPC channel to create new connections if the maximum allow concurrency is exceeded.
+        return new WinHttpHandler
+        {
+            EnableMultipleHttp2Connections = true
+        };
 #elif !NETSTANDARD2_0
         return new HttpClientHandler();
 #else


### PR DESCRIPTION
Feedback from a customer about streams pausing when a limit is reached. Can help this scenario by defaulting the WinHttpHandler to create more streams if required.