### PR TITLE
Fix memory leak when using call context propagation with cancellation token

### DIFF
--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
     <Compile Include="..\Shared\TestHttpMessageHandler.cs" Link="Infrastructure\TestHttpMessageHandler.cs" />
     <Compile Include="..\Shared\TestServerCallContext.cs" Link="Infrastructure\TestServerCallContext.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" Link="Infrastructure\TestHelpers.cs" />
 
     <ProjectReference Include="..\..\src\Grpc.Core.Api\Grpc.Core.Api.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -20,7 +20,6 @@
     <Compile Include="..\Shared\TaskExtensions.cs" Link="Infrastructure\TaskExtensions.cs" />
     <Compile Include="..\Shared\TestHttpMessageHandler.cs" Link="Infrastructure\TestHttpMessageHandler.cs" />
     <Compile Include="..\Shared\TestServerCallContext.cs" Link="Infrastructure\TestServerCallContext.cs" />
-    <Compile Include="..\Shared\TestHelpers.cs" Link="Infrastructure\TestHelpers.cs" />
 
     <ProjectReference Include="..\..\src\Grpc.Core.Api\Grpc.Core.Api.csproj" />
     <ProjectReference Include="..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj" />


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2419

There was an incorrect assumption that the disposable call was always disposed of by the client. It isn't, which could create a memory leak under the right situation (context propagation + long lasting cancellation token + many unary calls)

Fix is to make the interceptor configure the returned call type to automatically dispose its own state once finished with reading the response.