### PR TITLE
Add semaphore to limit subchannel connect to prevent race conditions

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -332,6 +332,7 @@ public sealed class Subchannel : IDisposable
             }
             catch (OperationCanceledException)
             {
+                // Canceled while waiting for semaphore.
                 return;
             }
         }

--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -422,9 +422,14 @@ public sealed class Subchannel : IDisposable
                 // Dispose context because it might have been created with a connect timeout.
                 // Want to clean up the connect timeout timer.
                 connectContext.Dispose();
-            }
 
-            _connectSemaphore.Release();
+                // Subchannel could have been disposed while connect is running.
+                // If subchannel is shutting down then don't release semaphore to avoid ObjectDisposedException.
+                if (_state != ConnectivityState.Shutdown)
+                {
+                    _connectSemaphore.Release();
+                }
+            }
         }
     }
 

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -93,8 +93,11 @@ public class ConnectionTests : FunctionalTestBase
 
         var client = TestClientFactory.Create(channel, endpoint.Method);
 
+        // Act
         var ex = await ExceptionAssert.ThrowsAsync<RpcException>(() => client.UnaryCall(new HelloRequest()).ResponseAsync).DefaultTimeout();
         Assert.AreEqual("A connection could not be established within the configured ConnectTimeout.", ex.Status.DebugException!.Message);
+
+        await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => connectTcs.Task).DefaultTimeout();
     }
 
     [Test]

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -167,7 +167,7 @@ public class ConnectionTests : FunctionalTestBase
             connectionIdleTimeout: connectionIdleTimeout).DefaultTimeout();
 
         Logger.LogInformation("Connecting channel.");
-        await channel.ConnectAsync();
+        await channel.ConnectAsync().DefaultTimeout();
 
         // Wait for timeout plus a little extra to avoid issues from imprecise timers.
         await Task.Delay(connectionIdleTimeout + TimeSpan.FromMilliseconds(50));


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/2420

I have a theory that concurrent calls to `ConnectTransportAsync` could put a subchannel in a bad state. Two connection requests happen simultaneously but a race condition occurs as they exit.

**Before:**

1. Connect 1 starts.
2. Connect 2 starts. Cancels connect 1.
3. Connect 2 succeeds.
4. Connect 2 exits and updates subchannel status to Ready.
5. Connect 1 exits and updates subchannel status to TransientFailure.

This PR limits access to connect with a semaphore. A subchannel will have one connect in progress at a time.

**After:**

1. Connect 1 acquires semaphore and starts.
2. Connect 2 tries to start. Cancels connect 1. Waits with semaphore for connect 1 to finish.
3. Connect 1 exits and updates subchannel status to TransientFailure.
4. Connect 1 releases semaphore.
5. Connect 2 acquires semaphore.
6. Connect 2 succeeds.
7. Connect 2 exits and updates subchannel status to Ready.
8. Connect 2 releases semaphore.

Note: New test is unrelated to this exact problem. I wrote it while considering another theory. It's a good test to keep around.