### PR TITLE
Fix HTTP/3 test errors on .NET 6

### DIFF
--- a/test/FunctionalTests/Client/ClientFactoryTests.cs
+++ b/test/FunctionalTests/Client/ClientFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -81,7 +81,7 @@ public class ClientFactoryTests : FunctionalTestBase
         Assert.AreEqual("Hello world", response2.Message);
     }
 
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
     [Test]
     [RequireHttp3]
     public async Task ClientFactory_Http3_Success()

--- a/test/FunctionalTests/Client/ConnectionTests.cs
+++ b/test/FunctionalTests/Client/ConnectionTests.cs
@@ -98,7 +98,7 @@ public class ConnectionTests : FunctionalTestBase
     }
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
     [Test]
     [RequireHttp3]
     public async Task Http3()

--- a/test/FunctionalTests/Web/Client/AuthTests.cs
+++ b/test/FunctionalTests/Web/Client/AuthTests.cs
@@ -28,16 +28,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class AuthTests : GrpcWebFunctionalTestBase

--- a/test/FunctionalTests/Web/Client/ClientFactoryTests.cs
+++ b/test/FunctionalTests/Web/Client/ClientFactoryTests.cs
@@ -28,16 +28,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class ClientFactoryTests : GrpcWebFunctionalTestBase

--- a/test/FunctionalTests/Web/Client/ConnectionTests.cs
+++ b/test/FunctionalTests/Web/Client/ConnectionTests.cs
@@ -72,7 +72,7 @@ public class ConnectionTests : FunctionalTestBase
     [TestCase(TestServerEndpointName.Http2WithTls, "1.1", false)]
 #endif
     [TestCase(TestServerEndpointName.Http2WithTls, null, true)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
     [TestCase(TestServerEndpointName.Http3WithTls, null, true)]
 #endif
     public async Task SendValidRequest_WithConnectionOptions(TestServerEndpointName endpointName, string? version, bool success)

--- a/test/FunctionalTests/Web/Client/IssueTests.cs
+++ b/test/FunctionalTests/Web/Client/IssueTests.cs
@@ -27,16 +27,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class IssueTests : GrpcWebFunctionalTestBase

--- a/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/ServerStreamingMethodTests.cs
@@ -29,16 +29,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class ServerStreamingMethodTests : GrpcWebFunctionalTestBase

--- a/test/FunctionalTests/Web/Client/TrailerMetadataTests.cs
+++ b/test/FunctionalTests/Web/Client/TrailerMetadataTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -26,16 +26,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class TrailerMetadataTests : GrpcWebFunctionalTestBase

--- a/test/FunctionalTests/Web/Client/UnaryMethodTests.cs
+++ b/test/FunctionalTests/Web/Client/UnaryMethodTests.cs
@@ -26,16 +26,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Client;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class UnaryMethodTests : GrpcWebFunctionalTestBase

--- a/test/FunctionalTests/Web/Server/DeadlineTests.cs
+++ b/test/FunctionalTests/Web/Server/DeadlineTests.cs
@@ -28,16 +28,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Server;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class DeadlineTests : GrpcWebFunctionalTestBase

--- a/test/FunctionalTests/Web/Server/UnaryMethodTests.cs
+++ b/test/FunctionalTests/Web/Server/UnaryMethodTests.cs
@@ -27,16 +27,16 @@ namespace Grpc.AspNetCore.FunctionalTests.Web.Server;
 
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWeb, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http1)]
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.GrpcWebText, TestServerEndpointName.Http3WithTls)]
 #endif
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http2)]
-#if NET6_0_OR_GREATER
+#if NET7_0_OR_GREATER
 [TestFixture(GrpcTestMode.Grpc, TestServerEndpointName.Http3WithTls)]
 #endif
 public class UnaryMethodTests : GrpcWebFunctionalTestBase


### PR DESCRIPTION
I noticed HTTP/3 test errors on .NET 6.  I believe HTTP/3 support was disabled in .NET 6. Update tests to run on .NET 7 or later.