### PR TITLE
Don't capture async locals in resolver

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -257,7 +257,7 @@ public sealed class Subchannel : IDisposable
         }
 
         // Don't capture the current ExecutionContext and its AsyncLocals onto the connect
-        bool restoreFlow = false;
+        var restoreFlow = false;
         if (!ExecutionContext.IsFlowSuppressed())
         {
             ExecutionContext.SuppressFlow();

--- a/src/Shared/NonCapturingTimer.cs
+++ b/src/Shared/NonCapturingTimer.cs
@@ -13,7 +13,7 @@ internal static class NonCapturingTimer
         ArgumentNullThrowHelper.ThrowIfNull(callback);
 
         // Don't capture the current ExecutionContext and its AsyncLocals onto the timer
-        bool restoreFlow = false;
+        var restoreFlow = false;
         try
         {
             if (!ExecutionContext.IsFlowSuppressed())

--- a/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ResolverTests.cs
@@ -112,6 +112,66 @@ public class ResolverTests
     }
 
     [Test]
+    public async Task Refresh_AsyncLocal_NotCaptured()
+    {
+        // Arrange
+        var waitHandle = new ManualResetEvent(false);
+
+        var services = new ServiceCollection();
+        var testSink = new TestSink();
+        services.AddLogging(b =>
+        {
+            b.AddProvider(new TestLoggerProvider(testSink));
+        });
+        services.AddNUnitLogger();
+        var loggerFactory = services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+
+        var asyncLocal = new AsyncLocal<object>();
+        asyncLocal.Value = new object();
+
+        var callbackAsyncLocalValues = new List<object>();
+
+        var resolver = new CallbackPollingResolver(loggerFactory, new TestBackoffPolicyFactory(TimeSpan.FromMilliseconds(100)), (listener) =>
+        {
+            callbackAsyncLocalValues.Add(asyncLocal.Value);
+            if (callbackAsyncLocalValues.Count >= 2)
+            {
+                listener(ResolverResult.ForResult(new List<BalancerAddress>()));
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var tcs = new TaskCompletionSource<ResolverResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        resolver.Start(result => tcs.TrySetResult(result));
+
+        // Act
+        resolver.Refresh();
+
+        // Assert
+        await tcs.Task.DefaultTimeout();
+
+        Assert.AreEqual(2, callbackAsyncLocalValues.Count);
+        Assert.IsNull(callbackAsyncLocalValues[0]);
+        Assert.IsNull(callbackAsyncLocalValues[1]);
+    }
+
+    private class CallbackPollingResolver : PollingResolver
+    {
+        private readonly Func<Action<ResolverResult>, Task> _callback;
+
+        public CallbackPollingResolver(ILoggerFactory loggerFactory, IBackoffPolicyFactory backoffPolicyFactory, Func<Action<ResolverResult>, Task> callback) : base(loggerFactory, backoffPolicyFactory)
+        {
+            _callback = callback;
+        }
+
+        protected override Task ResolveAsync(CancellationToken cancellationToken)
+        {
+            return _callback(Listener);
+        }
+    }
+
+    [Test]
     public async Task Resolver_ResolveNameFromServices_Success()
     {
         // Arrange


### PR DESCRIPTION
Follow on from https://github.com/grpc/grpc-dotnet/pull/2129

`PollingResolver.ResolveAsync` is always started in a task and can run for a long time. Don't capture async locals.