### PR TITLE
ci: upgrade checkout action version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Install dotnet
       run: ./build/get-dotnet.sh
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run interop tests
       run: ./grpcweb_interoptests.sh


### PR DESCRIPTION
upgrade checkout action version to fix the ci build warning

noticed these warnings on ci build

![image](https://github.com/grpc/grpc-dotnet/assets/7604648/6745eb4d-6aa0-4b95-a013-04b4e12bb93b)


try to upgrade to the latest version to fix


looks good from https://github.com/grpc/grpc-dotnet/actions/runs/9012001811

![image](https://github.com/grpc/grpc-dotnet/assets/7604648/c65c534c-5561-4a7f-8235-22435fd601c5)
