### PR TITLE
Assign primary handler before other configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <OpenTelemetryIntergationPackageVersion>1.8.1</OpenTelemetryIntergationPackageVersion>
     <OpenTelemetryGrpcPackageVersion>1.8.0-beta.1</OpenTelemetryGrpcPackageVersion>
     <MicrosoftExtensionsPackageVersion>8.0.0</MicrosoftExtensionsPackageVersion>
-    <MicrosoftExtensions6PackageVersion>6.0.0</MicrosoftExtensions6PackageVersion>
+    <MicrosoftExtensionsLtsPackageVersion>6.0.0</MicrosoftExtensionsLtsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- ASP.NET Core -->
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Grpc.Swagger" Version="0.8.0" />
 
     <!-- Extensions -->
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsPackageVersion)" />

--- a/src/Grpc.Net.Client/Grpc.Net.Client.csproj
+++ b/src/Grpc.Net.Client/Grpc.Net.Client.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="$(MicrosoftExtensions6PackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="$(MicrosoftExtensionsLtsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -489,7 +489,10 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
         // Decision to dispose invoker is controlled by _shouldDisposeHttpClient.
         if (handler == null)
         {
-            handler = HttpHandlerFactory.CreatePrimaryHandler();
+            if (!HttpHandlerFactory.TryCreatePrimaryHandler(out handler))
+            {
+                throw HttpHandlerFactory.CreateUnsupportedHandlerException();
+            }
         }
         else
         {

--- a/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
+++ b/src/Grpc.Net.ClientFactory/Grpc.Net.ClientFactory.csproj
@@ -26,6 +26,6 @@
   <ItemGroup>
     <!-- PrivateAssets set to None to ensure the build targets/props are propagated to parent project -->
     <ProjectReference Include="..\Grpc.Net.Client\Grpc.Net.Client.csproj" PrivateAssets="None" />
-    <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="$(MicrosoftExtensions6PackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="$(MicrosoftExtensionsLtsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -310,7 +310,7 @@ public static class GrpcClientServiceExtensions
         builder.Services.AddTransient<TClient>(s =>
         {
             var clientFactory = s.GetRequiredService<GrpcClientFactory>();
-            return clientFactory.CreateClient<TClient>(builder.Name);
+            return clientFactory.CreateClient<TClient>(name);
         });
 
         // Insert primary handler before other configuration so there is the opportunity to override it.
@@ -343,7 +343,7 @@ public static class GrpcClientServiceExtensions
         services.Insert(0, configurePrimaryHandler);
 
         // Some platforms don't have a built-in handler that supports gRPC.
-        // Validate that a handler was set after all configuration has run.
+        // Validate that a handler was set by the app to after all configuration has run.
         services.PostConfigure<HttpClientFactoryOptions>(name, options =>
         {
             options.HttpMessageHandlerBuilderActions.Add(builder =>

--- a/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
+++ b/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs
@@ -308,7 +308,7 @@ public static class GrpcClientServiceExtensions
 
         services.AddHttpClient(name);
 
-        // Get PrimaryHandler o we can track whether the user set a value or not.
+        // Get PrimaryHandler and store it to compare later. Used to track whether the user set a handler or not.
         // This action comes before registered user actions so the primary handler here will be the one created by the factory.
         HttpMessageHandler? initialPrimaryHandler = null;
         services.Configure<HttpClientFactoryOptions>(name, options =>
@@ -320,6 +320,8 @@ public static class GrpcClientServiceExtensions
         {
             options.HttpMessageHandlerBuilderActions.Add(builder =>
             {
+                // If the primary handler is unchanged from what the factory created then replace the handler
+                // with one that has settings optimized for a gRPC client.
                 if (builder.PrimaryHandler == initialPrimaryHandler)
                 {
                     // This will throw in .NET Standard 2.0 with a prompt that a user must set a handler.

--- a/src/Grpc.Net.ClientFactory/Internal/GrpcClientMappingRegistry.cs
+++ b/src/Grpc.Net.ClientFactory/Internal/GrpcClientMappingRegistry.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 #endregion
-
 
 namespace Grpc.Net.ClientFactory.Internal;
 

--- a/test/FunctionalTests/Linker/LinkerTests.cs
+++ b/test/FunctionalTests/Linker/LinkerTests.cs
@@ -19,6 +19,7 @@
 // Skip running load running tests in debug configuration
 #if !DEBUG
 
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Grpc.AspNetCore.FunctionalTests.Linker.Helpers;
@@ -86,7 +87,17 @@ public class LinkerTests
                 websiteProcess.Start(BuildStartPath(linkerTestsWebsitePath, "LinkerTestsWebsite"), arguments: null);
                 await websiteProcess.WaitForReadyAsync().TimeoutAfter(Timeout);
 
-                clientProcess.Start(BuildStartPath(linkerTestsClientPath, "LinkerTestsClient"), arguments: websiteProcess.ServerPort!.ToString());
+                string? clientArguments = null;
+                if (websiteProcess.ServerPort is {} serverPort)
+                {
+                    clientArguments = serverPort.ToString(CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Website server port not available.");
+                }
+
+                clientProcess.Start(BuildStartPath(linkerTestsClientPath, "LinkerTestsClient"), arguments: clientArguments);
                 await clientProcess.WaitForExitAsync().TimeoutAfter(Timeout);
             }
             finally

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -41,13 +41,11 @@
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" />
-    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System.Net.Http" />
-    
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
 </Project>

--- a/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
+++ b/test/Grpc.Net.ClientFactory.Tests/DefaultGrpcClientFactoryTests.cs
@@ -61,13 +61,13 @@ public class DefaultGrpcClientFactoryTests
     public void CreateClient_Default_PrimaryHandlerIsSocketsHttpHandler()
     {
         // Arrange
-        SocketsHttpHandler? socketsHttpHandler = null;
+        HttpMessageHandler? clientPrimaryHandler = null;
         var services = new ServiceCollection();
         services
             .AddGrpcClient<TestGreeterClient>(o => o.Address = new Uri("http://localhost"))
             .ConfigurePrimaryHttpMessageHandler((primaryHandler, _) =>
             {
-                socketsHttpHandler = (SocketsHttpHandler)primaryHandler;
+                clientPrimaryHandler = primaryHandler;
             });
 
         var serviceProvider = services.BuildServiceProvider(validateScopes: true);
@@ -78,8 +78,9 @@ public class DefaultGrpcClientFactoryTests
         var client = clientFactory.CreateClient<TestGreeterClient>(nameof(TestGreeterClient));
 
         // Assert
-        Assert.NotNull(socketsHttpHandler);
-        Assert.IsTrue(socketsHttpHandler!.EnableMultipleHttp2Connections);
+        Assert.NotNull(clientPrimaryHandler);
+        Assert.IsInstanceOf<SocketsHttpHandler>(clientPrimaryHandler);
+        Assert.IsTrue(((SocketsHttpHandler)clientPrimaryHandler!).EnableMultipleHttp2Connections);
     }
 #endif
 

--- a/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
+++ b/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">

--- a/testassets/InteropTestsWebsite/Dockerfile
+++ b/testassets/InteropTestsWebsite/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
 # Copy everything

--- a/testassets/LinkerTestsWebsite/Program.cs
+++ b/testassets/LinkerTestsWebsite/Program.cs
@@ -35,5 +35,4 @@ var app = builder.Build();
 
 app.MapGrpcService<GreeterService>();
 
-app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));
 app.Run();


### PR DESCRIPTION
PrimaryHandler is non-nullable so we shouldn't be setting it to null. This will cause problems when combined with changes in https://github.com/dotnet/runtime/pull/101808

This PR assigns primary handler at the start of config and tracks the initial value to see whether it's changed at post-configure if not valid.