### PR TITLE
[vote]Added Active maintainers into MAINTAINERS.md.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,10 +15,10 @@ for general contribution guidelines.
 - [BrennanConroy](https://github.com/BrennanConroy), Microsoft Corporation
 - [davidfowl](https://github.com/davidfowl), Microsoft Corporation
 - [JamesNK](https://github.com/JamesNK), Microsoft Corporation
-- [jtattermusch](https://github.com/jtattermusch), Google LLC
 - [mgravell](https://github.com/mgravell), Microsoft Corporation
 - [ReubenBond](https://github.com/ReubenBond), Microsoft Corporation
 - [stanley-cheung](https://github.com/stanley-cheung), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
+- [jtattermusch](https://github.com/jtattermusch)
 - [JunTaoLuo](https://github.com/JunTaoLuo)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,7 @@ for general contribution guidelines.
 - [jtattermusch](https://github.com/jtattermusch), Google LLC
 - [mgravell](https://github.com/mgravell), Microsoft Corporation
 - [ReubenBond](https://github.com/ReubenBond), Microsoft Corporation
+- [stanley-cheung](https://github.com/stanley-cheung), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
 - [JunTaoLuo](https://github.com/JunTaoLuo)


### PR DESCRIPTION
[vote] Added stanley-cheung into grpc/grpc-dotnet active maintainers list.  Please comment as "Agree" if you agree to the change, if not please comment as "Disagree". Your comment will be counted as a vote. The PR needs to stay open for 14 days, I.e. till 15th June 2024 as per governance guidelines