### PR TITLE
Update repo for .NET 9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,13 @@ jobs:
 
     - name: Build and run tests
       run: ./build_and_test.sh
+  
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: artifacts
+        path: artifacts
+        if-no-files-found: error
 
   grpc_web:
     name: gRPC-Web Tests

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,9 @@
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- Some packages generate warnings when used on TFMs that are out of support (or almost out of support) -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MicrosoftAspNetCoreAppPackageVersion>9.0.0-preview.4.24267.6</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>9.0.0-preview.5.24306.11</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreApp8PackageVersion>8.0.6</MicrosoftAspNetCoreApp8PackageVersion>
     <MicrosoftAspNetCoreApp7PackageVersion>7.0.5</MicrosoftAspNetCoreApp7PackageVersion>
     <MicrosoftAspNetCoreApp6PackageVersion>6.0.11</MicrosoftAspNetCoreApp6PackageVersion>
@@ -9,7 +9,7 @@
     <OpenTelemetryPackageVersion>1.6.0</OpenTelemetryPackageVersion>
     <OpenTelemetryIntergationPackageVersion>1.8.1</OpenTelemetryIntergationPackageVersion>
     <OpenTelemetryGrpcPackageVersion>1.8.0-beta.1</OpenTelemetryGrpcPackageVersion>
-    <MicrosoftExtensionsPackageVersion>9.0.0-preview.4.24266.19</MicrosoftExtensionsPackageVersion>
+    <MicrosoftExtensionsPackageVersion>9.0.0-preview.5.24306.7</MicrosoftExtensionsPackageVersion>
     <MicrosoftExtensionsLtsPackageVersion>6.0.0</MicrosoftExtensionsLtsPackageVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,14 +1,15 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MicrosoftAspNetCoreAppPackageVersion>8.0.0</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>9.0.0-preview.4.24267.6</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreApp8PackageVersion>8.0.6</MicrosoftAspNetCoreApp8PackageVersion>
     <MicrosoftAspNetCoreApp7PackageVersion>7.0.5</MicrosoftAspNetCoreApp7PackageVersion>
     <MicrosoftAspNetCoreApp6PackageVersion>6.0.11</MicrosoftAspNetCoreApp6PackageVersion>
-    <GrpcDotNetPackageVersion>2.58.0</GrpcDotNetPackageVersion>
+    <GrpcDotNetPackageVersion>2.63.0</GrpcDotNetPackageVersion>
     <OpenTelemetryPackageVersion>1.6.0</OpenTelemetryPackageVersion>
     <OpenTelemetryIntergationPackageVersion>1.8.1</OpenTelemetryIntergationPackageVersion>
     <OpenTelemetryGrpcPackageVersion>1.8.0-beta.1</OpenTelemetryGrpcPackageVersion>
-    <MicrosoftExtensionsPackageVersion>8.0.0</MicrosoftExtensionsPackageVersion>
+    <MicrosoftExtensionsPackageVersion>9.0.0-preview.4.24266.19</MicrosoftExtensionsPackageVersion>
     <MicrosoftExtensionsLtsPackageVersion>6.0.0</MicrosoftExtensionsLtsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -64,7 +65,7 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageVersion Include="Microsoft.Build" Version="16.9.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24216.2" />
     <PackageVersion Include="Microsoft.Crank.EventSources" Version="0.2.0-alpha.21255.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Testing" Version="2.1.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/build/get-dotnet.sh
+++ b/build/get-dotnet.sh
@@ -27,17 +27,14 @@ echo "Downloading install script: $install_script_url => $install_script_path"
 curl -sSL -o $install_script_path $install_script_url
 chmod +x $install_script_path
 
-# Install .NET Core 3.x SDK to run 3.x test targets
-$install_script_path -v 3.1.300 -i $dotnet_install_path
-
-# Install .NET 5 SDK to run 5.0 test targets
-$install_script_path -v 5.0.302 -i $dotnet_install_path
-
 # Install .NET 6 SDK to run 6.0 test targets
-$install_script_path -v 6.0.202 -i $dotnet_install_path
+$install_script_path -v 6.0.423 -i $dotnet_install_path
 
 # Install .NET 7 SDK to run 7.0 test targets
-$install_script_path -v 7.0.100 -i $dotnet_install_path
+$install_script_path -v 7.0.410 -i $dotnet_install_path
+
+# Install .NET 8 SDK to run 8.0 test targets
+$install_script_path -v 8.0.301 -i $dotnet_install_path
 
 # Install .NET version specified by global.json
 $install_script_path -v $sdk_version -i $dotnet_install_path

--- a/examples/Aggregator/Client/Client.csproj
+++ b/examples/Aggregator/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Aggregator/Server/Server.csproj
+++ b/examples/Aggregator/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Blazor/Client/Client.csproj
+++ b/examples/Blazor/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Blazor/Server/Server.csproj
+++ b/examples/Blazor/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>46982f83-f153-443e-b589-4b2bc7b5945e</UserSecretsId>
   </PropertyGroup>
 

--- a/examples/Browser/Server/Server.csproj
+++ b/examples/Browser/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <SpaRoot>wwwroot\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**;$(SpaRoot)dist\**</DefaultItemExcludes>
   </PropertyGroup>

--- a/examples/Certifier/Client/Client.csproj
+++ b/examples/Certifier/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Certifier/Server/Server.csproj
+++ b/examples/Certifier/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Channeler/Client/Client.csproj
+++ b/examples/Channeler/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Channeler/Server/Server.csproj
+++ b/examples/Channeler/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Coder/Client/Client.csproj
+++ b/examples/Coder/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Coder/Server/Server.csproj
+++ b/examples/Coder/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Compressor/Client/Client.csproj
+++ b/examples/Compressor/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Compressor/Server/Server.csproj
+++ b/examples/Compressor/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Container/Backend/Backend.csproj
+++ b/examples/Container/Backend/Backend.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Container/Backend/Dockerfile
+++ b/examples/Container/Backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0-preview AS build-env
 WORKDIR /app
 
 # Copy everything
@@ -8,7 +8,7 @@ RUN dotnet restore examples/Container/Backend
 RUN dotnet publish examples/Container/Backend -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:9.0-preview
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "Backend.dll"]

--- a/examples/Container/Frontend/Dockerfile
+++ b/examples/Container/Frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0-preview AS build-env
 WORKDIR /app
 
 # Copy everything
@@ -8,7 +8,7 @@ RUN dotnet restore examples/Container/Frontend
 RUN dotnet publish examples/Container/Frontend -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:9.0-preview
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "Frontend.dll"]

--- a/examples/Container/Frontend/Frontend.csproj
+++ b/examples/Container/Frontend/Frontend.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Counter/Client/Client.csproj
+++ b/examples/Counter/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Counter/Server/Server.csproj
+++ b/examples/Counter/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Downloader/Client/Client.csproj
+++ b/examples/Downloader/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/examples/Downloader/Server/Server.csproj
+++ b/examples/Downloader/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Error/Client/Client.csproj
+++ b/examples/Error/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Error/Server/Server.csproj
+++ b/examples/Error/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Frameworker/Server/Server.csproj
+++ b/examples/Frameworker/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Greeter/Client/Client.csproj
+++ b/examples/Greeter/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Greeter/Server/Server.csproj
+++ b/examples/Greeter/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Interceptor/Client/Client.csproj
+++ b/examples/Interceptor/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Interceptor/Server/Server.csproj
+++ b/examples/Interceptor/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Liber/Client/Client.csproj
+++ b/examples/Liber/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Liber/Server/Server.csproj
+++ b/examples/Liber/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Locator/Client/Client.csproj
+++ b/examples/Locator/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Locator/Server/Server.csproj
+++ b/examples/Locator/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Mailer/Client/Client.csproj
+++ b/examples/Mailer/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Mailer/Server/Server.csproj
+++ b/examples/Mailer/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Progressor/Client/Client.csproj
+++ b/examples/Progressor/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Progressor/Server/Server.csproj
+++ b/examples/Progressor/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Racer/Client/Client.csproj
+++ b/examples/Racer/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Racer/Server/Server.csproj
+++ b/examples/Racer/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Reflector/Client/Client.csproj
+++ b/examples/Reflector/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Reflector/Server/Server.csproj
+++ b/examples/Reflector/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Retrier/Client/Client.csproj
+++ b/examples/Retrier/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Retrier/Server/Server.csproj
+++ b/examples/Retrier/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Spar/Server/Server.csproj
+++ b/examples/Spar/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(SpaRoot)node_modules\**;$(SpaRoot)dist\**;$(DefaultItemExcludes)</DefaultItemExcludes>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>

--- a/examples/Tester/Client/Client.csproj
+++ b/examples/Tester/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>dotnet-Client-33BD397C-6A11-40D0-AF85-24B9610F7517</UserSecretsId>
   </PropertyGroup>
 

--- a/examples/Tester/Server/Server.csproj
+++ b/examples/Tester/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Tester/Tests/Tests.csproj
+++ b/examples/Tester/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Ticketer/Client/Client.csproj
+++ b/examples/Ticketer/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Ticketer/Server/Server.csproj
+++ b/examples/Ticketer/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Transcoder/Server/Server.csproj
+++ b/examples/Transcoder/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/examples/Transporter/Client/Client.csproj
+++ b/examples/Transporter/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Transporter/Server/Server.csproj
+++ b/examples/Transporter/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Uploader/Client/Client.csproj
+++ b/examples/Uploader/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Uploader/Server/Server.csproj
+++ b/examples/Uploader/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Vigor/Client/Client.csproj
+++ b/examples/Vigor/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Vigor/Server/Server.csproj
+++ b/examples/Vigor/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Worker/Client/Client.csproj
+++ b/examples/Worker/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>dotnet-Client-33BD397C-6A11-40D0-AF85-24B9610F7517</UserSecretsId>
   </PropertyGroup>
 

--- a/examples/Worker/Server/Server.csproj
+++ b/examples/Worker/Server/Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "9.0.100-preview.5.24305.3",
     "rollForward": "latestFeature"
   }
 }

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Client/CompressedUnaryClientBenchmark.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Client/CompressedUnaryClientBenchmark.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -47,7 +47,7 @@ public class CompressedUnaryClientBenchmark : UnaryClientBenchmarkBase
     protected override byte[] GetMessageData(HelloReply message)
     {
         var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers.Add(GrpcProtocolConstants.MessageAcceptEncodingHeader, TestCompressionProvider.Name);
+        httpContext.Request.Headers.Append(GrpcProtocolConstants.MessageAcceptEncodingHeader, TestCompressionProvider.Name);
 
         var callContext = HttpContextServerCallContextHelper.CreateServerCallContext(
             httpContext,

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Grpc.AspNetCore.Microbenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/perf/Grpc.AspNetCore.Microbenchmarks/Server/CompressedUnaryServerCallHandlerBenchmark.cs
+++ b/perf/Grpc.AspNetCore.Microbenchmarks/Server/CompressedUnaryServerCallHandlerBenchmark.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -46,7 +46,7 @@ public class CompressedUnaryServerCallHandlerBenchmark : UnaryServerCallHandlerB
     protected override byte[] GetMessageData(ChatMessage message)
     {
         var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers.Add(GrpcProtocolConstants.MessageAcceptEncodingHeader, TestCompressionProvider.Name);
+        httpContext.Request.Headers.Append(GrpcProtocolConstants.MessageAcceptEncodingHeader, TestCompressionProvider.Name);
 
         var callContext = HttpContextServerCallContextHelper.CreateServerCallContext(
             httpContext,

--- a/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcAspNetCoreServer/GrpcAspNetCoreServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Uncomment line below to enable gRPC-Web on the server -->
     <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
@@ -13,14 +13,9 @@
 
     <!-- Turn on preview features so we can use Http3. Can be removed in .NET 7 -->
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <!-- TODO(JamesNK): Workaround https://github.com/grpc/grpc/issues/29672 -->
-    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
-    
     <Protobuf Include="..\Shared\benchmark_service.proto" GrpcServices="Server" Link="Protos\benchmark_service.proto" />
     <Protobuf Include="..\Shared\messages.proto" GrpcServices="Server" Link="Protos\messages.proto" />
 

--- a/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
+++ b/perf/benchmarkapps/GrpcClient/GrpcClient.csproj
@@ -1,19 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <DefineConstants Condition="'$(EnableGrpcWeb)' == 'true'">$(DefineConstants);GRPC_WEB</DefineConstants>
     <!-- Enable server GC to more closely simulate a microservice app making calls -->
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <!-- TODO(JamesNK): Workaround https://github.com/grpc/grpc/issues/29672 -->
-    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
-
     <Protobuf Include="..\Shared\benchmark_service.proto" GrpcServices="Client" Link="Protos\benchmark_service.proto" />
     <Protobuf Include="..\Shared\messages.proto" GrpcServices="Client" Link="Protos\messages.proto" />
     

--- a/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
+++ b/perf/benchmarkapps/GrpcCoreServer/GrpcCoreServer.csproj
@@ -1,10 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <!-- TODO(JamesNK): Workaround https://github.com/grpc/grpc/issues/29672 -->
-    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/perf/benchmarkapps/QpsWorker/QpsWorker.csproj
+++ b/perf/benchmarkapps/QpsWorker/QpsWorker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
+++ b/src/Grpc.AspNetCore.HealthChecks/Grpc.AspNetCore.HealthChecks.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
+++ b/src/Grpc.AspNetCore.Server.ClientFactory/Grpc.AspNetCore.Server.ClientFactory.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
+++ b/src/Grpc.AspNetCore.Server.Reflection/Grpc.AspNetCore.Server.Reflection.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 
     <!-- Disable analysis for ConfigureAwait(false) -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA2007</WarningsNotAsErrors>

--- a/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
+++ b/src/Grpc.AspNetCore.Server/Grpc.AspNetCore.Server.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs
@@ -72,7 +72,7 @@ internal sealed partial class HttpContextServerCallContext : ServerCallContext, 
 
     protected override string MethodCore => HttpContext.Request.Path.Value!;
 
-    protected override string HostCore => HttpContext.Request.Host.Value;
+    protected override string HostCore => HttpContext.Request.Host.Value!;
 
     protected override string PeerCore
     {

--- a/src/Grpc.AspNetCore.Web/Grpc.AspNetCore.Web.csproj
+++ b/src/Grpc.AspNetCore.Web/Grpc.AspNetCore.Web.csproj
@@ -6,7 +6,7 @@
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- Disable analysis for ConfigureAwait(false) -->

--- a/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
+++ b/src/Grpc.AspNetCore/Grpc.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <PackageTags>gRPC RPC HTTP/2 aspnetcore</PackageTags>
 
     <IsGrpcPublishedPackage>true</IsGrpcPublishedPackage>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- Don't include empty DLL or PDB in metapackage -->

--- a/src/Grpc.Net.Client/Balancer/PollingResolver.cs
+++ b/src/Grpc.Net.Client/Balancer/PollingResolver.cs
@@ -147,7 +147,7 @@ public abstract class PollingResolver : Resolver
 
                     // Run ResolveAsync in a background task.
                     // This is done to prevent synchronous block inside ResolveAsync from blocking future Refresh calls.
-                    _resolveTask = Task.Run(() => ResolveNowAsync(_cts.Token), _cts.Token);
+                    _resolveTask = Task.Run(() => ResolveNowAsync(_cts.Token));
                     _resolveTask.ContinueWith(static (t, state) =>
                     {
                         var pollingResolver = (PollingResolver)state!;
@@ -172,6 +172,8 @@ public abstract class PollingResolver : Resolver
 
     private async Task ResolveNowAsync(CancellationToken cancellationToken)
     {
+        Log.ResolveStarting(_logger, GetType());
+
         // Reset resolve success to false. Will be set to true when an OK result is sent to listener.
         _resolveSuccessful = false;
 
@@ -274,9 +276,12 @@ public abstract class PollingResolver : Resolver
         private static readonly Action<ILogger, string, Exception> _errorRetryingResolve =
             LoggerMessage.Define<string>(LogLevel.Error, new EventId(6, "ErrorRetryingResolve"), "{ResolveType} error retrying resolve.");
 
-        private static readonly Action<ILogger, string,Exception?> _resolveTaskCompleted =
+        private static readonly Action<ILogger, string, Exception?> _resolveTaskCompleted =
             LoggerMessage.Define<string>(LogLevel.Trace, new EventId(7, "ResolveTaskCompleted"), "{ResolveType} resolve task completed.");
 
+        private static readonly Action<ILogger, string, Exception?> _resolveStarting =
+            LoggerMessage.Define<string>(LogLevel.Trace, new EventId(8, "ResolveStarting"), "{ResolveType} resolve starting.");
+        
         public static void ResolverRefreshRequested(ILogger logger, Type resolverType)
         {
             _resolverRefreshRequested(logger, resolverType.Name, null);
@@ -310,6 +315,11 @@ public abstract class PollingResolver : Resolver
         public static void ResolveTaskCompleted(ILogger logger, Type resolverType)
         {
             _resolveTaskCompleted(logger, resolverType.Name, null);
+        }
+
+        public static void ResolveStarting(ILogger logger, Type resolverType)
+        {
+            _resolveStarting(logger, resolverType.Name, null);
         }
     }
 }

--- a/test/FunctionalTests/Balancer/DnsResolverTests.cs
+++ b/test/FunctionalTests/Balancer/DnsResolverTests.cs
@@ -275,6 +275,7 @@ public class DnsResolverTests : FunctionalTestBase
         var dnsResolver = CreateDnsResolver(new Uri("dns:///localhost"), backoffDuration: TimeSpan.FromSeconds(5));
         dnsResolver.Start(r =>
         {
+            Logger.LogInformation("Setting resolver results to TCS {TcsId}", System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(tcs));
             tcs.TrySetResult(r);
         });
 
@@ -290,7 +291,10 @@ public class DnsResolverTests : FunctionalTestBase
         await dnsResolver._resolveTask.DefaultTimeout();
 
         Logger.LogInformation("Recreate TCS and refresh resolver again.");
+
         tcs = new TaskCompletionSource<ResolverResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Logger.LogInformation("New TCS: {TcsId}", System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(tcs));
+
         dnsResolver.Refresh();
 
         Logger.LogInformation("Dispose resolver while refresh is in progress. The refresh should be waiting for the min interval to complete.");

--- a/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
+++ b/test/FunctionalTests/Grpc.AspNetCore.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability>true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
 
@@ -9,7 +9,7 @@
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
     <DefineConstants>SUPPORT_LOAD_BALANCING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
@@ -27,11 +27,6 @@
     <Compile Include="..\Shared\BalancerWaitHelpers.cs" Link="Infrastructure\Balancer\BalancerWaitHelpers.cs" />
     <Compile Include="..\Shared\CallbackInterceptor.cs" Link="Infrastructure\CallbackInterceptor.cs" />
     <Compile Include="..\Shared\HttpEventSourceListener.cs" Link="Infrastructure\HttpEventSourceListener.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
   </ItemGroup>
   
   <ItemGroup>
@@ -65,6 +60,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" VersionOverride="$(MicrosoftAspNetCoreApp7PackageVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" VersionOverride="$(MicrosoftAspNetCoreApp8PackageVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
   </ItemGroup>
 

--- a/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcTestFixture.cs
@@ -73,7 +73,9 @@ public sealed class IPEndpointInfoContainer(Func<EndpointInfo> accessor) : Endpo
 
 public class GrpcTestFixture<TStartup> : IDisposable where TStartup : class
 {
-    private readonly string _socketPath = Path.Combine(Path.GetTempPath(), "grpc-transporter.tmp");
+#if NET5_0_OR_GREATER
+    private readonly string _socketPath = Path.GetTempFileName();
+#endif
     private readonly InProcessTestServer _server;
 
     public GrpcTestFixture(
@@ -308,10 +310,16 @@ public class GrpcTestFixture<TStartup> : IDisposable where TStartup : class
     {
         Client.Dispose();
         _server.Dispose();
+#if NET5_0_OR_GREATER
+        if (File.Exists(_socketPath))
+        {
+            File.Delete(_socketPath);
+        }
+#endif
     }
 
 #if NET6_0_OR_GREATER
-    private class Http3DelegatingHandler : DelegatingHandler
+private class Http3DelegatingHandler : DelegatingHandler
     {
         public Http3DelegatingHandler(HttpMessageHandler innerHandler)
         {

--- a/test/FunctionalTests/Linker/LinkerTests.cs
+++ b/test/FunctionalTests/Linker/LinkerTests.cs
@@ -34,19 +34,19 @@ public class LinkerTests
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(120);
 
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
     [Test]
     public async Task RunWebsiteAndCallWithClient_Aot_Success()
     {
         await RunWebsiteAndCallWithClient(publishAot: true);
     }
-#endif
 
     [Test]
     public async Task RunWebsiteAndCallWithClient_Trimming_Success()
     {
         await RunWebsiteAndCallWithClient(publishAot: false);
     }
+#endif
 
     private async Task RunWebsiteAndCallWithClient(bool publishAot)
     {

--- a/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.ClientFactory.Tests/Grpc.AspNetCore.Server.ClientFactory.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability>true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
   </PropertyGroup>

--- a/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
+++ b/test/Grpc.AspNetCore.Server.Tests/Grpc.AspNetCore.Server.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability>true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
   </PropertyGroup>

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -130,8 +130,11 @@ public class ClientChannelTests
             waitForReady: true,
             CancellationToken.None).AsTask().DefaultTimeout();
 
+        _ = LogPickComplete(pickTask2, logger);
+
         Assert.IsFalse(pickTask2.IsCompleted, "PickAsync should wait until an subchannel is ready.");
 
+        logger.LogInformation("Setting to ready subchannel.");
         resolver.UpdateAddresses(new List<BalancerAddress>
         {
             new BalancerAddress("localhost", 82)
@@ -139,6 +142,12 @@ public class ClientChannelTests
 
         var result2 = await pickTask2.DefaultTimeout();
         Assert.AreEqual(new DnsEndPoint("localhost", 82), result2.Address!.EndPoint);
+
+        static async Task LogPickComplete(Task<(Subchannel Subchannel, BalancerAddress Address, ISubchannelCallTracker? SubchannelCallTracker)> pickTask2, ILogger logger)
+        {
+            await pickTask2.DefaultTimeout();
+            logger.LogInformation("PickAsync complete.");
+        }
     }
 
     [Test]

--- a/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/PickFirstBalancerTests.cs
@@ -550,8 +550,13 @@ public class PickFirstBalancerTests
         await tcs.Task.DefaultTimeout();
 
         // Assert
-        var pickStartedCount = testSink.Writes.Count(w => w.EventId.Name == "PickStarted");
-        Assert.AreEqual(1, pickStartedCount);
+        await TestHelpers.AssertIsTrueRetryAsync(
+            () =>
+            {
+                var pickStartedCount = testSink.Writes.Count(w => w.EventId.Name == "PickStarted");
+                return pickStartedCount >= 1;
+            },
+            "Wait for pick started.").DefaultTimeout();
 
         transportFactory.Transports.Single().UpdateState(ConnectivityState.TransientFailure, new Status(StatusCode.Unavailable, "An error"));
 

--- a/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
+++ b/test/Grpc.Net.Client.Tests/Grpc.Net.Client.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
     <DefineConstants>SUPPORT_LOAD_BALANCING;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/test/Grpc.Net.Client.Web.Tests/Grpc.Net.Client.Web.Tests.csproj
+++ b/test/Grpc.Net.Client.Web.Tests/Grpc.Net.Client.Web.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>
   </PropertyGroup>

--- a/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
+++ b/test/Grpc.Net.ClientFactory.Tests/Grpc.Net.ClientFactory.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability>true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
     <DisableAspNetCoreDefaultClientTypeOverride>true</DisableAspNetCoreDefaultClientTypeOverride>

--- a/test/Grpc.StatusProto.Tests/Grpc.StatusProto.Tests.csproj
+++ b/test/Grpc.StatusProto.Tests/Grpc.StatusProto.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/test/dotnet-grpc.Tests/dotnet-grpc.Tests.csproj
+++ b/test/dotnet-grpc.Tests/dotnet-grpc.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- MSBuild has issues with testing frameworks other than the one referenced in global.json -->
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Grpc.Dotnet.Cli.Tests</RootNamespace>
   </PropertyGroup>

--- a/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
+++ b/testassets/BenchmarkWorkerWebsite/BenchmarkWorkerWebsite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>

--- a/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
+++ b/testassets/FunctionalTestsWebsite/FunctionalTestsWebsite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Multi-target because this website is referenced by Grpc.AspNetCore.FunctionalTests which also multi-targets -->
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
   </PropertyGroup>

--- a/testassets/InteropTestsClient/InteropTestsClient.csproj
+++ b/testassets/InteropTestsClient/InteropTestsClient.csproj
@@ -2,14 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net8.0;net7.0;net6.0;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net9.0;net8.0;net7.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net9.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Required for QUIC & HTTP/3 in .NET 6 - https://github.com/dotnet/runtime/pull/55332 -->
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Shared\Assert.cs" Link="Assert.cs" />

--- a/testassets/InteropTestsGrpcWebClient/InteropTestsGrpcWebClient.csproj
+++ b/testassets/InteropTestsGrpcWebClient/InteropTestsGrpcWebClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <DefineConstants>BLAZOR_WASM</DefineConstants>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>

--- a/testassets/InteropTestsGrpcWebWebsite/Dockerfile
+++ b/testassets/InteropTestsGrpcWebWebsite/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0-preview AS build-env
 WORKDIR /app
 
 # Copy everything
@@ -8,7 +8,7 @@ RUN dotnet restore testassets/InteropTestsGrpcWebWebsite
 RUN dotnet publish testassets/InteropTestsGrpcWebWebsite -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:9.0-preview
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "InteropTestsGrpcWebWebsite.dll", "--urls", "http://+:80"]

--- a/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
+++ b/testassets/InteropTestsGrpcWebWebsite/InteropTestsGrpcWebWebsite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/testassets/InteropTestsNativeServer/InteropTestsNativeServer.csproj
+++ b/testassets/InteropTestsNativeServer/InteropTestsNativeServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/testassets/InteropTestsWebsite/Dockerfile
+++ b/testassets/InteropTestsWebsite/Dockerfile
@@ -1,14 +1,14 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0-preview AS build-env
 WORKDIR /app
 
 # Copy everything
 COPY . ./
 RUN dotnet --info
 RUN dotnet restore testassets/InteropTestsWebsite
-RUN dotnet publish testassets/InteropTestsWebsite --framework net8.0 -c Release -o out -p:LatestFramework=true
+RUN dotnet publish testassets/InteropTestsWebsite --framework net9.0 -c Release -o out -p:LatestFramework=true
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:9.0-preview
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "InteropTestsWebsite.dll", "--port_http1", "80"]

--- a/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
+++ b/testassets/InteropTestsWebsite/InteropTestsWebsite.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'!='true'">net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LatestFramework)'=='true'">net9.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
 

--- a/testassets/LinkerTestsClient/LinkerTestsClient.csproj
+++ b/testassets/LinkerTestsClient/LinkerTestsClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishAot>$(AppPublishAot)</PublishAot>

--- a/testassets/LinkerTestsWebsite/LinkerTestsWebsite.csproj
+++ b/testassets/LinkerTestsWebsite/LinkerTestsWebsite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishAot>$(AppPublishAot)</PublishAot>    


### PR DESCRIPTION
* Update repo to .NET 9 SDK
* Add .NET 9 TFMs and tests. If you're wondering why an empty file is added to the Grpc.AspNetCore project, that's intentional to suppress a NuGet warning.
* Refactor how tests are run in CI. Now trx file is uploaded to artifacts