### PR TITLE
Bump branch version to 2.64.0-pre1

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,13 +2,13 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.61.0-dev</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.64.0-pre1</GrpcDotnetVersion>
 
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>
 
     <!-- file version of all grpc-dotnet -->
-    <GrpcDotnetAssemblyFileVersion>2.61.0.0</GrpcDotnetAssemblyFileVersion>
+    <GrpcDotnetAssemblyFileVersion>2.64.0.0</GrpcDotnetAssemblyFileVersion>
 
   </PropertyGroup>
 </Project>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -36,10 +36,10 @@ public static class VersionInfo
     /// <summary>
     /// Current <c>AssemblyFileVersion</c> of gRPC C# assemblies
     /// </summary>
-    public const string CurrentAssemblyFileVersion = "2.61.0.0";
+    public const string CurrentAssemblyFileVersion = "2.64.0.0";
 
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.61.0-dev";
+    public const string CurrentVersion = "2.64.0-pre1";
 }


### PR DESCRIPTION
This is to bump the branch `v2.64.x` version to `2.64.0-pre1`.