### PR TITLE
[2.64.x] Update Native.DetectWindowsVersion() to consider Windows Server 2019 to be Window Server

### DIFF
--- a/src/Grpc.Net.Client/Internal/Native.cs
+++ b/src/Grpc.Net.Client/Internal/Native.cs
@@ -36,7 +36,7 @@ internal static class Native
     internal static void DetectWindowsVersion(out Version version, out bool isWindowsServer)
     {
         // https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
-        const byte VER_NT_SERVER = 3;
+        const byte VER_NT_WORKSTATION = 1;
 
         var osVersionInfo = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf<OSVERSIONINFOEX>() };
 
@@ -46,7 +46,7 @@ internal static class Native
         }
 
         version = new Version(osVersionInfo.MajorVersion, osVersionInfo.MinorVersion, osVersionInfo.BuildNumber, 0);
-        isWindowsServer = osVersionInfo.ProductType == VER_NT_SERVER;
+        isWindowsServer = osVersionInfo.ProductType != VER_NT_WORKSTATION;
     }
 
     internal static bool IsUwp(string frameworkDescription, Version version)


### PR DESCRIPTION
https://github.com/grpc/grpc-dotnet/pull/2468 was merged after branch. Person who made PR has asked for it to be in upcoming release.