### PR TITLE
Reduce usage of RunContinuationsAsynchronously

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -144,6 +144,9 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
     internal void StartUnaryCore(HttpContent content)
     {
+        // Not created with RunContinuationsAsynchronously to avoid unnecessary dispatch to the thread pool.
+        // The TCS is set from RunCall but it is the last operation before the method exits so there shouldn't
+        // be an impact from running the response continutation synchronously.
         _responseTcs = new TaskCompletionSource<TResponse>();
 
         var timeout = GetTimeout();
@@ -163,6 +166,9 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
 
     internal void StartClientStreamingCore(HttpContentClientStreamWriter<TRequest, TResponse> clientStreamWriter, HttpContent content)
     {
+        // Not created with RunContinuationsAsynchronously to avoid unnecessary dispatch to the thread pool.
+        // The TCS is set from RunCall but it is the last operation before the method exits so there shouldn't
+        // be an impact from running the response continutation synchronously.
         _responseTcs = new TaskCompletionSource<TResponse>();
 
         var timeout = GetTimeout();

--- a/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
+++ b/src/Grpc.Net.Client/Internal/HttpClientCallInvoker.cs
@@ -177,7 +177,7 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         {
             // No retry/hedge policy configured. Fast path!
             // Note that callWrapper is null here and will be set later.
-            return CreateGrpcCall<TRequest, TResponse>(channel, method, options, attempt: 1, callWrapper: null);
+            return CreateGrpcCall<TRequest, TResponse>(channel, method, options, attempt: 1, forceAsyncHttpResponse: false, callWrapper: null);
         }
     }
 
@@ -210,6 +210,7 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         Method<TRequest, TResponse> method,
         CallOptions options,
         int attempt,
+        bool forceAsyncHttpResponse,
         object? callWrapper)
         where TRequest : class
         where TResponse : class
@@ -217,7 +218,7 @@ internal sealed class HttpClientCallInvoker : CallInvoker
         ObjectDisposedThrowHelper.ThrowIf(channel.Disposed, typeof(GrpcChannel));
 
         var methodInfo = channel.GetCachedGrpcMethodInfo(method);
-        var call = new GrpcCall<TRequest, TResponse>(method, methodInfo, options, channel, attempt);
+        var call = new GrpcCall<TRequest, TResponse>(method, methodInfo, options, channel, attempt, forceAsyncHttpResponse);
         call.CallWrapper = callWrapper;
 
         return call;

--- a/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/HedgingCall.cs
@@ -75,7 +75,7 @@ internal sealed partial class HedgingCall<TRequest, TResponse> : RetryCallBase<T
 
                 OnStartingAttempt();
 
-                call = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount, CallWrapper);
+                call = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount, forceAsyncHttpResponse: true, CallWrapper);
                 _activeCalls.Add(call);
 
                 startCallFunc(call);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCall.cs
@@ -109,7 +109,7 @@ internal sealed class RetryCall<TRequest, TResponse> : RetryCallBase<TRequest, T
                     // Start new call.
                     OnStartingAttempt();
 
-                    currentCall = _activeCall = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount, CallWrapper);
+                    currentCall = _activeCall = HttpClientCallInvoker.CreateGrpcCall<TRequest, TResponse>(Channel, Method, Options, AttemptCount, forceAsyncHttpResponse: true, CallWrapper);
                     startCallFunc(currentCall);
 
                     SetNewActiveCallUnsynchronized(currentCall);

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -37,6 +37,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
     private Task<TResponse>? _responseTask;
     private Task<Metadata>? _responseHeadersTask;
     private TRequest? _request;
+    private bool _commitStarted;
 
     // Internal for unit testing.
     internal CancellationTokenRegistration? _ctsRegistration;
@@ -369,8 +370,11 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
     {
         lock (Lock)
         {
-            if (!CommitedCallTask.IsCompletedSuccessfully())
+            if (!_commitStarted)
             {
+                // Specify that call is commiting but hasn't get set the TCS to publish commited call publically.
+                _commitStarted = true;
+
                 // The buffer size is verified in unit tests after calls are completed.
                 // Clear the buffer before commiting call.
                 ClearRetryBuffer();

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBase.cs
@@ -372,7 +372,7 @@ internal abstract partial class RetryCallBase<TRequest, TResponse> : IGrpcCall<T
         {
             if (!_commitStarted)
             {
-                // Specify that call is commiting but hasn't get set the TCS to publish commited call publically.
+                // Specify that call is commiting. This is to prevent any chance of re-entrancy from logic run in OnCommitCall.
                 _commitStarted = true;
 
                 // The buffer size is verified in unit tests after calls are completed.

--- a/test/Grpc.Net.Client.Tests/CancellationTests.cs
+++ b/test/Grpc.Net.Client.Tests/CancellationTests.cs
@@ -113,7 +113,7 @@ public class CancellationTests
 
         cts.Cancel();
 
-        var ex = await ExceptionAssert.ThrowsAsync<TaskCanceledException>(() => responseHeadersTask).DefaultTimeout();
+        var ex = await ExceptionAssert.ThrowsAsync<OperationCanceledException>(() => responseHeadersTask).DefaultTimeout();
         Assert.AreEqual(StatusCode.Cancelled, call.GetStatus().StatusCode);
         Assert.AreEqual("Call canceled by the client.", call.GetStatus().Detail);
     }

--- a/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
+++ b/test/Grpc.Net.Client.Tests/HttpContentClientStreamReaderTests.cs
@@ -231,7 +231,8 @@ public class HttpContentClientStreamReaderTests
             new GrpcMethodInfo(new GrpcCallScope(ClientTestHelpers.ServiceMethod.Type, uri), uri, methodConfig: null),
             new CallOptions(),
             channel,
-            attemptCount: 0);
+            attemptCount: 0,
+            forceAsyncHttpResponse: false);
     }
 
     private static GrpcChannel CreateChannel(HttpClient httpClient, ILoggerFactory? loggerFactory = null, bool? throwOperationCanceledOnCancellation = null)


### PR DESCRIPTION
`RunContinuationsAsynchronously` can cause dispatch from IO completion thread to thread pool, which can cause problems with sync over async and thread pool exhaustion.