### PR TITLE
feature: ReflectionServiceImpl allow anonymous

### DIFF
--- a/src/Grpc.Reflection/ReflectionServiceImpl.cs
+++ b/src/Grpc.Reflection/ReflectionServiceImpl.cs
@@ -17,12 +17,14 @@
 using Google.Protobuf.Reflection;
 using Grpc.Core;
 using Grpc.Reflection.V1Alpha;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Grpc.Reflection;
 
 /// <summary>
 /// Implementation of server reflection service.
 /// </summary>
+[AllowAnonymous]
 public class ReflectionServiceImpl : Grpc.Reflection.V1Alpha.ServerReflection.ServerReflectionBase
 {
     readonly List<string> services;


### PR DESCRIPTION
In general, the API allows anonymity default, but in our app it defaults to non-anonymity. The purpose is usually only enabled in the development environment and anonymity is allowed.
#2483 