### PR TITLE
Bump version to 2.65.0-pre1

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.65.0-dev</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.65.0-pre1</GrpcDotnetVersion>
 
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -41,5 +41,5 @@ public static class VersionInfo
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.65.0-dev";
+    public const string CurrentVersion = "2.65.0-pre1";
 }


### PR DESCRIPTION
Bump version on `v2.65.x` branch to `2.65.0-pre1`.