### PR TITLE
Fix failure to create GrpcChannel under Wine compatibility layer (including Steam Proton and Apple Game Porting Toolkit)

### DIFF
--- a/src/Grpc.Net.Client/Internal/Native.cs
+++ b/src/Grpc.Net.Client/Internal/Native.cs
@@ -64,21 +64,30 @@ internal static class Native
         }
         else
         {
-            var bufferSize = 0U;
-            var result = GetCurrentApplicationUserModelId(ref bufferSize, Array.Empty<byte>());
-            switch (result)
+            try
             {
-                case 15703: // APPMODEL_ERROR_NO_APPLICATION
-                    return false;
-                case 0:     // ERROR_SUCCESS
-                case 122:   // ERROR_INSUFFICIENT_BUFFER
-                            // Success is actually insufficient buffer as we're really only looking for
-                            // not NO_APPLICATION and we're not actually giving a buffer here. The
-                            // API will always return NO_APPLICATION if we're not running under a
-                            // WinRT process, no matter what size the buffer is.
-                    return true;
-                default:
-                    throw new InvalidOperationException($"Failed to get AppModelId, result was {result}.");
+                var bufferSize = 0U;
+                var result = GetCurrentApplicationUserModelId(ref bufferSize, Array.Empty<byte>());
+                switch (result)
+                {
+                    case 15703: // APPMODEL_ERROR_NO_APPLICATION
+                        return false;
+                    case 0:     // ERROR_SUCCESS
+                    case 122:   // ERROR_INSUFFICIENT_BUFFER
+                                // Success is actually insufficient buffer as we're really only looking for
+                                // not NO_APPLICATION and we're not actually giving a buffer here. The
+                                // API will always return NO_APPLICATION if we're not running under a
+                                // WinRT process, no matter what size the buffer is.
+                        return true;
+                    default:
+                        throw new InvalidOperationException($"Failed to get AppModelId, result was {result}.");
+                }
+            }
+            catch (EntryPointNotFoundException)
+            {
+                // Wine compatibility layers such as Steam Deck/Steam OS Proton and the Apple Game Porting Toolkit
+                // return Windows 8 or later as the OS version, but does not implement the GetCurrentApplicationUserModelId API.
+                return false;
             }
         }
     }


### PR DESCRIPTION
Wine compatibility layers such as Steam Deck/Steam OS Proton and the Apple Game Porting Toolkit return Windows 8 or later as the OS version, but does not implement the `GetCurrentApplicationUserModelId` API.

As a result, an issue occurs where it is not possible to create a `GrpcChannel` due to an `EntryPointNotFoundException`.

```
System.TypeInitializationException: The type initializer for 'Grpc.Net.Client.Internal.OperatingSystem' threw an exception. ---> System.EntryPointNotFoundException: GetCurrentApplicationUserModelId assembly:<unknown assembly> type:<unknowntype> member:(null)
  at (wrapper managed-to-native) Grpc.Net.Client.Internal.Native.GetCurrentApplicationUserModelId(uint&,byte[])
  at Grpc.Net.Client.Internal.Native.IsUwp (System.String frameworkDescription, System.Version version) [0x00028] in <cfd57654def7423a841054daeb7fc483>:0
  at Grpc.Net.Client.Internal.OperatingSystem..ctor () [0x00049] in <cfd57654def7423a841054daeb7fc483>:0
  at Grpc.Net.Client.Internal.OperatingSystem..cctor () [0x00000] in <cfd57654def7423a841054daeb7fc483>:0
```

For example, if using Grpc.Net.Client in a game developed with Unity, the game will not be playable on Steam Deck.