### PR TITLE
Remove internal_ci flag from interop test script

### DIFF
--- a/kokoro/interop.sh
+++ b/kokoro/interop.sh
@@ -27,4 +27,4 @@ cd ../grpc
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/run_tests/run_interop_tests.py -l aspnetcore c++ -s aspnetcore c++ --use_docker --internal_ci -t -j 8
+tools/run_tests/run_interop_tests.py -l aspnetcore c++ -s aspnetcore c++ --use_docker -t -j 8


### PR DESCRIPTION
interop builds triggered by CI are failing: https://btx.cloud.google.com/invocations/62b90494-0880-4141-86d0-bf62b11ee433/targets/grpc%2Fdotnet%2Fpresubmit%2Finterop;config=default/log

> run_interop_tests.py: error: unrecognized arguments: --internal_ci

Failure is caused by https://github.com/grpc/grpc/pull/37261

This PR removes the internal_ci flag.