### PR TITLE
Add HTTP version configuration to GrpcChannelOptions

### DIFF
--- a/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
+++ b/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
@@ -44,6 +44,7 @@ public sealed class GrpcWebHandler : DelegatingHandler
     /// be overridden.
     /// </para>
     /// </summary>
+    [Obsolete("HttpVersion is obsolete and will be removed in a future release. Use GrpcChannelOptions.HttpVersion and GrpcChannelOptions.HttpVersionPolicy instead.")]
     public Version? HttpVersion { get; set; }
 
     /// <summary>
@@ -136,13 +137,18 @@ public sealed class GrpcWebHandler : DelegatingHandler
         // https://github.com/mono/mono/issues/18718
         request.SetOption(WebAssemblyEnableStreamingResponseKey, true);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (HttpVersion != null)
         {
             // This doesn't guarantee that the specified version is used. Some handlers will ignore it.
             // For example, version in the browser always negotiated by the browser and HttpClient
             // uses what the browser has negotiated.
             request.Version = HttpVersion;
+#if NET5_0_OR_GREATER
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+#endif
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 #if NET5_0_OR_GREATER
         else if (request.RequestUri?.Scheme == Uri.UriSchemeHttps
             && request.VersionPolicy == HttpVersionPolicy.RequestVersionExact

--- a/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
+++ b/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
@@ -44,7 +44,11 @@ public sealed class GrpcWebHandler : DelegatingHandler
     /// be overridden.
     /// </para>
     /// </summary>
+#if NET5_0_OR_GREATER
     [Obsolete("HttpVersion is obsolete and will be removed in a future release. Use GrpcChannelOptions.HttpVersion and GrpcChannelOptions.HttpVersionPolicy instead.")]
+#else
+    [Obsolete("HttpVersion is obsolete and will be removed in a future release. Use GrpcChannelOptions.HttpVersion instead.")]
+#endif
     public Version? HttpVersion { get; set; }
 
     /// <summary>

--- a/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
+++ b/src/Grpc.Net.Client.Web/GrpcWebHandler.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -145,13 +145,13 @@ public sealed class GrpcWebHandler : DelegatingHandler
         }
 #if NET5_0_OR_GREATER
         else if (request.RequestUri?.Scheme == Uri.UriSchemeHttps
-            && request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher
+            && request.VersionPolicy == HttpVersionPolicy.RequestVersionExact
             && request.Version == System.Net.HttpVersion.Version20)
         {
-            // If no explicit HttpVersion is set and the request is using TLS then default to HTTP/1.1.
-            // HTTP/1.1 together with HttpVersionPolicy.RequestVersionOrHigher it will be compatible
-            // with all endpoints.
-            request.Version = System.Net.HttpVersion.Version11;
+            // If no explicit HttpVersion is set and the request is using TLS then change the version policy
+            // to allow for HTTP/1.1. HttpVersionPolicy.RequestVersionOrLower it will be compatible
+            // with HTTP/1.1 and HTTP/2.
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
         }
 #endif
 #if NETSTANDARD2_0

--- a/src/Grpc.Net.Client/GrpcChannel.cs
+++ b/src/Grpc.Net.Client/GrpcChannel.cs
@@ -79,6 +79,10 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
     internal Dictionary<string, ICompressionProvider> CompressionProviders { get; }
     internal string MessageAcceptEncoding { get; }
     internal bool Disposed { get; private set; }
+    internal Version HttpVersion { get; }
+#if NET5_0_OR_GREATER
+    internal HttpVersionPolicy HttpVersionPolicy { get; }
+#endif
 
 #if SUPPORT_LOAD_BALANCING
     // Load balancing
@@ -175,6 +179,10 @@ public sealed class GrpcChannel : ChannelBase, IDisposable
             RetryThrottling = serviceConfig.RetryThrottling != null ? CreateChannelRetryThrottling(serviceConfig.RetryThrottling) : null;
             _serviceConfigMethods = CreateServiceConfigMethods(serviceConfig);
         }
+        HttpVersion = channelOptions.HttpVersion ?? GrpcProtocolConstants.Http2Version;
+#if NET5_0_OR_GREATER
+        HttpVersionPolicy = channelOptions.HttpVersionPolicy ?? HttpVersionPolicy.RequestVersionExact;
+#endif
 
         // Non-HTTP addresses (e.g. dns:///custom-hostname) usually specify a path instead of an authority.
         // Only log about a path being present if HTTP or HTTPS.

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -304,9 +304,10 @@ public sealed class GrpcChannelOptions
     /// <summary>
     /// Gets or sets the HTTP policy to use when making gRPC calls.
     /// <para>
-    /// The policy determins how <see cref="Version"/> is interpreted when the final HTTP version is
-    /// negotiated with the server. Changing this property allows the HTTP version of gRPC calls to
-    /// be overridden.
+    /// When a <see cref="HttpVersionPolicy"/> is specified the value will be set on <see cref="HttpRequestMessage.VersionPolicy"/>
+    /// as gRPC calls are made. The policy determines how <see cref="Version"/> is interpreted when
+    /// the final HTTP version is negotiated with the server. Changing this property allows the HTTP
+    /// version of gRPC calls to be overridden.
     /// </para>
     /// <para>
     /// A <c>null</c> value doesn't override the HTTP policy of gRPC calls. Defaults to <see cref="HttpVersionPolicy.RequestVersionExact"/>.

--- a/src/Grpc.Net.Client/GrpcChannelOptions.cs
+++ b/src/Grpc.Net.Client/GrpcChannelOptions.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -286,6 +286,34 @@ public sealed class GrpcChannelOptions
     /// </para>
     /// </summary>
     public IServiceProvider? ServiceProvider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP version to use when making gRPC calls.
+    /// <para>
+    /// When a <see cref="Version"/> is specified the value will be set on <see cref="HttpRequestMessage.Version"/>
+    /// as gRPC calls are made. Changing this property allows the HTTP version of gRPC calls to
+    /// be overridden.
+    /// </para>
+    /// <para>
+    /// A <c>null</c> value doesn't override the HTTP version of gRPC calls. Defaults to <c>2.0</c>.
+    /// </para>
+    /// </summary>
+    public Version? HttpVersion { get; set; }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// Gets or sets the HTTP policy to use when making gRPC calls.
+    /// <para>
+    /// The policy determins how <see cref="Version"/> is interpreted when the final HTTP version is
+    /// negotiated with the server. Changing this property allows the HTTP version of gRPC calls to
+    /// be overridden.
+    /// </para>
+    /// <para>
+    /// A <c>null</c> value doesn't override the HTTP policy of gRPC calls. Defaults to <see cref="HttpVersionPolicy.RequestVersionExact"/>.
+    /// </para>
+    /// </summary>
+    public HttpVersionPolicy? HttpVersionPolicy { get; set; }
+#endif
 
     internal T ResolveService<T>(T defaultValue)
     {

--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -957,9 +957,9 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
     private HttpRequestMessage CreateHttpRequestMessage(TimeSpan? timeout)
     {
         var message = new HttpRequestMessage(HttpMethod.Post, _grpcMethodInfo.CallUri);
-        message.Version = GrpcProtocolConstants.Http2Version;
+        message.Version = Channel.HttpVersion;
 #if NET5_0_OR_GREATER
-        message.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+        message.VersionPolicy = Channel.HttpVersionPolicy;
 #endif
 
         // Set raw headers on request using name/values. Typed headers allocate additional objects.

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -317,13 +317,13 @@ public class ConnectionTests : FunctionalTestBase
             HttpHandler = grpcWebHandler,
             ServiceProvider = services.BuildServiceProvider(),
             Credentials = new SslCredentials(),
-            HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact
+            HttpVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
         });
 
         var client = TestClientFactory.Create(channel, endpoint1.Method);
 
         // Act
-        grpcWebHandler.HttpVersion = new Version(1, 1);
+        SetHandlerHttpVersion(grpcWebHandler, new Version(1, 1));
         var http11CallTasks = new List<Task<HelloReply>>();
         for (int i = 0; i < 10; i++)
         {
@@ -353,7 +353,7 @@ public class ConnectionTests : FunctionalTestBase
         }
 
         // Act
-        grpcWebHandler.HttpVersion = new Version(2, 0);
+        SetHandlerHttpVersion(grpcWebHandler, new Version(2, 0));
         var http2CallTasks = new List<Task<HelloReply>>();
         for (int i = 0; i < 10; i++)
         {
@@ -390,7 +390,7 @@ public class ConnectionTests : FunctionalTestBase
             return activeStreams.Count == 10;
         }, "Wait for HTTP/2 connection to end.");
 
-        grpcWebHandler.HttpVersion = new Version(1, 1);
+        SetHandlerHttpVersion(grpcWebHandler, new Version(1, 1));
 
         await Task.Delay(1000);
 
@@ -411,6 +411,13 @@ public class ConnectionTests : FunctionalTestBase
         activeStreams = transport.GetActiveStreams();
         Assert.AreEqual(1, activeStreams.Count);
         Assert.AreEqual(new DnsEndPoint("127.0.0.1", endpoint2.Address.Port), activeStreams[0].EndPoint);
+    }
+
+    private static void SetHandlerHttpVersion(GrpcWebHandler handler, Version version)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        handler.HttpVersion = version;
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
 #if NET7_0_OR_GREATER

--- a/test/FunctionalTests/Balancer/ConnectionTests.cs
+++ b/test/FunctionalTests/Balancer/ConnectionTests.cs
@@ -310,13 +310,14 @@ public class ConnectionTests : FunctionalTestBase
                 }
             }
         };
-        var grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb, new RequestVersionHandler(socketsHttpHandler));
+        var grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb, socketsHttpHandler);
         var channel = GrpcChannel.ForAddress("static:///localhost", new GrpcChannelOptions
         {
             LoggerFactory = LoggerFactory,
             HttpHandler = grpcWebHandler,
             ServiceProvider = services.BuildServiceProvider(),
-            Credentials = new SslCredentials()
+            Credentials = new SslCredentials(),
+            HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact
         });
 
         var client = TestClientFactory.Create(channel, endpoint1.Method);
@@ -560,20 +561,6 @@ public class ConnectionTests : FunctionalTestBase
         // Assert
         Assert.AreEqual("Bearer TEST", authorization);
         Assert.AreEqual("Balancer", reply.Message);
-    }
-
-    private class RequestVersionHandler : DelegatingHandler
-    {
-        public RequestVersionHandler(HttpMessageHandler innerHandler) : base(innerHandler)
-        {
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-
-            return base.SendAsync(request, cancellationToken);
-        }
     }
 
     [Test]

--- a/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
+++ b/test/FunctionalTests/Balancer/PickFirstBalancerTests.cs
@@ -47,21 +47,6 @@ namespace Grpc.AspNetCore.FunctionalTests.Balancer;
 [TestFixture]
 public class PickFirstBalancerTests : FunctionalTestBase
 {
-    private GrpcChannel CreateGrpcWebChannel(TestServerEndpointName endpointName, Version? version)
-    {
-        var grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb);
-        grpcWebHandler.HttpVersion = version;
-
-        var httpClient = Fixture.CreateClient(endpointName, grpcWebHandler);
-        var channel = GrpcChannel.ForAddress(httpClient.BaseAddress!, new GrpcChannelOptions
-        {
-            HttpClient = httpClient,
-            LoggerFactory = LoggerFactory
-        });
-
-        return channel;
-    }
-
     [Test]
     public async Task UnaryCall_CallAfterConnectionTimeout_Success()
     {

--- a/test/FunctionalTests/Client/ClientFactoryTests.cs
+++ b/test/FunctionalTests/Client/ClientFactoryTests.cs
@@ -104,7 +104,11 @@ public class ClientFactoryTests : FunctionalTestBase
             {
                 return TestClientFactory.Create(invoker, method);
             })
-            .AddHttpMessageHandler(() => new Http3Handler())
+            .ConfigureChannel(options =>
+            {
+                options.HttpVersion = HttpVersion.Version30;
+                options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+            })
             .ConfigurePrimaryHttpMessageHandler(() =>
             {
                 return new SocketsHttpHandler
@@ -124,21 +128,6 @@ public class ClientFactoryTests : FunctionalTestBase
 
         // Assert
         Assert.AreEqual("Hello world", response1.Message);
-    }
-
-    private class Http3Handler : DelegatingHandler
-    {
-        public Http3Handler() { }
-        public Http3Handler(HttpMessageHandler innerHandler) : base(innerHandler) { }
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            request.Version = HttpVersion.Version30;
-            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-
-            return base.SendAsync(request, cancellationToken);
-        }
     }
 #endif
 }

--- a/test/FunctionalTests/Infrastructure/GrpcHttpHelper.cs
+++ b/test/FunctionalTests/Infrastructure/GrpcHttpHelper.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -16,7 +16,6 @@
 
 #endregion
 
-
 namespace Grpc.AspNetCore.FunctionalTests.Infrastructure;
 
 public static class GrpcHttpHelper
@@ -26,7 +25,7 @@ public static class GrpcHttpHelper
         var request = new HttpRequestMessage(method ?? HttpMethod.Post, url);
         request.Version = new Version(2, 0);
 #if NET5_0_OR_GREATER
-        request.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
 #endif
 
         return request;

--- a/test/FunctionalTests/Web/GrpcWebFunctionalTestBase.cs
+++ b/test/FunctionalTests/Web/GrpcWebFunctionalTestBase.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -88,7 +88,9 @@ public abstract class GrpcWebFunctionalTestBase : FunctionalTestBase
             var mode = GrpcTestMode == GrpcTestMode.GrpcWeb ? GrpcWebMode.GrpcWeb : GrpcWebMode.GrpcWebText;
             grpcWebHandler = new GrpcWebHandler(mode)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 HttpVersion = protocol
+#pragma warning restore CS0618 // Type or member is obsolete
             };
         }
 

--- a/test/Grpc.Net.Client.Web.Tests/GrpcWebHandlerTests.cs
+++ b/test/Grpc.Net.Client.Web.Tests/GrpcWebHandlerTests.cs
@@ -54,8 +54,9 @@ public class GrpcWebHandlerTests
         Assert.AreEqual(GrpcWebProtocolConstants.Http2Version, response.Version);
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     [Test]
-    public async Task HttpVersion_Set_HttpRequestMessageVersionChanged()
+    public async Task HttpVersion_SetOnHandler_HttpRequestMessageVersionChanged()
     {
         // Arrange
         var request = new HttpRequestMessage
@@ -71,6 +72,34 @@ public class GrpcWebHandlerTests
         {
             InnerHandler = testHttpHandler,
             HttpVersion = HttpVersion.Version11
+        };
+        var messageInvoker = new HttpMessageInvoker(grpcWebHandler);
+
+        // Act
+        var response = await messageInvoker.SendAsync(request, CancellationToken.None);
+
+        // Assert
+        Assert.AreEqual(HttpVersion.Version11, testHttpHandler.Request!.Version);
+        Assert.AreEqual(GrpcWebProtocolConstants.Http2Version, response.Version);
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    [Test]
+    public async Task HttpVersion_SetOnMessage_HttpRequestMessageVersionChanged()
+    {
+        // Arrange
+        var request = new HttpRequestMessage
+        {
+            Version = HttpVersion.Version11,
+            Content = new ByteArrayContent(Array.Empty<byte>())
+            {
+                Headers = { ContentType = new MediaTypeHeaderValue("application/grpc") }
+            }
+        };
+        var testHttpHandler = new TestHttpHandler();
+        var grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb)
+        {
+            InnerHandler = testHttpHandler
         };
         var messageInvoker = new HttpMessageInvoker(grpcWebHandler);
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2404

The grpc client today can automatically upgrade to HTTP3. That is unexpected for most users and it can cause changes in behavior.

Also, there are situations where you want more exact control over HTTP version. Having to use a delegating handler is an awkward solution.

This PR:

* Adds `GrpcChannelOptions.HttpVersion` and `GrpcChannelOptions.HttpVersionPolicy`.
* Obsoletes `GrpcWebHandler.HttpVersion` and points users to the channel options
* Changes default version policy behavior to `RequestVersionExact`. Client will use HTTP/2 unless configured otherwise.