### PR TITLE
Refactor: Use `await using` for `packageVersionStream` to ensure proper disposal of async resources

### DIFF
--- a/src/dotnet-grpc/Commands/CommandBase.cs
+++ b/src/dotnet-grpc/Commands/CommandBase.cs
@@ -127,7 +127,7 @@ internal class CommandBase
         }*/
         try
         {
-            using var packageVersionStream = await _httpClient.GetStreamAsync(PackageVersionUrl);
+            await using var packageVersionStream = await _httpClient.GetStreamAsync(PackageVersionUrl);
             using var packageVersionDocument = await JsonDocument.ParseAsync(packageVersionStream);
             var packageVersionsElement = packageVersionDocument.RootElement.GetProperty("Packages");
             var packageVersionsDictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
### Summary
This PR refactors the `ResolvePackageVersions` method to use `await using` for `packageVersionStream`. This change ensures proper disposal of async resources, improving the reliability and performance of the application.

### Details
- Updated the `ResolvePackageVersions` method to use `await using` for `packageVersionStream`.
- This change ensures that the stream is properly disposed of even if an exception occurs, following best practices for asynchronous resource management.