### PR TITLE
Fix System.Text.Json vulnerability warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,7 +82,7 @@
     <PackageVersion Include="System.Memory" Version="4.5.3" />
     <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
-    <PackageVersion Include="System.Threading.Channels" Version="4.6.0" />
     <PackageVersion Include="System.Text.Json" Version="6.0.10" />
+    <PackageVersion Include="System.Threading.Channels" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,5 +83,6 @@
     <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="4.6.0" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-grpc/dotnet-grpc.csproj
+++ b/src/dotnet-grpc/dotnet-grpc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Command line tool for gRPC projects</Description>
     <PackageTags>gRPC RPC CLI</PackageTags>
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="System.CommandLine.Rendering" />
     <PackageReference Include="System.Security.Principal.Windows" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix warning about package:

> /home/runner/work/grpc-dotnet/grpc-dotnet/src/dotnet-grpc/dotnet-grpc.csproj : error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/home/runner/work/grpc-dotnet/grpc-dotnet/Grpc.DotNet.sln]
> /home/runner/work/grpc-dotnet/grpc-dotnet/test/dotnet-grpc.Tests/dotnet-grpc.Tests.csproj : error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4 [/home/runner/work/grpc-dotnet/grpc-dotnet/Grpc.DotNet.sln]