### PR TITLE
Performance microoptimizations

### DIFF
--- a/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcProtocolHelpers.cs
@@ -18,6 +18,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Grpc.Core;
@@ -108,7 +109,7 @@ internal static class GrpcProtocolHelpers
         switch (base64.Length % 4)
         {
             case 0:
-                // base64 has the required padding 
+                // base64 has the required padding
                 decodable = base64;
                 break;
             case 2:
@@ -208,11 +209,8 @@ internal static class GrpcProtocolHelpers
 
         static void AddProperty(Dictionary<string, List<AuthProperty>> properties, string name, string value)
         {
-            if (!properties.TryGetValue(name, out var values))
-            {
-                values = new List<AuthProperty>();
-                properties[name] = values;
-            }
+            ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(properties, name, out _);
+            values ??= [];
 
             values.Add(AuthProperty.Create(name, Encoding.UTF8.GetBytes(value)));
         }

--- a/src/Grpc.AspNetCore.Web/Internal/ServerGrpcWebMode.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/ServerGrpcWebMode.cs
@@ -20,7 +20,7 @@ namespace Grpc.AspNetCore.Web.Internal;
 
 internal readonly record struct ServerGrpcWebContext(ServerGrpcWebMode Request, ServerGrpcWebMode Response);
 
-internal enum ServerGrpcWebMode
+internal enum ServerGrpcWebMode : byte
 {
     None,
     GrpcWeb,

--- a/src/Shared/Server/MethodOptions.cs
+++ b/src/Shared/Server/MethodOptions.cs
@@ -158,10 +158,7 @@ internal sealed class MethodOptions
         {
             foreach (var compressionProvider in compressionProviders)
             {
-                if (!resolvedProviders.ContainsKey(compressionProvider.EncodingName))
-                {
-                    resolvedProviders.Add(compressionProvider.EncodingName, compressionProvider);
-                }
+                resolvedProviders.TryAdd(compressionProvider.EncodingName, compressionProvider);
             }
         }
     }


### PR DESCRIPTION
- Reduce the size of the internal struct ServerGrpcWebContext that is copied around
- Avoid double lookup in dictionary

Non-breaking changes