### PR TITLE
Correctness: Make some private & internal classes sealed where possible

### DIFF
--- a/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
+++ b/perf/benchmarkapps/Shared/BenchmarkServiceImpl.cs
@@ -20,7 +20,7 @@ using Google.Protobuf;
 using Grpc.Core;
 using Grpc.Testing;
 
-class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
+sealed class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
 {
 #if CLIENT_CERTIFICATE_AUTHENTICATION
     [Microsoft.AspNetCore.Authorization.Authorize]

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
@@ -24,7 +24,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
-internal class ClientStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
+internal sealed class ClientStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class
     where TService : class

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
-internal class DuplexStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
+internal sealed class DuplexStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class
     where TService : class

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerStreamingServerCallHandler.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
-internal class ServerStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
+internal sealed class ServerStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class
     where TService : class

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
@@ -24,7 +24,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
-internal class UnaryServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
+internal sealed class UnaryServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class
     where TService : class

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcMarkerService.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcMarkerService.cs
@@ -24,6 +24,6 @@ namespace Grpc.AspNetCore.Server.Internal;
 /// A marker class used to determine if all the required gRPC services were added
 /// to the <see cref="IServiceCollection"/>.
 /// </summary>
-internal class GrpcMarkerService
+internal sealed class GrpcMarkerService
 {
 }

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServerBuilder.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServerBuilder.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Grpc.AspNetCore.Server.Internal;
 
-internal class GrpcServerBuilder : IGrpcServerBuilder
+internal sealed class GrpcServerBuilder : IGrpcServerBuilder
 {
     public IServiceCollection Services { get; }
 

--- a/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/GrpcServiceOptionsSetup.cs
@@ -22,7 +22,7 @@ using Microsoft.Extensions.Options;
 
 namespace Grpc.AspNetCore.Server.Internal;
 
-internal class GrpcServiceOptionsSetup : IConfigureOptions<GrpcServiceOptions>
+internal sealed class GrpcServiceOptionsSetup : IConfigureOptions<GrpcServiceOptions>
 {
     // Default to no send limit and 4mb receive limit.
     // Matches the gRPC C impl defaults
@@ -45,7 +45,7 @@ internal class GrpcServiceOptionsSetup : IConfigureOptions<GrpcServiceOptions>
     }
 }
 
-internal class GrpcServiceOptionsSetup<TService> : IConfigureOptions<GrpcServiceOptions<TService>> where TService : class
+internal sealed class GrpcServiceOptionsSetup<TService> : IConfigureOptions<GrpcServiceOptions<TService>> where TService : class
 {
     private readonly GrpcServiceOptions _options;
 

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamReader.cs
@@ -26,7 +26,7 @@ namespace Grpc.AspNetCore.Server.Internal;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
 [DebuggerTypeProxy(typeof(HttpContextStreamReader<>.HttpContextStreamReaderDebugView))]
-internal class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> where TRequest : class
+internal sealed class HttpContextStreamReader<TRequest> : IAsyncStreamReader<TRequest> where TRequest : class
 {
     private readonly HttpContextServerCallContext _serverCallContext;
     private readonly Func<DeserializationContext, TRequest> _deserializer;

--- a/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/HttpContextStreamWriter.cs
@@ -26,7 +26,7 @@ namespace Grpc.AspNetCore.Server.Internal;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
 [DebuggerTypeProxy(typeof(HttpContextStreamWriter<>.HttpContextStreamWriterDebugView))]
-internal class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TResponse>
+internal sealed class HttpContextStreamWriter<TResponse> : IServerStreamWriter<TResponse>
     where TResponse : class
 {
     private readonly HttpContextServerCallContext _context;

--- a/src/Grpc.AspNetCore.Server/Internal/ReadOnlySequenceStream.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ReadOnlySequenceStream.cs
@@ -21,7 +21,7 @@ using System.Buffers;
 namespace Grpc.AspNetCore.Server.Internal;
 
 // Potentially remove in the future when https://github.com/dotnet/corefx/issues/31804 is implemented
-internal class ReadOnlySequenceStream : Stream
+internal sealed class ReadOnlySequenceStream : Stream
 {
     private static readonly Task<int> TaskOfZero = Task.FromResult(0);
 

--- a/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs
@@ -31,7 +31,7 @@ namespace Grpc.AspNetCore.Server.Internal;
 /// <summary>
 /// Creates server call handlers. Provides a place to get services that call handlers will use.
 /// </summary>
-internal partial class ServerCallHandlerFactory<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> where TService : class
+internal sealed partial class ServerCallHandlerFactory<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> where TService : class
 {
     private readonly ILoggerFactory _loggerFactory;
     private readonly IGrpcServiceActivator<TService> _serviceActivator;

--- a/src/Grpc.AspNetCore.Server/Internal/SystemClock.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/SystemClock.cs
@@ -18,7 +18,7 @@
 
 namespace Grpc.AspNetCore.Server.Internal;
 
-internal class SystemClock : ISystemClock
+internal sealed class SystemClock : ISystemClock
 {
     public static readonly SystemClock Instance = new SystemClock();
 

--- a/src/Grpc.AspNetCore.Server/Model/Internal/BinderServiceModelProvider.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/BinderServiceModelProvider.cs
@@ -24,7 +24,7 @@ using Log = Grpc.AspNetCore.Server.Model.Internal.BinderServiceMethodProviderLog
 
 namespace Grpc.AspNetCore.Server.Model.Internal;
 
-internal class BinderServiceMethodProvider<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> : IServiceMethodProvider<TService> where TService : class
+internal sealed class BinderServiceMethodProvider<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> : IServiceMethodProvider<TService> where TService : class
 {
     private readonly ILogger<BinderServiceMethodProvider<TService>> _logger;
 

--- a/src/Grpc.AspNetCore.Server/Model/Internal/MethodModel.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/MethodModel.cs
@@ -22,7 +22,7 @@ using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace Grpc.AspNetCore.Server.Model.Internal;
 
-internal class MethodModel
+internal sealed class MethodModel
 {
     public MethodModel(IMethod method, RoutePattern pattern, IList<object> metadata, RequestDelegate requestDelegate)
     {

--- a/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ProviderServiceBinder.cs
@@ -24,7 +24,7 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Grpc.AspNetCore.Server.Model.Internal;
 
-internal class ProviderServiceBinder<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> : ServiceBinderBase where TService : class
+internal sealed class ProviderServiceBinder<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> : ServiceBinderBase where TService : class
 {
     private readonly ServiceMethodProviderContext<TService> _context;
     private readonly Type _declaringType;

--- a/src/Grpc.AspNetCore.Server/Model/Internal/ServiceMethodsRegistry.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ServiceMethodsRegistry.cs
@@ -21,7 +21,7 @@ namespace Grpc.AspNetCore.Server.Model.Internal;
 /// <summary>
 /// A registry of all the service methods in the application.
 /// </summary>
-internal class ServiceMethodsRegistry
+internal sealed class ServiceMethodsRegistry
 {
     public List<MethodModel> Methods { get; } = new List<MethodModel>();
 }

--- a/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
+++ b/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs
@@ -27,7 +27,7 @@ using Log = Grpc.AspNetCore.Server.Model.Internal.ServiceRouteBuilderLog;
 
 namespace Grpc.AspNetCore.Server.Model.Internal;
 
-internal class ServiceRouteBuilder<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> where TService : class
+internal sealed class ServiceRouteBuilder<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService> where TService : class
 {
     private readonly IEnumerable<IServiceMethodProvider<TService>> _serviceMethodProviders;
     private readonly ServerCallHandlerFactory<TService> _serverCallHandlerFactory;

--- a/src/Grpc.AspNetCore.Web/Internal/Base64PipeReader.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/Base64PipeReader.cs
@@ -25,7 +25,7 @@ namespace Grpc.AspNetCore.Web.Internal;
 /// <summary>
 /// Reads and decodes base64 encoded bytes from the inner reader.
 /// </summary>
-internal class Base64PipeReader : PipeReader
+internal sealed class Base64PipeReader : PipeReader
 {
     private readonly PipeReader _inner;
     private ReadOnlySequence<byte> _currentDecodedBuffer;

--- a/src/Grpc.AspNetCore.Web/Internal/Base64PipeWriter.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/Base64PipeWriter.cs
@@ -25,7 +25,7 @@ namespace Grpc.AspNetCore.Web.Internal;
 /// <summary>
 /// Writes bytes as base64 encoded to the inner writer.
 /// </summary>
-internal class Base64PipeWriter : PipeWriter
+internal sealed class Base64PipeWriter : PipeWriter
 {
     private readonly PipeWriter _inner;
     // We have to write original data to buffer. GetSpan/GetMemory isn't guaranteed to return the

--- a/src/Grpc.AspNetCore.Web/Internal/GrpcWebFeature.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/GrpcWebFeature.cs
@@ -22,7 +22,7 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace Grpc.AspNetCore.Web.Internal;
 
-internal class GrpcWebFeature :
+internal sealed class GrpcWebFeature :
     IRequestBodyPipeFeature,
     IHttpResponseBodyFeature,
     IHttpResponseTrailersFeature,

--- a/src/Grpc.AspNetCore.Web/Internal/MemorySegment.cs
+++ b/src/Grpc.AspNetCore.Web/Internal/MemorySegment.cs
@@ -20,7 +20,7 @@ using System.Buffers;
 
 namespace Grpc.AspNetCore.Web.Internal;
 
-internal class MemorySegment<T> : ReadOnlySequenceSegment<T>
+internal sealed class MemorySegment<T> : ReadOnlySequenceSegment<T>
 {
     public MemorySegment(ReadOnlyMemory<T> memory)
     {

--- a/src/Grpc.Core.Api/CallCredentials.cs
+++ b/src/Grpc.Core.Api/CallCredentials.cs
@@ -53,7 +53,7 @@ public abstract class CallCredentials
     /// </summary>
     public abstract void InternalPopulateConfiguration(CallCredentialsConfiguratorBase configurator, object? state);
 
-    private class CompositeCallCredentials : CallCredentials
+    private sealed class CompositeCallCredentials : CallCredentials
     {
         readonly IReadOnlyList<CallCredentials> credentials;
 
@@ -69,7 +69,7 @@ public abstract class CallCredentials
         }
     }
 
-    private class AsyncAuthInterceptorCredentials : CallCredentials
+    private sealed class AsyncAuthInterceptorCredentials : CallCredentials
     {
         readonly AsyncAuthInterceptor interceptor;
 

--- a/src/Grpc.Core.Api/ClientBase.cs
+++ b/src/Grpc.Core.Api/ClientBase.cs
@@ -175,12 +175,12 @@ public abstract class ClientBase
     /// <summary>
     /// Represents configuration of ClientBase. The class itself is visible to
     /// subclasses, but contents are marked as internal to make the instances opaque.
-    /// The verbose name of this class was chosen to make name clash in generated code 
+    /// The verbose name of this class was chosen to make name clash in generated code
     /// less likely.
     /// </summary>
     protected internal class ClientBaseConfiguration
     {
-        private class ClientBaseConfigurationInterceptor : Interceptor
+        private sealed class ClientBaseConfigurationInterceptor : Interceptor
         {
             readonly Func<IMethod, string?, CallOptions, ClientBaseConfigurationInfo> interceptor;
 

--- a/src/Grpc.Core.Api/Interceptors/CallInvokerExtensions.cs
+++ b/src/Grpc.Core.Api/Interceptors/CallInvokerExtensions.cs
@@ -94,7 +94,7 @@ public static class CallInvokerExtensions
         return new InterceptingCallInvoker(invoker, new MetadataInterceptor(interceptor));
     }
 
-    private class MetadataInterceptor : Interceptor
+    private sealed class MetadataInterceptor : Interceptor
     {
         readonly Func<Metadata, Metadata> interceptor;
 

--- a/src/Grpc.Core.Api/Interceptors/InterceptingCallInvoker.cs
+++ b/src/Grpc.Core.Api/Interceptors/InterceptingCallInvoker.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-using System;
 using System.Diagnostics;
 using Grpc.Core.Utils;
 
@@ -27,7 +26,7 @@ namespace Grpc.Core.Interceptors;
 /// intercept calls through a given interceptor.
 /// </summary>
 [DebuggerDisplay("{invoker}")]
-internal class InterceptingCallInvoker : CallInvoker
+internal sealed class InterceptingCallInvoker : CallInvoker
 {
     readonly CallInvoker invoker;
     readonly Interceptor interceptor;

--- a/src/Grpc.Core.Api/Internal/UnimplementedCallInvoker.cs
+++ b/src/Grpc.Core.Api/Internal/UnimplementedCallInvoker.cs
@@ -17,16 +17,13 @@
 #endregion
 
 using System;
-using System.Threading.Tasks;
-using Grpc.Core;
-using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal;
 
 /// <summary>
 /// Call invoker that throws <c>NotImplementedException</c> for all requests.
 /// </summary>
-internal class UnimplementedCallInvoker : CallInvoker
+internal sealed class UnimplementedCallInvoker : CallInvoker
 {
     public UnimplementedCallInvoker()
     {

--- a/src/Grpc.Net.Client.Web/Internal/Base64RequestStream.cs
+++ b/src/Grpc.Net.Client.Web/Internal/Base64RequestStream.cs
@@ -21,7 +21,7 @@ using System.Buffers.Text;
 
 namespace Grpc.Net.Client.Web.Internal;
 
-internal class Base64RequestStream : Stream
+internal sealed class Base64RequestStream : Stream
 {
     private readonly Stream _inner;
     private byte[]? _buffer;

--- a/src/Grpc.Net.Client.Web/Internal/Base64ResponseStream.cs
+++ b/src/Grpc.Net.Client.Web/Internal/Base64ResponseStream.cs
@@ -22,7 +22,7 @@ using System.Diagnostics;
 
 namespace Grpc.Net.Client.Web.Internal;
 
-internal class Base64ResponseStream : Stream
+internal sealed class Base64ResponseStream : Stream
 {
     private readonly Stream _inner;
 

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebRequestContent.cs
@@ -20,7 +20,7 @@ using System.Net;
 
 namespace Grpc.Net.Client.Web.Internal;
 
-internal class GrpcWebRequestContent : HttpContent
+internal sealed class GrpcWebRequestContent : HttpContent
 {
     private readonly HttpContent _inner;
     private readonly GrpcWebMode _mode;

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseContent.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseContent.cs
@@ -21,7 +21,7 @@ using System.Net.Http.Headers;
 
 namespace Grpc.Net.Client.Web.Internal;
 
-internal class GrpcWebResponseContent : HttpContent
+internal sealed class GrpcWebResponseContent : HttpContent
 {
     private readonly HttpContent _inner;
     private readonly GrpcWebMode _mode;

--- a/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseStream.cs
+++ b/src/Grpc.Net.Client.Web/Internal/GrpcWebResponseStream.cs
@@ -29,7 +29,7 @@ namespace Grpc.Net.Client.Web.Internal;
 /// for trailers. When the trailers message is encountered then they are parsed as HTTP/1.1 trailers and
 /// added to the HttpResponseMessage.TrailingHeaders.
 /// </summary>
-internal class GrpcWebResponseStream : Stream
+internal sealed class GrpcWebResponseStream : Stream
 {
     private const int HeaderLength = 5;
 

--- a/src/Grpc.Net.Client.Web/Internal/OperatingSystem.cs
+++ b/src/Grpc.Net.Client.Web/Internal/OperatingSystem.cs
@@ -25,7 +25,7 @@ internal interface IOperatingSystem
     bool IsBrowser { get; }
 }
 
-internal class OperatingSystem : IOperatingSystem
+internal sealed class OperatingSystem : IOperatingSystem
 {
     public static readonly OperatingSystem Instance = new OperatingSystem();
 

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerAddressEqualityComparer.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerAddressEqualityComparer.cs
@@ -21,7 +21,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Grpc.Net.Client.Balancer.Internal;
 
-internal class BalancerAddressEqualityComparer : IEqualityComparer<BalancerAddress>
+internal sealed class BalancerAddressEqualityComparer : IEqualityComparer<BalancerAddress>
 {
     internal static readonly BalancerAddressEqualityComparer Instance = new BalancerAddressEqualityComparer();
 

--- a/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/BalancerHttpHandler.cs
@@ -17,19 +17,14 @@
 #endregion
 
 #if SUPPORT_LOAD_BALANCING
-using System;
 using System.Diagnostics;
-using System.IO;
 using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Grpc.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Grpc.Net.Client.Balancer.Internal;
 
-internal partial class BalancerHttpHandler : DelegatingHandler
+internal sealed partial class BalancerHttpHandler : DelegatingHandler
 {
     private static readonly object SetupLock = new object();
 
@@ -178,7 +173,7 @@ internal partial class BalancerHttpHandler : DelegatingHandler
         public static partial void SendingRequest(ILogger logger, Uri requestUri);
 
         [LoggerMessage(Level = LogLevel.Trace, EventId = 2, EventName = "StartingConnectCallback", Message = "Starting connect callback for {Endpoint}.")]
-        private static partial void StartingConnectCallback(ILogger logger, string endpoint); 
+        private static partial void StartingConnectCallback(ILogger logger, string endpoint);
 
         public static void StartingConnectCallback(ILogger logger, DnsEndPoint endpoint)
         {

--- a/src/Grpc.Net.Client/Balancer/Internal/ErrorPicker.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/ErrorPicker.cs
@@ -17,13 +17,12 @@
 #endregion
 
 #if SUPPORT_LOAD_BALANCING
-using System;
 using System.Diagnostics;
 using Grpc.Core;
 
 namespace Grpc.Net.Client.Balancer.Internal;
 
-internal class ErrorPicker : SubchannelPicker
+internal sealed class ErrorPicker : SubchannelPicker
 {
     private readonly Status _status;
 

--- a/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/PassiveSubchannelTransport.cs
@@ -17,12 +17,8 @@
 #endregion
 
 #if SUPPORT_LOAD_BALANCING
-using System;
 using System.Diagnostics;
-using System.IO;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Grpc.Core;
 
 namespace Grpc.Net.Client.Balancer.Internal;
@@ -32,7 +28,7 @@ namespace Grpc.Net.Client.Balancer.Internal;
 /// This transport will only be used when there is one address.
 /// It isn't able to correctly determine connectivity state.
 /// </summary>
-internal class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
+internal sealed class PassiveSubchannelTransport : ISubchannelTransport, IDisposable
 {
     private readonly Subchannel _subchannel;
     private DnsEndPoint? _currentEndPoint;

--- a/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
+++ b/src/Grpc.Net.Client/Balancer/Internal/SocketConnectivitySubchannelTransport.cs
@@ -28,7 +28,7 @@ namespace Grpc.Net.Client.Balancer.Internal;
 
 /// <summary>
 /// Transport that makes it possible to monitor connectivity state while using HttpClient.
-/// 
+///
 /// Features:
 /// 1. When a connection is requested the transport creates a Socket and connects to the server.
 ///    The socket is used with the first stream created by SocketsHttpHandler.ConnectCallback.
@@ -39,7 +39,7 @@ namespace Grpc.Net.Client.Balancer.Internal;
 /// 2. Transport supports multiple addresses. When connecting it will iterate through the addresses,
 ///    attempting to connect to each one.
 /// </summary>
-internal class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDisposable
+internal sealed class SocketConnectivitySubchannelTransport : ISubchannelTransport, IDisposable
 {
     private const int MaximumInitialSocketDataSize = 1024 * 16;
     internal static readonly TimeSpan SocketPingInterval = TimeSpan.FromSeconds(5);

--- a/src/Grpc.Net.Client/Balancer/PickFirstBalancer.cs
+++ b/src/Grpc.Net.Client/Balancer/PickFirstBalancer.cs
@@ -17,8 +17,6 @@
 #endregion
 
 #if SUPPORT_LOAD_BALANCING
-using System;
-using System.Collections.Generic;
 using Grpc.Core;
 using Grpc.Net.Client.Balancer.Internal;
 using Grpc.Net.Client.Configuration;
@@ -187,7 +185,7 @@ internal class PickFirstPicker : SubchannelPicker
     }
 }
 
-internal class RequestConnectionPicker : PickFirstPicker
+internal sealed class RequestConnectionPicker : PickFirstPicker
 {
     public RequestConnectionPicker(Subchannel subchannel) : base(subchannel)
     {

--- a/src/Grpc.Net.Client/Internal/GrpcCallScope.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCallScope.cs
@@ -21,7 +21,7 @@ using Grpc.Core;
 
 namespace Grpc.Net.Client.Internal;
 
-internal class GrpcCallScope : IReadOnlyList<KeyValuePair<string, object>>
+internal sealed class GrpcCallScope : IReadOnlyList<KeyValuePair<string, object>>
 {
     private const string GrpcMethodTypeKey = "GrpcMethodType";
     private const string GrpcUriKey = "GrpcUri";

--- a/src/Grpc.Net.Client/Internal/GrpcMethodInfo.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcMethodInfo.cs
@@ -24,7 +24,7 @@ namespace Grpc.Net.Client.Internal;
 /// <summary>
 /// Cached log scope and URI for a gRPC <see cref="IMethod"/>.
 /// </summary>
-internal class GrpcMethodInfo
+internal sealed class GrpcMethodInfo
 {
     public GrpcMethodInfo(GrpcCallScope logScope, Uri callUri, MethodConfig? methodConfig)
     {
@@ -116,13 +116,13 @@ internal class GrpcMethodInfo
     public MethodConfigInfo? MethodConfig { get; }
 }
 
-internal class MethodConfigInfo
+internal sealed class MethodConfigInfo
 {
     public RetryPolicyInfo? RetryPolicy { get; set; }
     public HedgingPolicyInfo? HedgingPolicy { get; set; }
 }
 
-internal class RetryPolicyInfo
+internal sealed class RetryPolicyInfo
 {
     public int MaxAttempts { get; init; }
     public TimeSpan InitialBackoff { get; init; }
@@ -131,7 +131,7 @@ internal class RetryPolicyInfo
     public List<StatusCode> RetryableStatusCodes { get; init; } = default!;
 }
 
-internal class HedgingPolicyInfo
+internal sealed class HedgingPolicyInfo
 {
     public int MaxAttempts { get; set; }
     public TimeSpan HedgingDelay { get; set; }

--- a/src/Grpc.Net.Client/Internal/Http/PushStreamContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/PushStreamContent.cs
@@ -20,7 +20,7 @@ using System.Net;
 
 namespace Grpc.Net.Client.Internal.Http;
 
-internal class PushStreamContent<TRequest, TResponse> : HttpContent
+internal sealed class PushStreamContent<TRequest, TResponse> : HttpContent
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/Http/PushUnaryContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/PushUnaryContent.cs
@@ -22,7 +22,7 @@ using Grpc.Shared;
 namespace Grpc.Net.Client.Internal;
 
 // TODO: Still need generic args?
-internal class PushUnaryContent<TRequest, TResponse> : HttpContent
+internal sealed class PushUnaryContent<TRequest, TResponse> : HttpContent
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/Http/WinHttpUnaryContent.cs
+++ b/src/Grpc.Net.Client/Internal/Http/WinHttpUnaryContent.cs
@@ -27,7 +27,7 @@ namespace Grpc.Net.Client.Internal.Http;
 /// The payload is then written directly to the request using specialized context
 /// and serializer method.
 /// </summary>
-internal class WinHttpUnaryContent<TRequest, TResponse> : HttpContent
+internal sealed class WinHttpUnaryContent<TRequest, TResponse> : HttpContent
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -27,7 +27,7 @@ namespace Grpc.Net.Client.Internal;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
 [DebuggerTypeProxy(typeof(HttpContentClientStreamReader<,>.HttpContentClientStreamReaderDebugView))]
-internal class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStreamReader<TResponse>
+internal sealed class HttpContentClientStreamReader<TRequest, TResponse> : IAsyncStreamReader<TResponse>
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamWriter.cs
@@ -26,7 +26,7 @@ namespace Grpc.Net.Client.Internal;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
 [DebuggerTypeProxy(typeof(HttpContentClientStreamWriter<,>.HttpContentClientStreamWriterDebugView))]
-internal class HttpContentClientStreamWriter<TRequest, TResponse> : ClientStreamWriterBase<TRequest>
+internal sealed class HttpContentClientStreamWriter<TRequest, TResponse> : ClientStreamWriterBase<TRequest>
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/Retry/ChannelRetryThrottling.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/ChannelRetryThrottling.cs
@@ -21,7 +21,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.Net.Client.Internal.Retry;
 
-internal partial class ChannelRetryThrottling
+internal sealed partial class ChannelRetryThrottling
 {
     private readonly object _lock = new object();
     private readonly double _tokenRatio;

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamReader.cs
@@ -24,7 +24,7 @@ namespace Grpc.Net.Client.Internal.Retry;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
 [DebuggerTypeProxy(typeof(RetryCallBaseClientStreamReader<,>.RetryCallBaseClientStreamReaderDebugView))]
-internal class RetryCallBaseClientStreamReader<TRequest, TResponse> : IAsyncStreamReader<TResponse>
+internal sealed class RetryCallBaseClientStreamReader<TRequest, TResponse> : IAsyncStreamReader<TResponse>
     where TRequest : class
     where TResponse : class
 {

--- a/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamWriter.cs
+++ b/src/Grpc.Net.Client/Internal/Retry/RetryCallBaseClientStreamWriter.cs
@@ -24,7 +24,7 @@ namespace Grpc.Net.Client.Internal.Retry;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
 [DebuggerTypeProxy(typeof(RetryCallBaseClientStreamWriter<,>.RetryCallBaseClientStreamWriterDebugView))]
-internal class RetryCallBaseClientStreamWriter<TRequest, TResponse> : ClientStreamWriterBase<TRequest>
+internal sealed class RetryCallBaseClientStreamWriter<TRequest, TResponse> : ClientStreamWriterBase<TRequest>
     where TRequest : class
     where TResponse : class
 {

--- a/src/Shared/Server/InterceptorPipelineBuilder.cs
+++ b/src/Shared/Server/InterceptorPipelineBuilder.cs
@@ -22,7 +22,7 @@ using Grpc.Core.Interceptors;
 
 namespace Grpc.Shared.Server;
 
-internal class InterceptorPipelineBuilder<TRequest, TResponse>
+internal sealed class InterceptorPipelineBuilder<TRequest, TResponse>
     where TRequest : class
     where TResponse : class
 {

--- a/src/Shared/TrailingHeadersHelpers.cs
+++ b/src/Shared/TrailingHeadersHelpers.cs
@@ -51,7 +51,7 @@ internal static class TrailingHeadersHelpers
 
     public static readonly string ResponseTrailersKey = "__ResponseTrailers";
 
-    private class ResponseTrailers : HttpHeaders
+    private sealed class ResponseTrailers : HttpHeaders
     {
         public static readonly ResponseTrailers Empty = new ResponseTrailers();
     }

--- a/src/dotnet-grpc/Commands/AddFileCommand.cs
+++ b/src/dotnet-grpc/Commands/AddFileCommand.cs
@@ -16,17 +16,14 @@
 
 #endregion
 
-using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using Grpc.Dotnet.Cli.Internal;
 using Grpc.Dotnet.Cli.Options;
 using Grpc.Dotnet.Cli.Properties;
-using Microsoft.Build.Evaluation;
 
 namespace Grpc.Dotnet.Cli.Commands;
 
-internal class AddFileCommand : CommandBase
+internal sealed class AddFileCommand : CommandBase
 {
     public AddFileCommand(IConsole console, string? projectPath, HttpClient httpClient)
         : base(console, projectPath, httpClient) { }

--- a/src/dotnet-grpc/Commands/AddUrlCommand.cs
+++ b/src/dotnet-grpc/Commands/AddUrlCommand.cs
@@ -17,14 +17,13 @@
 #endregion
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using Grpc.Dotnet.Cli.Internal;
 using Grpc.Dotnet.Cli.Options;
 using Grpc.Dotnet.Cli.Properties;
 
 namespace Grpc.Dotnet.Cli.Commands;
 
-internal class AddUrlCommand : CommandBase
+internal sealed class AddUrlCommand : CommandBase
 {
     public AddUrlCommand(IConsole console, string? projectPath, HttpClient httpClient)
         : base(console, projectPath, httpClient) { }

--- a/src/dotnet-grpc/Commands/ListCommand.cs
+++ b/src/dotnet-grpc/Commands/ListCommand.cs
@@ -17,7 +17,6 @@
 #endregion
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.Rendering;
 using System.CommandLine.Rendering.Views;
 using Grpc.Dotnet.Cli.Internal;
@@ -27,7 +26,7 @@ using Microsoft.Build.Evaluation;
 
 namespace Grpc.Dotnet.Cli.Commands;
 
-internal class ListCommand : CommandBase
+internal sealed class ListCommand : CommandBase
 {
     public ListCommand(IConsole console, string? projectPath, HttpClient httpClient)
         : base(console, projectPath, httpClient) { }

--- a/src/dotnet-grpc/Commands/RefreshCommand.cs
+++ b/src/dotnet-grpc/Commands/RefreshCommand.cs
@@ -17,15 +17,13 @@
 #endregion
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using Grpc.Dotnet.Cli.Internal;
 using Grpc.Dotnet.Cli.Options;
 using Grpc.Dotnet.Cli.Properties;
-using Microsoft.Build.Evaluation;
 
 namespace Grpc.Dotnet.Cli.Commands;
 
-internal class RefreshCommand : CommandBase
+internal sealed class RefreshCommand : CommandBase
 {
     public RefreshCommand(IConsole console, string? projectPath, HttpClient httpClient)
         : base(console, projectPath, httpClient) { }

--- a/src/dotnet-grpc/Commands/RemoveCommand.cs
+++ b/src/dotnet-grpc/Commands/RemoveCommand.cs
@@ -16,17 +16,14 @@
 
 #endregion
 
-using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using Grpc.Dotnet.Cli.Internal;
 using Grpc.Dotnet.Cli.Options;
 using Grpc.Dotnet.Cli.Properties;
-using Microsoft.Build.Evaluation;
 
 namespace Grpc.Dotnet.Cli.Commands;
 
-internal class RemoveCommand : CommandBase
+internal sealed class RemoveCommand : CommandBase
 {
     public RemoveCommand(IConsole console, string? projectPath, HttpClient httpClient)
         : base(console, projectPath, httpClient) { }

--- a/src/dotnet-grpc/Internal/CLIToolException.cs
+++ b/src/dotnet-grpc/Internal/CLIToolException.cs
@@ -19,7 +19,7 @@
 
 namespace Grpc.Dotnet.Cli.Internal;
 
-internal class CLIToolException : Exception
+internal sealed class CLIToolException : Exception
 {
     public CLIToolException(string message) : base(message) { }
 }

--- a/src/dotnet-grpc/Internal/GrpcDependencyAttribute.cs
+++ b/src/dotnet-grpc/Internal/GrpcDependencyAttribute.cs
@@ -20,7 +20,7 @@
 namespace Grpc.Dotnet.Cli.Internal;
 
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-internal class GrpcDependencyAttribute : Attribute
+internal sealed class GrpcDependencyAttribute : Attribute
 {
     public GrpcDependencyAttribute(string name, string version, string privateAssets, string applicableServices, string? applicableToWeb = null)
     {


### PR DESCRIPTION
Should in theory also be faster, as some virtual method table lookups can be avoided.
I haven't tested if it introduces any performance regressions due to runtime black magic inner workings.
My laptop cannot produce repeatable results due to throttling & background services.
I hope you have a benchmark setup to test it.

There are some whitespace changes due to:
`trim_trailing_whitespace = true`
`insert_final_newline = true`
in [`.editorconfig`](https://github.com/grpc/grpc-dotnet/blob/master/.editorconfig#L19)