### PR TITLE
use nameof for CallerArgumentExpression

### DIFF
--- a/src/Shared/ThrowHelpers/ArgumentNullThrowHelper.cs
+++ b/src/Shared/ThrowHelpers/ArgumentNullThrowHelper.cs
@@ -11,7 +11,7 @@ internal static partial class ArgumentNullThrowHelper
     /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
     /// <param name="argument">The reference type argument to validate as non-null.</param>
     /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
-    public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+    public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
 #if !NET7_0_OR_GREATER
         if (argument is null)


### PR DESCRIPTION
use `nameof` for `CallerArgumentExpression`