### PR TITLE
update ArgumentNullException.ThrowIfNull usage

### DIFF
--- a/src/Shared/ThrowHelpers/ArgumentNullThrowHelper.cs
+++ b/src/Shared/ThrowHelpers/ArgumentNullThrowHelper.cs
@@ -13,7 +13,7 @@ internal static partial class ArgumentNullThrowHelper
     /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
     public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression("argument")] string? paramName = null)
     {
-#if !NET7_0_OR_GREATER
+#if !NET6_0_OR_GREATER
         if (argument is null)
         {
             Throw(paramName);
@@ -23,7 +23,7 @@ internal static partial class ArgumentNullThrowHelper
 #endif
     }
 
-#if !NET7_0_OR_GREATER
+#if !NET6_0_OR_GREATER
     [DoesNotReturn]
     internal static void Throw(string? paramName) =>
         throw new ArgumentNullException(paramName);


### PR DESCRIPTION
The `ArgumentNullException.ThrowIfNull` is introduced since .NET 6, maybe we could use if for `NET6_0_OR_GREATER`

https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception.throwifnull?view=net-6.0