### PR TITLE
Complete health checks watch service on server shutting down

### DIFF
--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 
 namespace Grpc.AspNetCore.HealthChecks;
 
@@ -39,4 +40,21 @@ public sealed class GrpcHealthChecksOptions
     /// published by <see cref="IHealthCheckPublisher"/> are returned.
     /// </remarks>
     public bool UseHealthChecksCache { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to complete <c>Watch</c> health check calls when the application is stopping.
+    /// The default value is <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <c>false</c>, health checks <c>Watch</c> calls are completed with a status of NotServing when the server application begins shutting down.
+    /// Shutdown is indicated by the <see cref="IHostApplicationLifetime.ApplicationStopping"/> token being raised and causes <c>Watch</c> to complete.
+    /// When <c>true</c>, health checks <c>Watch</c> calls are left running until the server forcefully aborts the request when the server shuts down.
+    /// </para>
+    /// <para>
+    /// Completing the <c>Watch</c> call allows the server to gracefully exit. If <c>Watch</c> calls aren't shutdown then the server runs until
+    /// <see cref="HostOptions.ShutdownTimeout"/> is exceeded and the server forcefully aborts the request.
+    /// </para>
+    /// </remarks>
+    public bool SuppressCompletionOnShutdown { get; set; }
 }

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksOptions.cs
@@ -42,18 +42,18 @@ public sealed class GrpcHealthChecksOptions
     public bool UseHealthChecksCache { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to complete <c>Watch</c> health check calls when the application is stopping.
+    /// Gets or sets a value indicating whether to suppress completing <c>Watch</c> health check calls when the application begins shutting down.
     /// The default value is <c>false</c>.
     /// </summary>
     /// <remarks>
     /// <para>
     /// When <c>false</c>, health checks <c>Watch</c> calls are completed with a status of NotServing when the server application begins shutting down.
     /// Shutdown is indicated by the <see cref="IHostApplicationLifetime.ApplicationStopping"/> token being raised and causes <c>Watch</c> to complete.
-    /// When <c>true</c>, health checks <c>Watch</c> calls are left running until the server forcefully aborts the request when the server shuts down.
+    /// When <c>true</c>, health checks <c>Watch</c> calls are left running. Running calls will be eventually be forcefully aborted when the server finishes shutting down.
     /// </para>
     /// <para>
     /// Completing the <c>Watch</c> call allows the server to gracefully exit. If <c>Watch</c> calls aren't shutdown then the server runs until
-    /// <see cref="HostOptions.ShutdownTimeout"/> is exceeded and the server forcefully aborts the request.
+    /// <see cref="HostOptions.ShutdownTimeout"/> is exceeded and the server forcefully aborts remaining active requests.
     /// </para>
     /// </remarks>
     public bool SuppressCompletionOnShutdown { get; set; }

--- a/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
+++ b/src/Grpc.AspNetCore.HealthChecks/GrpcHealthChecksPublisher.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-using System.Linq;
 using Grpc.Health.V1;
 using Grpc.HealthCheck;
 using Microsoft.Extensions.Diagnostics.HealthChecks;

--- a/src/Grpc.HealthCheck/HealthServiceImpl.cs
+++ b/src/Grpc.HealthCheck/HealthServiceImpl.cs
@@ -141,6 +141,12 @@ public class HealthServiceImpl : Grpc.Health.V1.Health.HealthBase
     /// <returns>A task indicating completion of the handler.</returns>
     public override async Task Watch(HealthCheckRequest request, IServerStreamWriter<HealthCheckResponse> responseStream, ServerCallContext context)
     {
+        // The call has already been canceled. Writing to the response will fail so immediately exit.
+        if (context.CancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         string service = request.Service;
 
         // Channel is used to to marshall multiple callers updating status into a single queue.

--- a/src/Grpc.HealthCheck/HealthServiceImpl.cs
+++ b/src/Grpc.HealthCheck/HealthServiceImpl.cs
@@ -142,6 +142,7 @@ public class HealthServiceImpl : Grpc.Health.V1.Health.HealthBase
     public override async Task Watch(HealthCheckRequest request, IServerStreamWriter<HealthCheckResponse> responseStream, ServerCallContext context)
     {
         // The call has already been canceled. Writing to the response will fail so immediately exit.
+        // In the real world this situation is unlikely to happen as the server would have prevented a canceled call from making it this far.
         if (context.CancellationToken.IsCancellationRequested)
         {
             return;

--- a/test/Grpc.AspNetCore.Server.Tests/TestObjects/TestHostApplicationLifetime.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/TestObjects/TestHostApplicationLifetime.cs
@@ -1,0 +1,37 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Hosting;
+
+namespace Grpc.AspNetCore.Server.Tests.TestObjects;
+
+public class TestHostApplicationLifetime : IHostApplicationLifetime
+{
+    private readonly CancellationTokenSource _cts = new();
+
+    public CancellationToken ApplicationStarted => _cts.Token;
+    public CancellationToken ApplicationStopped => _cts.Token;
+    public CancellationToken ApplicationStopping => _cts.Token;
+
+    public void StopApplication()
+    {
+        _cts.Cancel();
+    }
+}


### PR DESCRIPTION
Fixes the same issue as https://github.com/grpc/grpc-dotnet/pull/2573: health checks `Watch` call completes when the server begins shutting down. This avoids the problem of a shutting down server waiting for the health check call to be complete (default is 30 seconds) before forcefully killing the request.

Differences:
* Avoids duplicating the health checks service implementaiton. Cancellation is now passed in via ServerCallContext
* Adds option to enable and disable this behavior. Completing on shutdown is enabled by default with the option to suppress it and go back to old behavior.
* Adds tests