### PR TITLE
Adds MapGrpcService overload for ServerServiceDefinition

### DIFF
--- a/examples/GreeterByServiceDefinition/Client/Client.csproj
+++ b/examples/GreeterByServiceDefinition/Client/Client.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\Proto\greet.proto" GrpcServices="Client" Link="Protos\greet.proto" />
+
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPackageVersion)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/GreeterByServiceDefinition/Client/Program.cs
+++ b/examples/GreeterByServiceDefinition/Client/Program.cs
@@ -1,0 +1,30 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Greet;
+using Grpc.Net.Client;
+
+using var channel = GrpcChannel.ForAddress("https://localhost:5001");
+var client = new Greeter.GreeterClient(channel);
+
+var reply = await client.SayHelloAsync(new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+
+Console.WriteLine("Shutting down");
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();

--- a/examples/GreeterByServiceDefinition/GreeterByServiceDefinition.sln
+++ b/examples/GreeterByServiceDefinition/GreeterByServiceDefinition.sln
@@ -1,0 +1,84 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33829.357
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{32B810EF-93B2-46C2-879A-BBA345A10E71}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.Core.Api", "..\..\src\Grpc.Core.Api\Grpc.Core.Api.csproj", "{BF8BD8C9-70D7-486F-BE4D-9ED2C7EA8CB1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.Net.Common", "..\..\src\Grpc.Net.Common\Grpc.Net.Common.csproj", "{912BCAE2-04D8-4FFE-B9A5-C7FAEA7EF808}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.Net.ClientFactory", "..\..\src\Grpc.Net.ClientFactory\Grpc.Net.ClientFactory.csproj", "{3F49C6CE-D3AC-4609-B416-5E180DA59C7F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.Server.ClientFactory", "..\..\src\Grpc.AspNetCore.Server.ClientFactory\Grpc.AspNetCore.Server.ClientFactory.csproj", "{B38F8199-FD16-4E02-B1E2-CECEBF29A638}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore.Server", "..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj", "{5E857C51-76FF-4263-9BD7-CCB7997795F9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.AspNetCore", "..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj", "{7D83B407-3C89-4671-BF97-A1B196633B0D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Grpc.Net.Client", "..\..\src\Grpc.Net.Client\Grpc.Net.Client.csproj", "{CD4371A4-F789-4752-B1C0-DD95B1D6A090}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{534AC5F8-2DF2-40BD-87A5-B3D8310118C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48A1D3BC-A14B-436A-8822-6DE2BEF8B747}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF8BD8C9-70D7-486F-BE4D-9ED2C7EA8CB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF8BD8C9-70D7-486F-BE4D-9ED2C7EA8CB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF8BD8C9-70D7-486F-BE4D-9ED2C7EA8CB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF8BD8C9-70D7-486F-BE4D-9ED2C7EA8CB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{912BCAE2-04D8-4FFE-B9A5-C7FAEA7EF808}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{912BCAE2-04D8-4FFE-B9A5-C7FAEA7EF808}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{912BCAE2-04D8-4FFE-B9A5-C7FAEA7EF808}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{912BCAE2-04D8-4FFE-B9A5-C7FAEA7EF808}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F49C6CE-D3AC-4609-B416-5E180DA59C7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F49C6CE-D3AC-4609-B416-5E180DA59C7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F49C6CE-D3AC-4609-B416-5E180DA59C7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F49C6CE-D3AC-4609-B416-5E180DA59C7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B38F8199-FD16-4E02-B1E2-CECEBF29A638}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B38F8199-FD16-4E02-B1E2-CECEBF29A638}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B38F8199-FD16-4E02-B1E2-CECEBF29A638}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B38F8199-FD16-4E02-B1E2-CECEBF29A638}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E857C51-76FF-4263-9BD7-CCB7997795F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E857C51-76FF-4263-9BD7-CCB7997795F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E857C51-76FF-4263-9BD7-CCB7997795F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E857C51-76FF-4263-9BD7-CCB7997795F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D83B407-3C89-4671-BF97-A1B196633B0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D83B407-3C89-4671-BF97-A1B196633B0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D83B407-3C89-4671-BF97-A1B196633B0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D83B407-3C89-4671-BF97-A1B196633B0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD4371A4-F789-4752-B1C0-DD95B1D6A090}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD4371A4-F789-4752-B1C0-DD95B1D6A090}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD4371A4-F789-4752-B1C0-DD95B1D6A090}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD4371A4-F789-4752-B1C0-DD95B1D6A090}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{BF8BD8C9-70D7-486F-BE4D-9ED2C7EA8CB1} = {32B810EF-93B2-46C2-879A-BBA345A10E71}
+		{912BCAE2-04D8-4FFE-B9A5-C7FAEA7EF808} = {32B810EF-93B2-46C2-879A-BBA345A10E71}
+		{3F49C6CE-D3AC-4609-B416-5E180DA59C7F} = {32B810EF-93B2-46C2-879A-BBA345A10E71}
+		{B38F8199-FD16-4E02-B1E2-CECEBF29A638} = {32B810EF-93B2-46C2-879A-BBA345A10E71}
+		{5E857C51-76FF-4263-9BD7-CCB7997795F9} = {32B810EF-93B2-46C2-879A-BBA345A10E71}
+		{7D83B407-3C89-4671-BF97-A1B196633B0D} = {32B810EF-93B2-46C2-879A-BBA345A10E71}
+		{CD4371A4-F789-4752-B1C0-DD95B1D6A090} = {32B810EF-93B2-46C2-879A-BBA345A10E71}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D22B3129-3BFB-41FA-9FCE-E45EBEF8C2DD}
+	EndGlobalSection
+EndGlobal

--- a/examples/GreeterByServiceDefinition/Proto/greet.proto
+++ b/examples/GreeterByServiceDefinition/Proto/greet.proto
@@ -1,0 +1,33 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/examples/GreeterByServiceDefinition/Server/Program.cs
+++ b/examples/GreeterByServiceDefinition/Server/Program.cs
@@ -1,0 +1,36 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Grpc.Core;
+using Server;
+using Microsoft.AspNetCore.Builder;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddGrpc();
+
+var app = builder.Build();
+app.MapGrpcService(getGreeterService);
+
+app.Run();
+
+static ServerServiceDefinition getGreeterService(IServiceProvider serviceProvider)
+{
+    var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+    var service = new GreeterService(loggerFactory);
+    return Greet.Greeter.BindService(service);
+}

--- a/examples/GreeterByServiceDefinition/Server/Server.csproj
+++ b/examples/GreeterByServiceDefinition/Server/Server.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\Proto\greet.proto" GrpcServices="Server" Link="Protos\greet.proto" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Grpc.AspNetCore\Grpc.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\..\src\Grpc.AspNetCore.Server\Grpc.AspNetCore.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/GreeterByServiceDefinition/Server/Services/GreeterService.cs
+++ b/examples/GreeterByServiceDefinition/Server/Services/GreeterService.cs
@@ -1,0 +1,41 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading.Tasks;
+using Greet;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Server
+{
+    public class GreeterService : Greeter.GreeterBase
+    {
+        private readonly ILogger _logger;
+
+        public GreeterService(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<GreeterService>();
+        }
+
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            _logger.LogInformation($"Sending hello to {request.Name}");
+            return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+        }
+    }
+}

--- a/examples/GreeterByServiceDefinition/Server/appsettings.Development.json
+++ b/examples/GreeterByServiceDefinition/Server/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Grpc": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/examples/GreeterByServiceDefinition/Server/appsettings.json
+++ b/examples/GreeterByServiceDefinition/Server/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -328,3 +328,13 @@ The error example shows how to use a richer error model with `Grpc.StatusProto`.
 * Error handling
 * Validation
 * [`google.rpc.Status`](https://cloud.google.com/apis/design/errors#error_model)
+
+
+## [GreeterByServiceDefinition](./GreeterByServiceDefinition)
+
+This sample is similar with [Greeter](#greeter), but its service instance for server is mapped by using `ServerServiceDefinition`.
+
+##### Scenarios:
+
+* Mapping server service by using `ServerServiceDefinition`
+* Unary call

--- a/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs
+++ b/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs
@@ -68,6 +68,7 @@ public static class GrpcServicesExtensions
 #endif
         services.AddOptions();
         services.TryAddSingleton<GrpcMarkerService>();
+        services.TryAddSingleton(typeof(ServerCallHandlerFactory));
         services.TryAddSingleton(typeof(ServerCallHandlerFactory<>));
         services.TryAddSingleton(typeof(IGrpcServiceActivator<>), typeof(DefaultGrpcServiceActivator<>));
         services.TryAddSingleton(typeof(IGrpcInterceptorActivator<>), typeof(DefaultGrpcInterceptorActivator<>));
@@ -75,6 +76,7 @@ public static class GrpcServicesExtensions
 
         // Model
         services.TryAddSingleton<ServiceMethodsRegistry>();
+        services.TryAddSingleton(typeof(ServiceRouteBuilder));
         services.TryAddSingleton(typeof(ServiceRouteBuilder<>));
         services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IServiceMethodProvider<>), typeof(BinderServiceMethodProvider<>)));
 

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs
@@ -24,6 +24,56 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
+internal sealed class ClientStreamingServerCallHandler<TRequest, TResponse> : ServerCallHandlerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    private readonly ClientStreamingServerMethodInvoker<TRequest, TResponse> _invoker;
+
+    public ClientStreamingServerCallHandler(
+        ClientStreamingServerMethodInvoker<TRequest, TResponse> invoker,
+        ILoggerFactory loggerFactory)
+        : base(invoker, loggerFactory)
+    {
+        _invoker = invoker;
+    }
+
+    protected override async Task HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext)
+    {
+        // Disable request body data rate for client streaming
+        DisableMinRequestBodyDataRateAndMaxRequestBodySize(httpContext);
+
+        TResponse? response;
+
+        var streamReader = new HttpContextStreamReader<TRequest>(serverCallContext, MethodInvoker.Method.RequestMarshaller.ContextualDeserializer);
+        try
+        {
+            response = await _invoker.Invoke(httpContext, serverCallContext, streamReader);
+        }
+        finally
+        {
+            streamReader.Complete();
+        }
+
+        if (response == null)
+        {
+            // This is consistent with Grpc.Core when a null value is returned
+            throw new RpcException(new Status(StatusCode.Cancelled, "No message returned from method."));
+        }
+
+        // Check if deadline exceeded while method was invoked. If it has then skip trying to write
+        // the response message because it will always fail.
+        // Note that the call is still going so the deadline could still be exceeded after this point.
+        if (serverCallContext.DeadlineManager?.IsDeadlineExceededStarted ?? false)
+        {
+            return;
+        }
+
+        var responseBodyWriter = httpContext.Response.BodyWriter;
+        await responseBodyWriter.WriteSingleMessageAsync(response, serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer);
+    }
+}
+
 internal sealed class ClientStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs
@@ -23,6 +23,39 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
+internal sealed class DuplexStreamingServerCallHandler<TRequest, TResponse> : ServerCallHandlerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    private readonly DuplexStreamingServerMethodInvoker<TRequest, TResponse> _invoker;
+
+    public DuplexStreamingServerCallHandler(
+        DuplexStreamingServerMethodInvoker<TRequest, TResponse> invoker,
+        ILoggerFactory loggerFactory)
+        : base(invoker, loggerFactory)
+    {
+        _invoker = invoker;
+    }
+
+    protected override async Task HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext)
+    {
+        // Disable request body data rate for client streaming
+        DisableMinRequestBodyDataRateAndMaxRequestBodySize(httpContext);
+
+        var streamReader = new HttpContextStreamReader<TRequest>(serverCallContext, MethodInvoker.Method.RequestMarshaller.ContextualDeserializer);
+        var streamWriter = new HttpContextStreamWriter<TResponse>(serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer);
+        try
+        {
+            await _invoker.Invoke(httpContext, serverCallContext, streamReader, streamWriter);
+        }
+        finally
+        {
+            streamReader.Complete();
+            streamWriter.Complete();
+        }
+    }
+}
+
 internal sealed class DuplexStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -30,7 +30,140 @@ using Microsoft.Net.Http.Headers;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
-internal abstract class ServerCallHandlerBase<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse>
+internal abstract class ServerCallHandlerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    private const string LoggerName = "Grpc.AspNetCore.Server.ServerCallHandler";
+
+    protected ServerMethodInvokerBase<TRequest, TResponse> MethodInvoker { get; }
+    protected ILogger Logger { get; }
+
+    protected ServerCallHandlerBase(
+        ServerMethodInvokerBase<TRequest, TResponse> methodInvoker,
+        ILoggerFactory loggerFactory)
+    {
+        MethodInvoker = methodInvoker;
+        Logger = loggerFactory.CreateLogger(LoggerName);
+    }
+
+    public Task HandleCallAsync(HttpContext httpContext)
+    {
+        if (GrpcProtocolHelpers.IsInvalidContentType(httpContext, out var error))
+        {
+            return ProcessInvalidContentTypeRequest(httpContext, error);
+        }
+
+        if (!GrpcProtocolConstants.IsHttp2(httpContext.Request.Protocol)
+#if NET6_0_OR_GREATER
+            && !GrpcProtocolConstants.IsHttp3(httpContext.Request.Protocol)
+#endif
+            )
+        {
+            return ProcessNonHttp2Request(httpContext);
+        }
+
+        var serverCallContext = new HttpContextServerCallContext(httpContext, MethodInvoker.Options, typeof(TRequest), typeof(TResponse), Logger);
+        httpContext.Features.Set<IServerCallContextFeature>(serverCallContext);
+
+        GrpcProtocolHelpers.AddProtocolHeaders(httpContext.Response);
+
+        try
+        {
+            serverCallContext.Initialize();
+
+            var handleCallTask = HandleCallAsyncCore(httpContext, serverCallContext);
+
+            if (handleCallTask.IsCompletedSuccessfully)
+            {
+                return serverCallContext.EndCallAsync();
+            }
+            else
+            {
+                return AwaitHandleCall(serverCallContext, MethodInvoker.Method, handleCallTask);
+            }
+        }
+        catch (Exception ex)
+        {
+            return serverCallContext.ProcessHandlerErrorAsync(ex, MethodInvoker.Method.Name);
+        }
+
+        static async Task AwaitHandleCall(HttpContextServerCallContext serverCallContext, Method<TRequest, TResponse> method, Task handleCall)
+        {
+            try
+            {
+                await handleCall;
+                await serverCallContext.EndCallAsync();
+            }
+            catch (Exception ex)
+            {
+                await serverCallContext.ProcessHandlerErrorAsync(ex, method.Name);
+            }
+        }
+    }
+
+    protected abstract Task HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext);
+
+    /// <summary>
+    /// This should only be called from client streaming calls
+    /// </summary>
+    /// <param name="httpContext"></param>
+    protected void DisableMinRequestBodyDataRateAndMaxRequestBodySize(HttpContext httpContext)
+    {
+        var minRequestBodyDataRateFeature = httpContext.Features.Get<IHttpMinRequestBodyDataRateFeature>();
+        if (minRequestBodyDataRateFeature != null)
+        {
+            minRequestBodyDataRateFeature.MinDataRate = null;
+        }
+
+        var maxRequestBodySizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
+        if (maxRequestBodySizeFeature != null)
+        {
+            if (!maxRequestBodySizeFeature.IsReadOnly)
+            {
+                maxRequestBodySizeFeature.MaxRequestBodySize = null;
+            }
+            else
+            {
+                // IsReadOnly could be true if middleware has already started reading the request body
+                // In that case we can't disable the max request body size for the request stream
+                GrpcServerLog.UnableToDisableMaxRequestBodySize(Logger);
+            }
+        }
+    }
+
+    private Task ProcessNonHttp2Request(HttpContext httpContext)
+    {
+        GrpcServerLog.UnsupportedRequestProtocol(Logger, httpContext.Request.Protocol);
+
+        var protocolError = $"Request protocol '{httpContext.Request.Protocol}' is not supported.";
+        GrpcProtocolHelpers.BuildHttpErrorResponse(httpContext.Response, StatusCodes.Status426UpgradeRequired, StatusCode.Internal, protocolError);
+        httpContext.Response.Headers[HeaderNames.Upgrade] = GrpcProtocolConstants.Http2Protocol;
+        return Task.CompletedTask;
+    }
+
+    private Task ProcessInvalidContentTypeRequest(HttpContext httpContext, string error)
+    {
+        // This might be a CORS preflight request and CORS middleware hasn't been configured
+        if (GrpcProtocolHelpers.IsCorsPreflightRequest(httpContext))
+        {
+            GrpcServerLog.UnhandledCorsPreflightRequest(Logger);
+
+            GrpcProtocolHelpers.BuildHttpErrorResponse(httpContext.Response, StatusCodes.Status405MethodNotAllowed, StatusCode.Internal, "Unhandled CORS preflight request received. CORS may not be configured correctly in the application.");
+            httpContext.Response.Headers[HeaderNames.Allow] = HttpMethods.Post;
+            return Task.CompletedTask;
+        }
+        else
+        {
+            GrpcServerLog.UnsupportedRequestContentType(Logger, httpContext.Request.ContentType);
+
+            GrpcProtocolHelpers.BuildHttpErrorResponse(httpContext.Response, StatusCodes.Status415UnsupportedMediaType, StatusCode.Internal, error);
+            return Task.CompletedTask;
+        }
+    }
+}
+
+internal abstract class ServerCallHandlerBase<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)]TService, TRequest, TResponse>
     where TService : class
     where TRequest : class
     where TResponse : class

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerStreamingServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerStreamingServerCallHandler.cs
@@ -23,6 +23,37 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
+internal sealed class ServerStreamingServerCallHandler<TRequest, TResponse> : ServerCallHandlerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    private readonly ServerStreamingServerMethodInvoker<TRequest, TResponse> _invoker;
+
+    public ServerStreamingServerCallHandler(
+        ServerStreamingServerMethodInvoker<TRequest, TResponse> invoker,
+        ILoggerFactory loggerFactory)
+        : base(invoker, loggerFactory)
+    {
+        _invoker = invoker;
+    }
+
+    protected override async Task HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext)
+    {
+        // Decode request
+        var request = await httpContext.Request.BodyReader.ReadSingleMessageAsync<TRequest>(serverCallContext, MethodInvoker.Method.RequestMarshaller.ContextualDeserializer);
+
+        var streamWriter = new HttpContextStreamWriter<TResponse>(serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer);
+        try
+        {
+            await _invoker.Invoke(httpContext, serverCallContext, request, streamWriter);
+        }
+        finally
+        {
+            streamWriter.Complete();
+        }
+    }
+}
+
 internal sealed class ServerStreamingServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class

--- a/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs
@@ -24,6 +24,45 @@ using Microsoft.Extensions.Logging;
 
 namespace Grpc.AspNetCore.Server.Internal.CallHandlers;
 
+internal sealed class UnaryServerCallHandler<TRequest, TResponse> : ServerCallHandlerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    private readonly UnaryServerMethodInvoker<TRequest, TResponse> _invoker;
+
+    public UnaryServerCallHandler(
+        UnaryServerMethodInvoker<TRequest, TResponse> invoker,
+        ILoggerFactory loggerFactory)
+        : base(invoker, loggerFactory)
+    {
+        _invoker = invoker;
+    }
+
+    protected override async Task HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext)
+    {
+        var request = await httpContext.Request.BodyReader.ReadSingleMessageAsync<TRequest>(serverCallContext, MethodInvoker.Method.RequestMarshaller.ContextualDeserializer);
+
+        var response = await _invoker.Invoke(httpContext, serverCallContext, request);
+
+        if (response == null)
+        {
+            // This is consistent with Grpc.Core when a null value is returned
+            throw new RpcException(new Status(StatusCode.Cancelled, "No message returned from method."));
+        }
+
+        // Check if deadline exceeded while method was invoked. If it has then skip trying to write
+        // the response message because it will always fail.
+        // Note that the call is still going so the deadline could still be exceeded after this point.
+        if (serverCallContext.DeadlineManager?.IsDeadlineExceededStarted ?? false)
+        {
+            return;
+        }
+
+        var responseBodyWriter = httpContext.Response.BodyWriter;
+        await responseBodyWriter.WriteSingleMessageAsync(response, serverCallContext, MethodInvoker.Method.ResponseMarshaller.ContextualSerializer);
+    }
+}
+
 internal sealed class UnaryServerCallHandler<[DynamicallyAccessedMembers(GrpcProtocolConstants.ServiceAccessibility)] TService, TRequest, TResponse> : ServerCallHandlerBase<TService, TRequest, TResponse>
     where TRequest : class
     where TResponse : class

--- a/src/Grpc.AspNetCore.Server/Internal/EndpointServiceBinder.cs
+++ b/src/Grpc.AspNetCore.Server/Internal/EndpointServiceBinder.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Grpc.Core;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Grpc.AspNetCore.Server.Model.Internal;
+
+namespace Grpc.AspNetCore.Server.Internal;
+
+/// <summary>
+/// The service binder to bind <see cref="ServerServiceDefinition"/> into ASP.Net core web application server.
+/// </summary>
+internal class EndpointServiceBinder : ServiceBinderBase
+{
+    private readonly ServerCallHandlerFactory _serverCallHandlerFactory;
+    private readonly IEndpointRouteBuilder _routeBuilder;
+    private readonly ILogger _logger;
+    public List<IEndpointConventionBuilder> EndpointConventionBuilders { get; }
+    public List<MethodModel> MethodModels { get; }
+
+    public EndpointServiceBinder(
+        ServerCallHandlerFactory serverCallHandlerFactory,
+        IEndpointRouteBuilder routeBuilder,
+        ILoggerFactory loggerFactory)
+    {
+        _serverCallHandlerFactory = serverCallHandlerFactory;
+        _routeBuilder = routeBuilder;
+        _logger = loggerFactory.CreateLogger<EndpointServiceBinder>();
+        EndpointConventionBuilders = new List<IEndpointConventionBuilder>();
+        MethodModels = new List<MethodModel>();
+    }
+
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse>? handler)
+    {
+        if(handler?.Method.DeclaringType == null)
+        {
+            throw new InvalidOperationException($"Instance methods are only allowed as server implementation for Grpc.Core.ServerServiceDefinition.");
+        }
+        var serviceType = handler.Method.DeclaringType;
+        var metadata = CreateMetadata(serviceType, handler);
+        var callHandler = _serverCallHandlerFactory.CreateUnary(method, handler);
+        var pattern = RoutePatternFactory.Parse(method.FullName);
+        AddMethod(new MethodModel(method, pattern, metadata, callHandler.HandleCallAsync));
+    }
+
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse>? handler)
+    {
+        if (handler?.Method.DeclaringType == null)
+        {
+            throw new InvalidOperationException($"Instance methods are only allowed as server implementation for Grpc.Core.ServerServiceDefinition.");
+        }
+        var serviceType = handler.Method.DeclaringType;
+        var metadata = CreateMetadata(serviceType, handler);
+        var callHandler = _serverCallHandlerFactory.CreateClientStreaming(method, handler);
+        var pattern = RoutePatternFactory.Parse(method.FullName);
+        AddMethod(new MethodModel(method, pattern, metadata, callHandler.HandleCallAsync));
+    }
+
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse>? handler)
+    {
+        if (handler?.Method.DeclaringType == null)
+        {
+            throw new InvalidOperationException($"Instance methods are only allowed as server implementation for Grpc.Core.ServerServiceDefinition.");
+        }
+        var serviceType = handler.Method.DeclaringType;
+        var metadata = CreateMetadata(serviceType, handler);
+        var callHandler = _serverCallHandlerFactory.CreateServerStreaming(method, handler);
+        var pattern = RoutePatternFactory.Parse(method.FullName);
+        AddMethod(new MethodModel(method, pattern, metadata, callHandler.HandleCallAsync));
+    }
+
+    public override void AddMethod<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse>? handler)
+    {
+        if (handler?.Method.DeclaringType == null)
+        {
+            throw new InvalidOperationException($"Instance methods are only allowed as server implementation for Grpc.Core.ServerServiceDefinition.");
+        }
+        var serviceType = handler.Method.DeclaringType;
+        var metadata = CreateMetadata(serviceType, handler);
+        var callHandler = _serverCallHandlerFactory.CreateDuplexStreaming(method, handler);
+        var pattern = RoutePatternFactory.Parse(method.FullName);
+        AddMethod(new MethodModel(method, pattern, metadata, callHandler.HandleCallAsync));
+    }
+
+    private IList<object> CreateMetadata(Type serviceType, Delegate handler)
+    {
+        var metadata = new List<object>();
+        // Add type metadata first so it has a lower priority
+        metadata.AddRange(serviceType.GetCustomAttributes(inherit: true));
+        // Add method metadata last so it has a higher priority
+        metadata.AddRange(handler.Method.GetCustomAttributes(inherit: true));
+
+        // Accepting CORS preflight means gRPC will allow requests with OPTIONS + preflight headers.
+        // If CORS middleware hasn't been configured then the request will reach gRPC handler.
+        // gRPC will return 405 response and log that CORS has not been configured.
+        metadata.Add(new HttpMethodMetadata(new[] { "POST" }, acceptCorsPreflight: true));
+
+        return metadata;
+    }
+
+    private void AddMethod(MethodModel method)
+    {
+        var endpointBuilder = _routeBuilder.Map(method.Pattern, method.RequestDelegate);
+        endpointBuilder.Add(ep =>
+        {
+            ep.DisplayName = $"gRPC - {method.Pattern.RawText}";
+
+            foreach (var item in method.Metadata)
+            {
+                ep.Metadata.Add(item);
+            }
+        });
+        EndpointConventionBuilders.Add(endpointBuilder);
+        MethodModels.Add(method);
+
+        var httpMethod = method.Metadata.OfType<HttpMethodMetadata>().LastOrDefault();
+
+        ServiceRouteBuilderLog.LogAddedServiceMethod(
+            _logger,
+            method.Method.Name,
+            method.Method.ServiceName,
+            method.Method.Type,
+            httpMethod?.HttpMethods ?? Array.Empty<string>(),
+            method.Pattern.RawText ?? string.Empty);
+    }
+}

--- a/src/Grpc.Core.Api/ServerServiceDefinition.cs
+++ b/src/Grpc.Core.Api/ServerServiceDefinition.cs
@@ -38,7 +38,7 @@ public class ServerServiceDefinition
     /// <summary>
     /// Forwards all the previously stored <c>AddMethod</c> calls to the service binder.
     /// </summary>
-    internal void BindService(ServiceBinderBase serviceBinder)
+    public void BindService(ServiceBinderBase serviceBinder)
     {
         foreach (var addMethodAction in addMethodActions)
         {

--- a/src/Shared/Server/ClientStreamingServerMethodInvoker.cs
+++ b/src/Shared/Server/ClientStreamingServerMethodInvoker.cs
@@ -26,6 +26,52 @@ using Microsoft.AspNetCore.Http;
 namespace Grpc.Shared.Server;
 
 /// <summary>
+/// Client streaming server method invoker for <see cref="Grpc.Core.ServerServiceDefinition"/>.
+/// </summary>
+/// <typeparam name="TRequest">Request message type for this method.</typeparam>
+/// <typeparam name="TResponse">Response message type for this method.</typeparam>
+internal sealed class ClientStreamingServerMethodInvoker<TRequest, TResponse> : ServerMethodInvokerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    private readonly ClientStreamingServerMethod<TRequest, TResponse> _invoker;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ClientStreamingServerMethodInvoker{TRequest, TResponse}"/>.
+    /// </summary>
+    /// <param name="invoker">The client streaming method to invoke.</param>
+    /// <param name="method">The description of the gRPC method.</param>
+    /// <param name="options">The options used to execute the method.</param>
+    public ClientStreamingServerMethodInvoker(
+        ClientStreamingServerMethod<TRequest, TResponse> invoker,
+        Method<TRequest, TResponse> method,
+        MethodOptions options)
+        : base(method, options)
+    {
+        _invoker = invoker;
+
+        if (Options.HasInterceptors)
+        {
+            var interceptorPipeline = new InterceptorPipelineBuilder<TRequest, TResponse>(Options.Interceptors);
+            _invoker = interceptorPipeline.ClientStreamingPipeline(_invoker);
+        }
+    }
+
+    /// <summary>
+    /// Invoke the client streaming method with the specified <see cref="HttpContext"/>.
+    /// </summary>
+    /// <param name="_">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="serverCallContext">The <see cref="ServerCallContext"/>.</param>
+    /// <param name="requestStream">The <typeparamref name="TRequest"/> reader.</param>
+    /// <returns>A <see cref="Task{TResponse}"/> that represents the asynchronous method. The <see cref="Task{TResponse}.Result"/>
+    /// property returns the <typeparamref name="TResponse"/> message.</returns>
+    public async Task<TResponse> Invoke(HttpContext _, ServerCallContext serverCallContext, IAsyncStreamReader<TRequest> requestStream)
+    {
+        return await _invoker(requestStream, serverCallContext);
+    }
+}
+
+/// <summary>
 /// Client streaming server method invoker.
 /// </summary>
 /// <typeparam name="TService">Service type for this method.</typeparam>

--- a/src/Shared/Server/DuplexStreamingServerMethodInvoker.cs
+++ b/src/Shared/Server/DuplexStreamingServerMethodInvoker.cs
@@ -26,6 +26,52 @@ using Microsoft.AspNetCore.Http;
 namespace Grpc.Shared.Server;
 
 /// <summary>
+/// Duplex streaming server method invoker for <see cref="Grpc.Core.ServerServiceDefinition"/>.
+/// </summary>
+/// <typeparam name="TRequest">Request message type for this method.</typeparam>
+/// <typeparam name="TResponse">Response message type for this method.</typeparam>
+internal sealed class DuplexStreamingServerMethodInvoker<TRequest, TResponse> : ServerMethodInvokerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    private readonly DuplexStreamingServerMethod<TRequest, TResponse> _invoker;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="DuplexStreamingServerMethodInvoker{TRequest, TResponse}"/>.
+    /// </summary>
+    /// <param name="invoker">The duplex streaming method to invoke.</param>
+    /// <param name="method">The description of the gRPC method.</param>
+    /// <param name="options">The options used to execute the method.</param>
+    public DuplexStreamingServerMethodInvoker(
+        DuplexStreamingServerMethod<TRequest, TResponse> invoker,
+        Method<TRequest, TResponse> method,
+        MethodOptions options)
+        : base(method, options)
+    {
+        _invoker = invoker;
+
+        if (Options.HasInterceptors)
+        {
+            var interceptorPipeline = new InterceptorPipelineBuilder<TRequest, TResponse>(Options.Interceptors);
+            _invoker = interceptorPipeline.DuplexStreamingPipeline(_invoker);
+        }
+    }
+
+    /// <summary>
+    /// Invoke the duplex streaming method with the specified <see cref="HttpContext"/>.
+    /// </summary>
+    /// <param name="_">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="serverCallContext">The <see cref="ServerCallContext"/>.</param>
+    /// <param name="requestStream">The <typeparamref name="TRequest"/> reader.</param>
+    /// <param name="responseStream">The <typeparamref name="TResponse"/> writer.</param>
+    /// <returns>A <see cref="Task{TResponse}"/> that represents the asynchronous method.</returns>
+    public async Task Invoke(HttpContext _, ServerCallContext serverCallContext, IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream)
+    {
+        await _invoker(requestStream, responseStream, serverCallContext);
+    }
+}
+
+/// <summary>
 /// Duplex streaming server method invoker.
 /// </summary>
 /// <typeparam name="TService">Service type for this method.</typeparam>

--- a/src/Shared/Server/ServerMethodInvokerBase.cs
+++ b/src/Shared/Server/ServerMethodInvokerBase.cs
@@ -24,6 +24,39 @@ using Grpc.Core;
 namespace Grpc.Shared.Server;
 
 /// <summary>
+/// Server method invoker base type for <see cref="Grpc.Core.ServerServiceDefinition"/>.
+/// </summary>
+/// <typeparam name="TRequest">Request message type for this method.</typeparam>
+/// <typeparam name="TResponse">Response message type for this method.</typeparam>
+internal abstract class ServerMethodInvokerBase<TRequest, TResponse>
+    where TRequest : class
+    where TResponse : class
+{
+    /// <summary>
+    /// Gets the description of the gRPC method.
+    /// </summary>
+    public Method<TRequest, TResponse> Method { get; }
+
+    /// <summary>
+    /// Gets the options used to execute the method.
+    /// </summary>
+    public MethodOptions Options { get; }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ServerMethodInvokerBase{TRequest, TResponse}"/>.
+    /// </summary>
+    /// <param name="method">The description of the gRPC method.</param>
+    /// <param name="options">The options used to execute the method.</param>
+    private protected ServerMethodInvokerBase(
+        Method<TRequest, TResponse> method,
+        MethodOptions options)
+    {
+        Method = method;
+        Options = options;
+    }
+}
+
+/// <summary>
 /// Server method invoker base type.
 /// </summary>
 /// <typeparam name="TService">Service type for this method.</typeparam>

--- a/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -103,6 +103,40 @@ public class GrpcEndpointRouteBuilderExtensionsTests
         BindServiceCore<GreeterWithAttributeServiceSubSubClass>();
     }
 
+    [Test]
+    public void MapGrpcService_ServerServiceDefinition_CreateEndPoints()
+    {
+        // Arrange
+        var services = ServicesHelpers.CreateServices();
+
+        var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider(validateScopes: true));
+
+        // Act
+        var service = GreeterWithAttribute.BindService(new GreeterWithAttributeService());
+        routeBuilder.MapGrpcService(service);
+
+        // Assert
+        AssertForBindServiceCore(routeBuilder);
+    }
+
+    [Test]
+    public void MapGrpcService_GetServerServiceDefinition_CreateEndPoints()
+    {
+        // Arrange
+        var services = ServicesHelpers.CreateServices();
+
+        var routeBuilder = CreateTestEndpointRouteBuilder(services.BuildServiceProvider(validateScopes: true));
+
+        // Act
+        static ServerServiceDefinition serverServiceDefinition(IServiceProvider provider)
+            => GreeterWithAttribute.BindService(new GreeterWithAttributeService());
+
+        routeBuilder.MapGrpcService(serverServiceDefinition);
+
+        // Assert
+        AssertForBindServiceCore(routeBuilder);
+    }
+
     private void BindServiceCore<TService>() where TService : class
     {
         // Arrange
@@ -114,6 +148,11 @@ public class GrpcEndpointRouteBuilderExtensionsTests
         routeBuilder.MapGrpcService<TService>();
 
         // Assert
+        AssertForBindServiceCore(routeBuilder);
+    }
+
+    private void AssertForBindServiceCore(IEndpointRouteBuilder routeBuilder)
+    {
         var endpoints = routeBuilder.DataSources
             .SelectMany(ds => ds.Endpoints)
             .Where(e => e.Metadata.GetMetadata<GrpcMethodMetadata>() != null)

--- a/test/Grpc.AspNetCore.Server.Tests/TestObjects/Services/WithAttribute/GreeterWithAttribute.cs
+++ b/test/Grpc.AspNetCore.Server.Tests/TestObjects/Services/WithAttribute/GreeterWithAttribute.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -57,7 +57,10 @@ public static partial class GreeterWithAttribute
 
     public static ServerServiceDefinition BindService(GreeterBase serviceImpl)
     {
-        throw new NotImplementedException();
+        return ServerServiceDefinition.CreateBuilder()
+            .AddMethod(__Method_SayHello, serviceImpl.SayHello)
+            .AddMethod(__Method_SayHellos, serviceImpl.SayHellos)
+            .Build();
     }
 
     public static void BindService(ServiceBinderBase serviceBinder, GreeterBase serviceImpl)


### PR DESCRIPTION
**This is a duplicate of #2535.**
**I made a serious operational error while tracking master, so I created a new pull request.**
**I apologize for the inconvenience.**

----

### Is your feature request related to a problem? Please describe.

This PR is implement for #2236.

`ServerServiceDefinition` is defined in *Grpc.Core.Api* library, and it was a prefer way to implement gRPC server with *Grpc.Core*.
In current grpc-dotnet, the server should be implemented on Asp.Net web application DI container via `GrpcEndpointRouteBuilderExtensions.MapGrpcService` generic method.
The APIs in this proposal bridges legacy way into grpc-dotnet to enable  to migrate easier.

### Describe the solution you'd like

2 overloads of `GrpcEndpointRouteBuilderExtensions.MapGrpcService` are added:

```csharp
public static class GrpcEndpointRouteBuilderExtensions
{
    public static GrpcServiceEndpointConventionBuilder MapGrpcService(
        this IEndpointRouteBuilder builder,
        ServerServiceDefinition serviceDefinition);

    public static GrpcServiceEndpointConventionBuilder MapGrpcService(
        this IEndpointRouteBuilder builder,
        Func<IServiceProvider, ServerServiceDefinition> getServiceDefinition);
}
```

This change enables to map gRPC services via `Grpc.Core.ServerServiceDefinition`,  therefore migration from Grpc.Core can be more easier.

#### Changes in this PR

- `Grpc.Core.Api`
  - makes `Grpc.Core.ServerServiceDefinition.BindService(ServiceBinderBase)` method as public[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.Core.Api/ServerServiceDefinition.cs#L41)

- `Grpc.AspNetCore.Server`
  - adds new extension methods in `Microsoft.AspNetCore.Builder.GrpcEndpointRouteBuilderExtensions` class
    - `MapGrpcService(this IEndpointRouteBuilder, ServerServiceDefinition)`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/GrpcEndpointRouteBuilderExtensions.cs#L59-L68)
    - `MapGrpcService(this IEndpointRouteBuilder, Func<IServiceProvider, ServerServiceDefinition>)`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/GrpcEndpointRouteBuilderExtensions.cs#L77-L87)
  - appends service entries of `ServerCallHandlerFactory` and `ServiceRouteBuilder` (non-generic) on `Microsoft.Extensions.DependencyInjection.AddServiceOptions` method[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs#L71)[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs#L79)
  - adds new class `Grpc.AspNetCore.Server.Internal.EndpointServiceBinder` to bind methods in `ServerServiceDefinition` into ASP.Net core web application server[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/EndpointServiceBinder.cs)
  - adds following internal classes that bind service via delegate instances instead of type argument:
    - `Grpc.AspNetCore.Server.Internal.ServerCallHandlerFactory` class[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs#L39-L157)
    - `Grpc.AspNetCore.Server.Model.Internal.ServiceRouteBuilder` class[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Model/Internal/ServiceRouteBuilder.cs#L30-L85)
    - `ServerCallHandlerBase`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerCallHandlerBase.cs#L33-L164), `UnaryServerCallhandler`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/CallHandlers/UnaryServerCallHandler.cs#L27-L64), `ServerStreamingServerCallHandler`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ServerStreamingServerCallHandler.cs#L26-L55), `ClientStreamingServerCallHandler`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/CallHandlers/ClientStreamingServerCallHandler.cs#L27-L75), and `DuplexStreamingServerCallHandler`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/CallHandlers/DuplexStreamingServerCallHandler.cs#L26-L57) classes in `Grpc.AspNetCore.Server.Internal.CallHandlers` namespace
    - `ServerMethodInvokerBase`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Shared/Server/ServerMethodInvokerBase.cs#L26-L57), `UnaryServerMethodInvoker`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Shared/Server/UnaryServerMethodInvoker.cs#L29-L73), `ServerStreamingServerMethodInvoker`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Shared/Server/ServerStreamingServerMethodInvoker.cs#L28-L72), `ClientStreamingServerMethodInvoker`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Shared/Server/ClientStreamingServerMethodInvoker.cs#L28-L72), and `DuplexStreamingServerMethodInvoker`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Shared/Server/DuplexStreamingServerMethodInvoker.cs#L28-L72) classes in `Grpc.Shared.Server` namespace
  - extracts shared interface between `ServerCallHandlerFactory` and `ServerCallHandlerFactory<TService>` into `IServerCallHandlerFactory`[*](https://github.com/aka-nse/grpc-dotnet/blob/e3b571f77efadcbcf475634ed8dad4738ac72d4f/src/Grpc.AspNetCore.Server/Internal/ServerCallHandlerFactory.cs#L31-L37)

- test
  - adds test cases for new overloads of `MapGrpcService`

- examples
  - modifies examples/README.md
  - adds new example project examples/GreeterByServiceDefinition
  - appends implementation of `Grpc.AspNetCore.Server.Tests.TestObjects.Services.WithAttribute.GreeterWithAttribute.BindService` method

### Describe alternatives you've considered

This commit contains concrete code as far as I can write, but I do not care about these implementations.
I welcome better ways to realize this suggestion.

### Additional context

*No response*