### PR TITLE
Remove old dotnet-core feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectivityStateTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectivityStateTests.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2019 The gRPC Authors
 //
@@ -29,6 +29,7 @@ using Grpc.Net.Client.Tests.Infrastructure;
 using Grpc.Net.Client.Tests.Infrastructure.Balancer;
 using Grpc.Tests.Shared;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 namespace Grpc.Net.Client.Tests.Balancer;
@@ -52,11 +53,13 @@ public class ConnectivityStateTests
         });
 
         var services = new ServiceCollection();
+        services.AddNUnitLogger();
         services.AddSingleton<TestResolver>();
         services.AddSingleton<ResolverFactory, TestResolverFactory>();
         services.AddSingleton<ISubchannelTransportFactory>(new TestSubchannelTransportFactory());
         var serviceProvider = services.BuildServiceProvider();
 
+        var logger = serviceProvider.GetRequiredService<ILogger<ConnectivityStateTests>>();
         var invoker = HttpClientCallInvokerFactory.Create(testMessageHandler, "test:///localhost", configure: o =>
         {
             o.Credentials = ChannelCredentials.Insecure;
@@ -72,6 +75,8 @@ public class ConnectivityStateTests
         Assert.IsNull(authority);
 
         var resolver = serviceProvider.GetRequiredService<TestResolver>();
+
+        logger.LogInformation("UpdateAddresses");
         resolver.UpdateAddresses(new List<BalancerAddress>
         {
             new BalancerAddress("localhost", 81)


### PR DESCRIPTION
Build errors when using this feed. It's no longer needed.