### PR TITLE
Avoid force-creating activities

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -824,13 +824,12 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         if (diagnosticSourceEnabled || Logger.IsEnabled(LogLevel.Critical) || Activity.Current != null || GrpcDiagnostics.ActivitySource.HasListeners())
         {
             activity = GrpcDiagnostics.ActivitySource.CreateActivity(GrpcDiagnostics.ActivityName, ActivityKind.Client);
-
             // ActivitySource only returns an activity if someone is listening.
-            // If we're at this point then we always want there to be an activity. Create the activity manually.
-            activity ??= new Activity(GrpcDiagnostics.ActivityName);
-
-            activity.AddTag(GrpcDiagnostics.GrpcMethodTagName, Method.FullName);
-            activity.Start();
+            if (activity != null)
+            {
+                activity.AddTag(GrpcDiagnostics.GrpcMethodTagName, Method.FullName);
+                activity.Start();
+            }
 
             if (diagnosticSourceEnabled)
             {


### PR DESCRIPTION
### The problem

Force-creating activities via `new Activity(...)` breaks fundamental Activity logic. You are replacing `Activity.Current`, but the other code does not expect this, because nobody listens to your activity source and nobody expects `Activity.Current` to suddenly change.

For example, if I roll a custom `SubchannelPicker` implementation and start creating activities there, these activities will be broken when exported to tracing collector. This happens because you have forcibly replaced `Activity.Current`, so my custom activity will have your activity as a parent. But nobody listens to your activity source, so your Activity is not exported, which means my custom activity will have an unknown parent activity id.

### The solution

Do not create an activity if nobody listens to your activity source