### PR TITLE
Fix XML documentation typo

### DIFF
--- a/src/Grpc.Core.Api/Interceptors/ClientInterceptorContext.cs
+++ b/src/Grpc.Core.Api/Interceptors/ClientInterceptorContext.cs
@@ -51,7 +51,7 @@ public struct ClientInterceptorContext<TRequest, TResponse>
     public Method<TRequest, TResponse> Method { get; }
 
     /// <summary>
-    /// Gets the host that the currect invocation will be dispatched to.
+    /// Gets the host that the current invocation will be dispatched to.
     /// </summary>
     public string? Host { get; }
 


### PR DESCRIPTION
Fix typo in the documentation for the `ClientInterceptorContext.Host` property.

Found when I copy-pasted it elsewhere and then a linter complained about the typo 😅
