### PR TITLE
Update OpenTelemetry packages to latest stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <OpenTelemetryPackageVersion>1.15.3</OpenTelemetryPackageVersion>
     <OpenTelemetryAspNetCoreInstrumentationPackageVersion>1.15.2</OpenTelemetryAspNetCoreInstrumentationPackageVersion>
     <OpenTelemetryHttpInstrumentationPackageVersion>1.15.1</OpenTelemetryHttpInstrumentationPackageVersion>
-    <OpenTelemetryGrpcPackageVersion>1.15.1</OpenTelemetryGrpcPackageVersion>
+    <OpenTelemetryGrpcPackageVersion>1.15.1-beta.1</OpenTelemetryGrpcPackageVersion>
     <MicrosoftExtensionsPackageVersion>10.0.0</MicrosoftExtensionsPackageVersion>
     <MicrosoftExtensionsLtsPackageVersion>8.0.0</MicrosoftExtensionsLtsPackageVersion>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,10 @@
     <MicrosoftAspNetCoreApp9PackageVersion>9.0.4</MicrosoftAspNetCoreApp9PackageVersion>
     <MicrosoftAspNetCoreApp8PackageVersion>8.0.15</MicrosoftAspNetCoreApp8PackageVersion>
     <GrpcDotNetPackageVersion>2.70.0</GrpcDotNetPackageVersion>
-    <OpenTelemetryPackageVersion>1.6.0</OpenTelemetryPackageVersion>
-    <OpenTelemetryIntergationPackageVersion>1.8.1</OpenTelemetryIntergationPackageVersion>
-    <OpenTelemetryGrpcPackageVersion>1.8.0-beta.1</OpenTelemetryGrpcPackageVersion>
+    <OpenTelemetryPackageVersion>1.15.3</OpenTelemetryPackageVersion>
+    <OpenTelemetryAspNetCoreInstrumentationPackageVersion>1.15.2</OpenTelemetryAspNetCoreInstrumentationPackageVersion>
+    <OpenTelemetryHttpInstrumentationPackageVersion>1.15.1</OpenTelemetryHttpInstrumentationPackageVersion>
+    <OpenTelemetryGrpcPackageVersion>1.15.1</OpenTelemetryGrpcPackageVersion>
     <MicrosoftExtensionsPackageVersion>10.0.0</MicrosoftExtensionsPackageVersion>
     <MicrosoftExtensionsLtsPackageVersion>8.0.0</MicrosoftExtensionsLtsPackageVersion>
   </PropertyGroup>
@@ -52,9 +53,9 @@
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryPackageVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryIntergationPackageVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryAspNetCoreInstrumentationPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="$(OpenTelemetryGrpcPackageVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryIntergationPackageVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryHttpInstrumentationPackageVersion)" />
 
     <!-- Other -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
 
     <!-- OpenTelemetry -->
     <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryPackageVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryPackageVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryAspNetCoreInstrumentationPackageVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="$(OpenTelemetryGrpcPackageVersion)" />

--- a/examples/Aggregator/Server/Program.cs
+++ b/examples/Aggregator/Server/Program.cs
@@ -43,7 +43,7 @@ if (bool.TryParse(builder.Configuration["EnableOpenTelemetry"], out var enableOp
                    .AddGrpcClientInstrumentation()
                    .AddHttpClientInstrumentation();
 
-            tracing.AddZipkinExporter();
+                 tracing.AddOtlpExporter();
         });
 }
 

--- a/examples/Aggregator/Server/Program.cs
+++ b/examples/Aggregator/Server/Program.cs
@@ -43,7 +43,7 @@ if (bool.TryParse(builder.Configuration["EnableOpenTelemetry"], out var enableOp
                    .AddGrpcClientInstrumentation()
                    .AddHttpClientInstrumentation();
 
-                 tracing.AddOtlpExporter();
+            tracing.AddOtlpExporter();
         });
 }
 

--- a/examples/Aggregator/Server/Server.csproj
+++ b/examples/Aggregator/Server/Server.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="Grpc.AspNetCore" />
 
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" />

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,7 +107,7 @@ The client or server can be run as a [Windows service](https://en.wikipedia.org/
 
 The aggregator example shows how a to make nested gRPC calls (a gRPC service calling another gRPC service). The gRPC client factory is used in ASP.NET Core to inject a client into services. The gRPC client factory is configured to propagate the context from the original call to the nested call. In this example the cancellation from the client will automatically propagate through to nested gRPC calls.
 
-The aggregator can optionally be run with [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet) enabled. OpenTelemetry is configured to capture tracing information and send it to [Zipkin](https://zipkin.io), a distributed tracing system. A Zipkin server needs to be running to receive traces. The simplest way to do that is [run the Zipkin Docker image](https://zipkin.io/pages/quickstart.html).
+The aggregator can optionally be run with [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet) enabled. OpenTelemetry is configured to capture tracing information and send it using OTLP. Run an OpenTelemetry Collector (or another OTLP-compatible backend) to receive traces.
 
 To run the aggregator server with OpenTelemetry enabled:
 


### PR DESCRIPTION
## Summary
- update OpenTelemetry core packages to latest stable versions
- update OpenTelemetry instrumentation packages to latest stable versions
- replace shared instrumentation version property with package-specific properties to avoid forcing mismatched versions

## Changes
- `OpenTelemetryPackageVersion`: `1.6.0` -> `1.15.3`
- add `OpenTelemetryAspNetCoreInstrumentationPackageVersion`: `1.15.2`
- add `OpenTelemetryHttpInstrumentationPackageVersion`: `1.15.1`
- `OpenTelemetryGrpcPackageVersion`: `1.8.0-beta.1` -> `1.15.1`

## Validation
- `dotnet restore .\Grpc.DotNet.slnx` succeeded