### PR TITLE
Fix subchannel permanently stuck in TransientFailure after ConnectTimeout

### DIFF
--- a/src/Grpc.Net.Client/Balancer/Subchannel.cs
+++ b/src/Grpc.Net.Client/Balancer/Subchannel.cs
@@ -432,6 +432,8 @@ public sealed class Subchannel : IDisposable
         catch (OperationCanceledException)
         {
             SubchannelLog.ConnectCanceled(_logger, Id);
+
+            UpdateConnectivityState(ConnectivityState.Idle, "Connect canceled.");
         }
         catch (Exception ex)
         {

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -890,7 +890,7 @@ public class ConnectionManagerTests
             new BalancerAddress("localhost", 80)
         });
 
-        var connectTimeout = TimeSpan.FromMilliseconds(100);
+        var connectTimeout = TimeSpan.FromMilliseconds(200);
         var connectAttempt = 0;
         var connectCanceledTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -904,7 +904,7 @@ public class ConnectionManagerTests
                 // First attempt: wait longer than ConnectTimeout so the connect context
                 // cancellation token fires, then return Failure (simulating a SocketException
                 // that resolved before the OCE was observed by the transport).
-                await Task.Delay(connectTimeout + TimeSpan.FromMilliseconds(200), CancellationToken.None);
+                await Task.Delay(connectTimeout + TimeSpan.FromMilliseconds(400), CancellationToken.None);
                 return new TryConnectResult(ConnectivityState.TransientFailure, ConnectResult.Failure);
             }
 

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -865,6 +865,95 @@ public class ConnectionManagerTests
         }
     }
 
+    [Test]
+    public async Task ConnectTimeout_FiresDuringFailedConnect_SubchannelRecoverable()
+    {
+        // Regression test for https://github.com/grpc/grpc-dotnet/issues/2734
+        // When ConnectTimeout fires and TryConnectAsync returns Failure (not Timeout),
+        // the ThrowIfCancellationRequested() after the switch throws OperationCanceledException.
+        // The catch block doesn't transition to Idle, so the subchannel gets permanently stuck
+        // in TransientFailure and RequestConnection() can never restart the connect loop.
+
+        // Arrange
+        var services = new ServiceCollection();
+        var testSink = new TestSink();
+        services.AddLogging(b => b.AddProvider(new TestLoggerProvider(testSink)));
+        services.AddNUnitLogger();
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger(GetType());
+
+        var resolver = new TestResolver(loggerFactory);
+        resolver.UpdateAddresses(new List<BalancerAddress>
+        {
+            new BalancerAddress("localhost", 80)
+        });
+
+        var connectTimeout = TimeSpan.FromMilliseconds(100);
+        var connectAttempt = 0;
+        var connectCanceledTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var transportFactory = TestSubchannelTransportFactory.Create(async (subchannel, attempt, cancellationToken) =>
+        {
+            var currentAttempt = Interlocked.Increment(ref connectAttempt);
+            logger.LogInformation($"TryConnectAsync attempt {currentAttempt}");
+
+            if (currentAttempt == 1)
+            {
+                // First attempt: wait longer than ConnectTimeout so the connect context
+                // cancellation token fires, then return Failure (simulating a SocketException
+                // that resolved before the OCE was observed by the transport).
+                await Task.Delay(connectTimeout + TimeSpan.FromMilliseconds(200), CancellationToken.None);
+                return new TryConnectResult(ConnectivityState.TransientFailure, ConnectResult.Failure);
+            }
+
+            // Subsequent attempts succeed.
+            return new TryConnectResult(ConnectivityState.Ready, ConnectResult.Success);
+        });
+        transportFactory.ConnectTimeout = connectTimeout;
+
+        testSink.MessageLogged += (w) =>
+        {
+            if (w.EventId.Name == "ConnectCanceled")
+            {
+                connectCanceledTcs.TrySetResult(null);
+            }
+        };
+
+        var clientChannel = CreateConnectionManager(loggerFactory, resolver, transportFactory);
+        clientChannel.ConfigureBalancer(c => new PickFirstBalancer(c, loggerFactory));
+
+        // Act
+        // Start connecting - this will call TryConnectAsync which takes >100ms,
+        // so ConnectTimeout fires during the connect attempt.
+        logger.LogInformation("Starting connect.");
+        _ = clientChannel.ConnectAsync(waitForReady: false, CancellationToken.None).ConfigureAwait(false);
+
+        // Wait for ConnectCanceled log, confirming the OCE was caught and the loop exited.
+        logger.LogInformation("Waiting for ConnectCanceled.");
+        await connectCanceledTcs.Task.DefaultTimeout();
+
+        // At this point, the subchannel's connect loop has exited.
+        // The bug: state is TransientFailure and RequestConnection() can't restart the loop.
+        logger.LogInformation("ConnectCanceled observed. Requesting new connection.");
+
+        // Assert - RequestConnection should be able to start a new connect loop
+        // and the subchannel should eventually reach Ready state.
+        var subchannels = clientChannel.GetSubchannels();
+        Assert.AreEqual(1, subchannels.Count);
+
+        // Trigger a new connection request (simulates a new RPC arriving).
+        subchannels[0].RequestConnection();
+
+        // The subchannel should recover and reach Ready.
+        await TestHelpers.AssertIsTrueRetryAsync(
+            () => subchannels[0].State == ConnectivityState.Ready,
+            "Wait for subchannel to reach Ready state.").DefaultTimeout();
+
+        Assert.AreEqual(ConnectivityState.Ready, subchannels[0].State);
+    }
+
     private class DropLoadBalancerFactory : LoadBalancerFactory
     {
         private readonly Func<IChannelControlHelper, DropLoadBalancer> _loadBalancerFunc;

--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -870,9 +870,8 @@ public class ConnectionManagerTests
     {
         // Regression test for https://github.com/grpc/grpc-dotnet/issues/2734
         // When ConnectTimeout fires and TryConnectAsync returns Failure (not Timeout),
-        // the ThrowIfCancellationRequested() after the switch throws OperationCanceledException.
-        // The catch block doesn't transition to Idle, so the subchannel gets permanently stuck
-        // in TransientFailure and RequestConnection() can never restart the connect loop.
+        // the subchannel should transition to Idle so that RequestConnection() can
+        // restart the connect loop.
 
         // Arrange
         var services = new ServiceCollection();
@@ -930,13 +929,16 @@ public class ConnectionManagerTests
         logger.LogInformation("Starting connect.");
         _ = clientChannel.ConnectAsync(waitForReady: false, CancellationToken.None).ConfigureAwait(false);
 
-        // Wait for ConnectCanceled log, confirming the OCE was caught and the loop exited.
+        // Wait for ConnectCanceled log, confirming the OCE was caught and the loop is exiting.
         logger.LogInformation("Waiting for ConnectCanceled.");
         await connectCanceledTcs.Task.DefaultTimeout();
 
-        // At this point, the subchannel's connect loop has exited.
-        // The bug: state is TransientFailure and RequestConnection() can't restart the loop.
-        logger.LogInformation("ConnectCanceled observed. Requesting new connection.");
+        // ConnectCanceled fires before UpdateConnectivityState(Idle) in the catch block.
+        // Wait for the state to actually reach Idle before calling RequestConnection().
+        logger.LogInformation("Waiting for subchannel to reach Idle after ConnectCanceled.");
+        await TestHelpers.AssertIsTrueRetryAsync(
+            () => clientChannel.GetSubchannels().Count == 1 && clientChannel.GetSubchannels()[0].State == ConnectivityState.Idle,
+            "Wait for subchannel to reach Idle state.").DefaultTimeout();
 
         // Assert - RequestConnection should be able to start a new connect loop
         // and the subchannel should eventually reach Ready state.
@@ -944,6 +946,7 @@ public class ConnectionManagerTests
         Assert.AreEqual(1, subchannels.Count);
 
         // Trigger a new connection request (simulates a new RPC arriving).
+        logger.LogInformation("Requesting new connection.");
         subchannels[0].RequestConnection();
 
         // The subchannel should recover and reach Ready.


### PR DESCRIPTION
## Problem

Fixes #2734

When `ConnectTimeout` fires while `TryConnectAsync` is running and the transport returns `ConnectResult.Failure` (e.g. from a `SocketException`), the `ThrowIfCancellationRequested()` at [line 395](https://github.com/grpc/grpc-dotnet/blob/2c776f2dc34a4e592ee5092ab618dc89fffaa104/src/Grpc.Net.Client/Balancer/Subchannel.cs#L395) throws `OperationCanceledException`. The same can happen at [line 425](https://github.com/grpc/grpc-dotnet/blob/2c776f2dc34a4e592ee5092ab618dc89fffaa104/src/Grpc.Net.Client/Balancer/Subchannel.cs#L425) when a backoff delay is interrupted after the connect timeout has already fired.

The `catch (OperationCanceledException)` block logs the cancellation but does **not** transition the subchannel state. Since the subchannel is in `TransientFailure` at this point (set by the failed `TryConnectAsync`), the connect loop exits and the subchannel is permanently stuck — `RequestConnection()` only starts a new connect loop from `Idle` state.

## Fix

Transition to `Idle` in the `catch (OperationCanceledException)` block. This restores the invariant that `RequestConnection()` relies on: if the retry loop is not running, the subchannel must be in `Idle` so a new loop can be started.

## Test

Added `ConnectTimeout_FiresDuringFailedConnect_SubchannelRecoverable` which:
1. Configures a short `ConnectTimeout` (100ms)
2. Has the transport take longer than the timeout then return `Failure`
3. Verifies the `OperationCanceledException` is caught (via `ConnectCanceled` log)
4. Asserts that `RequestConnection()` can restart the connect loop and reach `Ready`