### PR TITLE
_moveNextTask may be overwritten, after we release the lock, but befo…

### DIFF
--- a/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
+++ b/src/Grpc.Net.Client/Internal/HttpContentClientStreamReader.cs
@@ -97,6 +97,7 @@ internal sealed class HttpContentClientStreamReader<TRequest, TResponse> : IAsyn
             }
         }
 
+        Task<bool> moveNextTask;
         lock (_moveNextLock)
         {
             using (_call.StartScope())
@@ -109,12 +110,13 @@ internal sealed class HttpContentClientStreamReader<TRequest, TResponse> : IAsyn
                     return Task.FromException<bool>(ex);
                 }
 
+                moveNextTask = MoveNextCore(cancellationToken);
                 // Save move next task to track whether it is complete
-                _moveNextTask = MoveNextCore(cancellationToken);
+                _moveNextTask = moveNextTask;
             }
         }
 
-        return _moveNextTask;
+        return moveNextTask;
     }
 
     private async Task<bool> MoveNextCore(CancellationToken cancellationToken)


### PR DESCRIPTION
_moveNextTask may be overwritten, after we release the lock, but before we return it

https://github.com/grpc/grpc-dotnet/issues/2732
