### PR TITLE
Preserve current activity for gRPC calls without diagnostics

### DIFF
--- a/src/Grpc.Net.Client/Internal/GrpcCall.cs
+++ b/src/Grpc.Net.Client/Internal/GrpcCall.cs
@@ -820,9 +820,8 @@ internal sealed partial class GrpcCall<TRequest, TResponse> : GrpcCall, IGrpcCal
         // Set activity if:
         // 1. Diagnostic source is enabled
         // 2. Logging is enabled
-        // 3. There is an existing activity (to enable activity propagation)
-        // 4. ActivitySource has listeners
-        if (diagnosticSourceEnabled || Logger.IsEnabled(LogLevel.Critical) || Activity.Current != null || GrpcDiagnostics.ActivitySource.HasListeners())
+        // 3. ActivitySource has listeners
+        if (diagnosticSourceEnabled || Logger.IsEnabled(LogLevel.Critical) || GrpcDiagnostics.ActivitySource.HasListeners())
         {
             activity = GrpcDiagnostics.ActivitySource.CreateActivity(GrpcDiagnostics.ActivityName, ActivityKind.Client);
 

--- a/test/Grpc.Net.Client.Tests/DiagnosticsTests.cs
+++ b/test/Grpc.Net.Client.Tests/DiagnosticsTests.cs
@@ -218,6 +218,31 @@ public class DiagnosticsTests
         Assert.AreNotEqual(TimeSpan.Zero, activityDurationOnStop);
     }
 
+    [Test]
+    public async Task CurrentActivity_MakeCallWithoutDiagnostics_PreservedDuringSend()
+    {
+        // Arrange
+        Activity? activityDuringSend = null;
+        var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+        {
+            activityDuringSend = Activity.Current;
+
+            var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply()).DefaultTimeout();
+            return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: StatusCode.OK);
+        });
+        var invoker = HttpClientCallInvokerFactory.Create(httpClient);
+
+        // Act
+        using var parentActivity = new Activity("Parent").Start();
+
+        var call = invoker.AsyncUnaryCall(new HelloRequest());
+        await call.ResponseAsync.DefaultTimeout();
+
+        // Assert
+        Assert.AreSame(parentActivity, activityDuringSend);
+        Assert.AreSame(parentActivity, Activity.Current);
+    }
+
     private static T GetValueFromAnonymousType<T>(object dataitem, string itemkey)
     {
         var type = dataitem.GetType();


### PR DESCRIPTION
## Problem

Fixes #2516

`Grpc.Net.Client` currently creates a fallback gRPC client `Activity` when `Activity.Current` is not null, even when gRPC diagnostics, logging, and `ActivitySource` listeners are not enabled.

That fallback activity was originally added to enable activity propagation. However, it replaces the caller's current logical activity during the send path. In that case, downstream propagation can use the hidden gRPC activity as the parent instead of the caller's activity, which can produce an incorrect parent-child span relationship.

## Fix

Only create a gRPC client activity when it is actually needed for:

- diagnostic source events
- logging
- `Grpc.Net.Client` `ActivitySource` listeners

When none of those are enabled, the existing `Activity.Current` is preserved during send so lower-level HTTP/client instrumentation can propagate the caller's logical context.

## Test

Added `CurrentActivity_MakeCallWithoutDiagnostics_PreservedDuringSend` to verify that `Activity.Current` is preserved during the send path when gRPC diagnostics are not enabled.
