### PR TITLE
Using Grpc.Tools 2.83.0-pre1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
 
     <!-- gRPC -->
-    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0-pre1" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
     <PackageVersion Include="Grpc.Core.Api" Version="$(GrpcDotNetPackageVersion)"/>
     <PackageVersion Include="Grpc.Net.Client" Version="$(GrpcDotNetPackageVersion)" />


### PR DESCRIPTION
# Description

Release prep - update version of `Grpc.Tools` version to `2.83.0-pre1`