### PR TITLE
Update version for v2.83.x

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -8,7 +8,7 @@
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>
 
     <!-- file version of all grpc-dotnet -->
-    <GrpcDotnetAssemblyFileVersion>2.66.0.0</GrpcDotnetAssemblyFileVersion>
+    <GrpcDotnetAssemblyFileVersion>2.83.0.0</GrpcDotnetAssemblyFileVersion>
 
   </PropertyGroup>
 </Project>

--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.66.0-dev</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.83.0</GrpcDotnetVersion>
 
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>

--- a/build/version.props
+++ b/build/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <!-- package version of grpc-dotnet -->
-    <GrpcDotnetVersion>2.83.0</GrpcDotnetVersion>
+    <GrpcDotnetVersion>2.83.0-pre1</GrpcDotnetVersion>
 
     <!-- assembly version of grpc-dotnet -->
     <GrpcDotnetAssemblyVersion>2.0.0.0</GrpcDotnetAssemblyVersion>

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -41,5 +41,5 @@ public static class VersionInfo
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.66.0-dev";
+    public const string CurrentVersion = "2.83.0";
 }

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -36,7 +36,7 @@ public static class VersionInfo
     /// <summary>
     /// Current <c>AssemblyFileVersion</c> of gRPC C# assemblies
     /// </summary>
-    public const string CurrentAssemblyFileVersion = "2.66.0.0";
+    public const string CurrentAssemblyFileVersion = "2.83.0.0";
 
     /// <summary>
     /// Current version of gRPC C#

--- a/src/Grpc.Core.Api/VersionInfo.cs
+++ b/src/Grpc.Core.Api/VersionInfo.cs
@@ -41,5 +41,5 @@ public static class VersionInfo
     /// <summary>
     /// Current version of gRPC C#
     /// </summary>
-    public const string CurrentVersion = "2.83.0";
+    public const string CurrentVersion = "2.83.0-pre1";
 }


### PR DESCRIPTION
# Description

Following [Step 3 for release doc](https://github.com/grpc/grpc-dotnet/blob/master/doc/release_process.md#releasing-a-new-version-of-grpc-dotnet-every-6-weeks) for `v2.83.0x`

Update version and remove `-dev` suffix with `-pre1` suffix